### PR TITLE
Added "dummy" rotations for debugging

### DIFF
--- a/RotationSolver.DummyRotations/AssemblyInfo.cs
+++ b/RotationSolver.DummyRotations/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+﻿using RotationSolver.Basic.Attributes;
+
+[assembly: AssemblyLink(Donate = "", UserName = "FFXIV-CombatReborn", Repository = "RotationSolverReborn")]

--- a/RotationSolver.DummyRotations/DummyClass.cs
+++ b/RotationSolver.DummyRotations/DummyClass.cs
@@ -1,0 +1,47 @@
+﻿using RotationSolver.Basic.Actions;
+using RotationSolver.Basic.Attributes;
+using RotationSolver.Basic.Data;
+using RotationSolver.Basic.Rotations.Basic;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace RotationSolver.DummyRotations
+{
+    [Rotation("Dummy Rotation", CombatType.PvE, GameVersion = "6.58")]
+    [Api(1)]
+    public class DummyClass : SummonerRotation
+    {
+        protected override bool GeneralGCD(out IAction? act)
+        {
+            return base.GeneralGCD(out act);
+        }
+
+        protected override bool GeneralAbility(IAction nextGCD, out IAction? act)
+        {
+            return base.GeneralAbility(nextGCD, out act);
+        }
+
+        protected override IAction? CountDownAction(float remainTime)
+        {
+            return base.CountDownAction(remainTime);
+        }
+
+        protected override bool AttackAbility(IAction nextGCD, out IAction? act)
+        {
+            return base.AttackAbility(nextGCD, out act);
+        }
+
+        protected override bool EmergencyAbility(IAction nextGCD, out IAction? act)
+        {
+            return base.EmergencyAbility(nextGCD, out act);
+        }
+
+        public override void DisplayStatus()
+        {
+
+        }
+    }
+}

--- a/RotationSolver.DummyRotations/RotationSolver.DummyRotations.csproj
+++ b/RotationSolver.DummyRotations/RotationSolver.DummyRotations.csproj
@@ -1,0 +1,13 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0-windows</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\RotationSolver.Basic\RotationSolver.Basic.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/RotationSolver.sln
+++ b/RotationSolver.sln
@@ -26,6 +26,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "RotationSolver.SourceGenera
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "RotationSolver.GameData", "RotationSolver.GameData\RotationSolver.GameData.csproj", "{FE8D8078-67F6-473E-9076-B01C62F5B937}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RotationSolver.DummyRotations", "RotationSolver.DummyRotations\RotationSolver.DummyRotations.csproj", "{2C9BACA6-A791-478C-84BB-8A798123468A}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -82,6 +84,14 @@ Global
 		{FE8D8078-67F6-473E-9076-B01C62F5B937}.Release|Any CPU.Build.0 = Release|Any CPU
 		{FE8D8078-67F6-473E-9076-B01C62F5B937}.Release|x64.ActiveCfg = Release|Any CPU
 		{FE8D8078-67F6-473E-9076-B01C62F5B937}.Release|x64.Build.0 = Release|Any CPU
+		{2C9BACA6-A791-478C-84BB-8A798123468A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2C9BACA6-A791-478C-84BB-8A798123468A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2C9BACA6-A791-478C-84BB-8A798123468A}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{2C9BACA6-A791-478C-84BB-8A798123468A}.Debug|x64.Build.0 = Debug|Any CPU
+		{2C9BACA6-A791-478C-84BB-8A798123468A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2C9BACA6-A791-478C-84BB-8A798123468A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2C9BACA6-A791-478C-84BB-8A798123468A}.Release|x64.ActiveCfg = Release|Any CPU
+		{2C9BACA6-A791-478C-84BB-8A798123468A}.Release|x64.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Added a blank set of rotations to the base project to facilitate easier debugging of rotation level issues when necessary. These are not available to end-users, only developers.