### PR TITLE
Fix some "Sequence contains no elements" errors

### DIFF
--- a/RotationSolver.Basic/DataCenter.cs
+++ b/RotationSolver.Basic/DataCenter.cs
@@ -482,8 +482,8 @@ internal static class DataCenter
 
     public static IEnumerable<float> PartyMembersHP => RefinedHP.Values.Where(r => r > 0);
     public static float PartyMembersMinHP => PartyMembersHP.Any() ? PartyMembersHP.Min() : 0;
-    public static float PartyMembersAverHP => PartyMembersHP.Average();
-    public static float PartyMembersDifferHP => (float)Math.Sqrt(PartyMembersHP.Average(d => Math.Pow(d - PartyMembersAverHP, 2)));
+    public static float PartyMembersAverHP => PartyMembersHP.Any() ? PartyMembersHP.Average() : 0;
+    public static float PartyMembersDifferHP => PartyMembersHP.Any() ? (float)Math.Sqrt(PartyMembersHP.Average(d => Math.Pow(d - PartyMembersAverHP, 2))) : 0;
 
     public static bool HPNotFull => PartyMembersMinHP < 1;
 


### PR DESCRIPTION
Sometimes RSR shows an error about "Sequence contains no elements":
![grafik](https://github.com/FFXIV-CombatReborn/RotationSolverReborn/assets/38253929/0e936c20-f372-406e-ba2a-558cc3d7d64e)
RSR still seems to work fine afterwards, but this can be fixed quite easily.
The error comes from [this](https://github.com/FFXIV-CombatReborn/RebornRotations/blob/1e9e3efc3cc1ab10dc149049c78866ed777260c8/BasicRotations/Healer/SGE_Default.cs#L293) access to `PartyMembersAverHP`.
This seems like it has already been fixed for `PartyMembersMinHP`, so I just did it for `PartyMembersAverHP` and `PartyMembersDifferHP` as well.
When there are no entries in `PartyMembersHP` which have more than 0 HP, the list is empty and a `.Average()` throws an exception. Now, it instead returns 0.