### PR TITLE
Reset Manual State on /rotation off

### DIFF
--- a/RotationSolver/Commands/RSCommands_StateSpecialCommand.cs
+++ b/RotationSolver/Commands/RSCommands_StateSpecialCommand.cs
@@ -53,6 +53,7 @@ public static partial class RSCommands
         {
             case StateCommandType.Off:
                 DataCenter.State = false;
+                DataCenter.IsManual = false;
                 break;
 
             case StateCommandType.Auto:


### PR DESCRIPTION
Fixed an issue that could cause RSR to get stuck on when switching off from manual mode.