### PR TITLE
Raised default minimum update time and made it a job config

### DIFF
--- a/RotationSolver.Basic/Configuration/Configs.cs
+++ b/RotationSolver.Basic/Configuration/Configs.cs
@@ -625,8 +625,8 @@ internal partial class Configs : IPluginConfiguration
 
     [UI("The minimum time between updating RSR information. (Setting too low can negatively effect framerate)",
         Filter = BasicTimer)]
-    [Range(0, 1, ConfigUnitType.Seconds, 0.002f)]
-    public float MinUpdatingTime { get; set; } = 0.00f;
+    [JobConfig, Range(0, 0.3f, ConfigUnitType.Seconds, 0.002f)]
+    public float MinUpdatingTime { get; set; } = 0.01f;
 
     [UI("The HP for using Guard.", 
         Filter = AutoActionCondition, Section = 3,


### PR DESCRIPTION
Rather than updating every frame RSR will now update up to 100 times per second. This should help resolve issues that are caused by RSR updating too quickly. Additionally, minimum update time is now specific to each job. Default is the same across all jobs but can be adjusted individually.