### PR TITLE
Remove restriction for Perfect Balance

### DIFF
--- a/RotationSolver.Basic/Rotations/Basic/MonkRotation.cs
+++ b/RotationSolver.Basic/Rotations/Basic/MonkRotation.cs
@@ -157,7 +157,6 @@ partial class MonkRotation
 
     static partial void ModifyPerfectBalancePvE(ref ActionSetting setting)
     {
-        setting.ActionCheck = () => InCombat;
         setting.UnlockedByQuestID = 66602;
         setting.StatusProvide = [StatusID.PerfectBalance];
     }


### PR DESCRIPTION
Remove the restriction for calling PB. The other author's version doesn't even use PB until 2 GCDs after entering the fight. But the restriction stops others from using PB right into the opener. 
Current PB is disabled outside battle in the game by default, but there's a delay for its activation in the eye of rsr. Spam-clicking is needed for PB to be weaved between the first and second GCD. With this restriction, this window is missed for most of the time. 
Please check Balance and logs for better opener. This removal doesn't affect the existing rotation version. And it opens more possibilities.
Tested locally on a dummy with both rotation and rsr freshly compiled. Rotation file is yet to be polished. 