### PR TITLE
change gettargets behaviour

### DIFF
--- a/RotationSolver.Basic/Actions/ActionTargetInfo.cs
+++ b/RotationSolver.Basic/Actions/ActionTargetInfo.cs
@@ -70,7 +70,9 @@ public struct ActionTargetInfo(IBaseAction action)
             objs.Add(obj);
         }
 
-        return objs.Where(CanUseTo).Where(InViewTarget).Where(action.Setting.CanTarget);
+        var isAuto = !DataCenter.IsManual || IsTargetFriendly;
+        return objs.Where(b => isAuto || b.ObjectId == Svc.Targets.Target?.ObjectId)
+            .Where(InViewTarget).Where(CanUseTo).Where(action.Setting.CanTarget);
     }
 
     private readonly List<BattleChara> GetCanAffects(bool skipStatusProvideCheck, TargetType type)


### PR DESCRIPTION
If the operation is not manual (DataCenter.IsManual == false) or the action is friendly (IsTargetFriendly == true), it sets isAuto to true. This effectively means that automatic target selection is used for all non-manual operations and friendly actions, regardless of the manual/auto setting.

Filters objs based on a new set of conditions:
If isAuto is true, all objects that pass the subsequent conditions are included. This is similar to the original behavior but now explicitly includes friendly actions in auto-mode regardless of manual settings. If isAuto is false, only the currently targeted object (Svc.Targets.Target?.ObjectId) is included, if any. This is a significant change for manual operations with hostile actions, as it restricts the selection strictly to the currently targeted object.

Narrower Target Selection in Manual Mode for Hostile Actions: In manual mode, this change restricts target selection to the current target only

Automatic Target Selection for Friendly Actions: Friendly actions will always use automatic target selection, which could simplify operations involving healing or buffing by ignoring the manual mode for these actions.

Order of Conditions: While the logical outcome might not be significantly altered, the reordering of CanUseTo and InViewTarget prevents wasted checks from running