### PR TITLE
Combo config fix

### DIFF
--- a/RotationSolver.Basic/Configuration/RotationConfig/RotationConfigCombo.cs
+++ b/RotationSolver.Basic/Configuration/RotationConfig/RotationConfigCombo.cs
@@ -4,7 +4,8 @@ namespace RotationSolver.Basic.Configuration.RotationConfig;
 
 internal class RotationConfigCombo: RotationConfigBase
 {
-    public string[] Items { get; set; }
+    public string[] DisplayValues { get; }
+    public int selectedIdx { get; set; }
 
     public RotationConfigCombo(ICustomRotation rotation, PropertyInfo property)
         :base(rotation, property)
@@ -14,14 +15,15 @@ internal class RotationConfigCombo: RotationConfigBase
         {
             names.Add(v.GetAttribute<DescriptionAttribute>()?.Description ?? v.ToString());
         }
-        Items = [.. names];
+
+        DisplayValues = [.. names];
     }
 
     public override string ToString()
     {
         var indexStr = base.ToString();
-        if (!int.TryParse(indexStr, out var index)) return Items[0];
-        return Items[index];
+        if (!int.TryParse(indexStr, out var index)) return DisplayValues[0].ToString();
+        return DisplayValues[index];
     }
 
     public override bool DoCommand(IRotationConfigSet set, string str)
@@ -29,7 +31,7 @@ internal class RotationConfigCombo: RotationConfigBase
         if (!base.DoCommand(set, str)) return false;
 
         string numStr = str[Name.Length..].Trim();
-        var length = Items.Length;
+        var length = DisplayValues.Length;
 
         int nextId = (int.Parse(Value) + 1) % length;
         if (int.TryParse(numStr, out int num))
@@ -40,7 +42,7 @@ internal class RotationConfigCombo: RotationConfigBase
         {
             for (int i = 0; i < length; i++)
             {
-                if (Items[i] == str)
+                if (DisplayValues[i] == str)
                 {
                     nextId = i;
                 }

--- a/RotationSolver/UI/RotationConfigWindow.cs
+++ b/RotationSolver/UI/RotationConfigWindow.cs
@@ -1,4 +1,5 @@
-﻿using Dalamud.Game.ClientState.Keys;
+﻿using System.Diagnostics;
+using Dalamud.Game.ClientState.Keys;
 using Dalamud.Interface.Colors;
 using Dalamud.Interface.Internal;
 using Dalamud.Interface.Utility;
@@ -10,8 +11,9 @@ using ECommons.ExcelServices;
 using ECommons.GameFunctions;
 using ECommons.GameHelpers;
 using ECommons.ImGuiMethods;
-using ExCSS;
+using FFXIVClientStructs.FFXIV.Client.Game;
 using FFXIVClientStructs.FFXIV.Client.Game.Fate;
+using FFXIVClientStructs.FFXIV.Client.System.Framework;
 using FFXIVClientStructs.FFXIV.Common.Component.BGCollision;
 using Lumina.Excel.GeneratedSheets;
 using RotationSolver.Basic.Configuration;
@@ -20,11 +22,11 @@ using RotationSolver.Helpers;
 using RotationSolver.Localization;
 using RotationSolver.UI.SearchableConfigs;
 using RotationSolver.Updaters;
-using System.Diagnostics;
-using ECommons.Logging;
 using XIVPainter;
 using GAction = Lumina.Excel.GeneratedSheets.Action;
+using Status = Lumina.Excel.GeneratedSheets.Status;
 using TargetType = RotationSolver.Basic.Actions.TargetType;
+using Task = System.Threading.Tasks.Task;
 
 namespace RotationSolver.UI;
 
@@ -1503,8 +1505,8 @@ public partial class RotationConfigWindow : Window
                     ImGui.Text("ID: " + action.Info.ID.ToString());
 #if DEBUG
                     ImGui.Text("Is Real GCD: " + action.Info.IsRealGCD.ToString());
-                    ImGui.Text("Resources: " + FFXIVClientStructs.FFXIV.Client.Game.ActionManager.Instance()->CheckActionResources(FFXIVClientStructs.FFXIV.Client.Game.ActionType.Action, action.AdjustedID).ToString());
-                    ImGui.Text("Status: " + FFXIVClientStructs.FFXIV.Client.Game.ActionManager.Instance()->GetActionStatus(FFXIVClientStructs.FFXIV.Client.Game.ActionType.Action, action.AdjustedID).ToString());
+                    ImGui.Text("Resources: " + ActionManager.Instance()->CheckActionResources(ActionType.Action, action.AdjustedID).ToString());
+                    ImGui.Text("Status: " + ActionManager.Instance()->GetActionStatus(ActionType.Action, action.AdjustedID).ToString());
                     ImGui.Text("Cast Time: " + action.Info.CastTime.ToString());
                     ImGui.Text("MP: " + action.Info.MPNeed.ToString());
 #endif
@@ -1528,9 +1530,9 @@ public partial class RotationConfigWindow : Window
             {
                 try
                 {
-                    ImGui.Text("Status: " + FFXIVClientStructs.FFXIV.Client.Game.ActionManager.Instance()->GetActionStatus(FFXIVClientStructs.FFXIV.Client.Game.ActionType.Item, item.ID).ToString());
-                    ImGui.Text("Status HQ: " + FFXIVClientStructs.FFXIV.Client.Game.ActionManager.Instance()->GetActionStatus(FFXIVClientStructs.FFXIV.Client.Game.ActionType.Item, item.ID + 1000000).ToString());
-                    var remain = FFXIVClientStructs.FFXIV.Client.Game.ActionManager.Instance()->GetRecastTime(FFXIVClientStructs.FFXIV.Client.Game.ActionType.Item, item.ID) - FFXIVClientStructs.FFXIV.Client.Game.ActionManager.Instance()->GetRecastTimeElapsed(FFXIVClientStructs.FFXIV.Client.Game.ActionType.Item, item.ID);
+                    ImGui.Text("Status: " + ActionManager.Instance()->GetActionStatus(ActionType.Item, item.ID).ToString());
+                    ImGui.Text("Status HQ: " + ActionManager.Instance()->GetActionStatus(ActionType.Item, item.ID + 1000000).ToString());
+                    var remain = ActionManager.Instance()->GetRecastTime(ActionType.Item, item.ID) - ActionManager.Instance()->GetRecastTimeElapsed(ActionType.Item, item.ID);
                     ImGui.Text("remain: " + remain.ToString());
                     ImGui.Text("CanUse: " + item.CanUse(out _, true).ToString());
 
@@ -2342,7 +2344,7 @@ public partial class RotationConfigWindow : Window
                     =
                     [
                         .. pts,
-                        FFXIVClientStructs.FFXIV.Client.System.Framework.Framework.Instance()->BGCollisionModule
+                        Framework.Instance()->BGCollisionModule
                             ->RaycastEx(&hit, point + Vector3.UnitY * 5, -Vector3.UnitY, 20, 1, unknown) ? hit.Point : point,
                     ];
                     OtherConfiguration.SaveBeneficialPositions();

--- a/RotationSolver/UI/RotationConfigWindow.cs
+++ b/RotationSolver/UI/RotationConfigWindow.cs
@@ -21,6 +21,7 @@ using RotationSolver.Localization;
 using RotationSolver.UI.SearchableConfigs;
 using RotationSolver.Updaters;
 using System.Diagnostics;
+using ECommons.Logging;
 using XIVPainter;
 using GAction = Lumina.Excel.GeneratedSheets.Action;
 using TargetType = RotationSolver.Basic.Actions.TargetType;
@@ -1175,20 +1176,13 @@ public partial class RotationConfigWindow : Window
 
             if (config is RotationConfigCombo c)
             {
-                var val = int.Parse(c.Value);
-                ImGui.SetNextItemWidth(ImGui.CalcTextSize(c.Items[val]).X + 50 * Scale);
-                var openCombo = ImGui.BeginCombo(name, c.Items[val]);
-                ImGuiHelper.ReactPopup(key, command, Reset);
-                if (openCombo)
+                var names = c.DisplayValues;
+                var selectedValue = c.selectedIdx;
+                
+                ImGui.SetNextItemWidth(ImGui.CalcTextSize(c.DisplayValues.OrderByDescending(v => v.Length).First()).X + 50 * Scale);
+                if (ImGui.Combo(name, ref selectedValue, names, names.Length))
                 {
-                    for (int comboIndex = 0; comboIndex < c.Items.Length; comboIndex++)
-                    {
-                        if (ImGui.Selectable(c.Items[comboIndex]))
-                        {
-                            config.Value = comboIndex.ToString();
-                        }
-                    }
-                    ImGui.EndCombo();
+                    c.selectedIdx = selectedValue;
                 }
             }
             else if (config is RotationConfigBoolean b)


### PR DESCRIPTION
First pass at fixing the combo dropdown in the rotation configuration section. This currently doesn't use the description attribute for the display text, that'll be in the next revision.
![image](https://github.com/FFXIV-CombatReborn/RotationSolverReborn/assets/1733560/81d3292d-fec8-4b86-8c9a-6ba19673d98f)
