### PR TITLE
Dancer - Last Dance fix

### DIFF
--- a/RotationSolver.Basic/Rotations/Basic/DancerRotation.cs
+++ b/RotationSolver.Basic/Rotations/Basic/DancerRotation.cs
@@ -191,6 +191,12 @@ partial class DancerRotation
         //setting.ActionCheck = () => !IsDancing
     }
 
+    static partial void ModifyLastDancePvE(ref ActionSetting setting)
+    {
+        setting.StatusNeed = [StatusID.LastDanceReady];
+        //setting.ActionCheck = () => !IsDancing
+    }
+
     static partial void ModifyDanceOfTheDawnPvE(ref ActionSetting setting)
     {
         setting.StatusNeed = [StatusID.DanceOfTheDawnReady];


### PR DESCRIPTION
This fixes RSR trying to spam Last Dance while the status effect is not active and when the ability is set to 1 target.

I've tested this in dungeons as well as on Training Dummies and works fine