### PR TITLE
Fixed Subtractive Palette on PCT not being usable with Subtractive Spectrum

### DIFF
--- a/RotationSolver.Basic/Rotations/Basic/PictomancerRotation.cs
+++ b/RotationSolver.Basic/Rotations/Basic/PictomancerRotation.cs
@@ -165,7 +165,7 @@ public partial class PictomancerRotation
 
     static partial void ModifySubtractivePalettePvE(ref ActionSetting setting)
     {
-        setting.ActionCheck = () => PaletteGauge >= 50;
+        setting.ActionCheck = () => PaletteGauge >= 50 || Player.HasStatus(true, StatusID.SubtractiveSpectrum);
     }
 
     static partial void ModifyStoneInYellowPvE(ref ActionSetting setting)


### PR DESCRIPTION
Adds to the Subtractive Palette check to allow it to be cast if SubtractiveSpectrum is provided by Starry Muse.