### PR TITLE
.1f actionahdead and various text fixes

### DIFF
--- a/RotationSolver.Basic/Configuration/Configs.cs
+++ b/RotationSolver.Basic/Configuration/Configs.cs
@@ -328,7 +328,7 @@ internal partial class Configs : IPluginConfiguration
     private static readonly bool _useAOEAction = true;
 
     [ConditionBool, UI("Use single target AoE actions in manual mode.", Parent = nameof(UseAoeAction))]
-    private static readonly bool _useAOEWhenManual = false;
+    private static readonly bool _useAOEWhenManual = true;
 
     [ConditionBool, UI("Automatically trigger dps burst phase.", Filter = AutoActionCondition)]
     private static readonly bool _autoBurst = true;
@@ -491,7 +491,7 @@ internal partial class Configs : IPluginConfiguration
     [Range(0, 3, ConfigUnitType.Seconds)]
     public Vector2 TargetDelay { get; set; } = new(1, 2);
 
-    [UI("Action Execution Delay.\n(RSR will not take actions during window).",
+    [UI("Action Execution Delay. (RSR will not take actions during window).",
         Filter = BasicTimer)]
     [Range(0, 1, ConfigUnitType.Seconds, 0.002f)]
     public Vector2 WeaponDelay { get; set; } = new(0, 0);
@@ -708,9 +708,9 @@ internal partial class Configs : IPluginConfiguration
         PvEFilter = JobFilterType.Tank)]
     private readonly float _healthForAutoDefense = 1;
 
-    [JobConfig, Range(0, 0.5f, ConfigUnitType.Seconds)]
-    [UI("Action Ahead (How far ahead of a oGCD/GCD use does RSR decide which oGCD/GCD to use)", Filter = BasicTimer)]
-    private readonly float _action4head = 0.08f;
+    [JobConfig, Range(0, 0.1f, ConfigUnitType.Seconds)]
+    [UI("Action Ahead (How far ahead of a GCD use does RSR starts to try to use the GCD)", Filter = BasicTimer)]
+    private readonly float _actionAhead = 0.10f;
 
     [JobConfig, UI("Engage settings", Filter = TargetConfig, PvPFilter = JobFilterType.NoJob)]
     private readonly TargetHostileType _hostileType = TargetHostileType.AllTargetsWhenSolo;

--- a/RotationSolver/Data/UiString.cs
+++ b/RotationSolver/Data/UiString.cs
@@ -204,16 +204,16 @@ internal enum UiString
     [Description("No Casting debuffs")]
     ConfigWindow_List_NoCastingStatus,
 
-    [Description("Ignores target if it has one of this statuses")]
+    [Description("Ignores target if it has one of these statuses")]
     ConfigWindow_List_InvincibilityDesc,
 
-    [Description("Attacks the target first if it has one of this statuses")]
+    [Description("Attacks the target first if it has one of these statuses")]
     ConfigWindow_List_PriorityDesc,
 
     [Description("Dispellable debuffs list")]
     ConfigWindow_List_DangerousStatusDesc,
 
-    [Description("No Casting debuffs List")]
+    [Description("Do no action if you have one of these debuffs")]
     ConfigWindow_List_NoCastingStatusDesc,
 
     [Description("Copy to Clipboard")]
@@ -429,7 +429,7 @@ internal enum UiString
     [Description("Hostile")]
     ConfigWindow_List_Hostile,
 
-    [Description("Enemy targetting logic. Adding more options cycles them when using /rotation Auto.")]
+    [Description("Enemy targeting logic. Adding more options cycles them when using /rotation Auto.")]
     ConfigWindow_Param_HostileDesc,
 
     [Description("Move Up")]


### PR DESCRIPTION
[branch name now misleading, return of the actionahead properly, limited to .1 second due to possible issues with ogcd timing failures above that value and various text fixes for clarification and misspellings