### PR TITLE
Fixed pet summoning happening too quickly

### DIFF
--- a/RotationSolver.Basic/DataCenter.cs
+++ b/RotationSolver.Basic/DataCenter.cs
@@ -436,12 +436,27 @@ internal static class DataCenter
 
     public static bool IsHostileCastingToTank => IsCastingTankVfx() || AllHostileTargets.Any(IsHostileCastingTank);
 
+    private static DateTime _petLastSeen = DateTime.MinValue;
+
     public static bool HasPet
     {
         get
         {
             var mayPet = AllTargets.OfType<IBattleNpc>().Where(npc => npc.OwnerId == Player.Object.GameObjectId);
-            return mayPet.Any(npc => npc.BattleNpcKind == BattleNpcSubKind.Pet);
+            var hasPet = mayPet.Any(npc => npc.BattleNpcKind == BattleNpcSubKind.Pet);
+            if (hasPet)
+            {
+                _petLastSeen = DateTime.Now;
+                return true;
+            }
+            else if (!hasPet && _petLastSeen.AddSeconds(1) < DateTime.Now)
+            {
+                return false;
+            }
+            else
+            {
+                return true;
+            }
         }
     }
 

--- a/RotationSolver.Basic/Rotations/Basic/ScholarRotation.cs
+++ b/RotationSolver.Basic/Rotations/Basic/ScholarRotation.cs
@@ -89,8 +89,7 @@ partial class ScholarRotation
 
     static partial void ModifySummonEosPvE(ref ActionSetting setting)
     {
-        setting.ActionCheck = () => !DataCenter.HasPet && (!Player.HasStatus(true, StatusID.Dissipation)// || Dissipation.WillHaveOneCharge(30) && Dissipation.EnoughLevel
-        );
+        setting.ActionCheck = () => !DataCenter.HasPet && !Player.HasStatus(true, StatusID.Dissipation);
     }
 
     static partial void ModifyWhisperingDawnPvE(ref ActionSetting setting)


### PR DESCRIPTION
RSR will now wait 1 second after Eos/Carbuncle disappears before attempting to resummon. This solves the issue of RSR immediately attempting to resummon pets after a zone transition or teleport.