### PR TITLE
WAR and NIN hotfixes

### DIFF
--- a/RotationSolver.Basic/Rotations/Basic/NinjaRotation.cs
+++ b/RotationSolver.Basic/Rotations/Basic/NinjaRotation.cs
@@ -110,7 +110,8 @@ partial class NinjaRotation
 
     static partial void ModifyKassatsuPvE(ref ActionSetting setting)
     {
-        setting.StatusProvide = [StatusID.Kassatsu, StatusID.TenChiJin];
+        setting.StatusProvide = [StatusID.Kassatsu];
+        setting.ActionCheck = () => !Player.HasStatus(true, StatusID.TenChiJin);
         setting.UnlockedByQuestID = 65770;
     }
 
@@ -166,7 +167,7 @@ partial class NinjaRotation
         setting.StatusNeed = [StatusID.Kassatsu];
         setting.StatusProvide = [StatusID.TenChiJin, StatusID.TenriJindoReady];
         setting.UnlockedByQuestID = 68488;
-        setting.ActionCheck = () => Ninki <= 50 && !IsMoving;
+        setting.ActionCheck = () => !IsMoving;
     }
 
     static partial void ModifyMeisuiPvE(ref ActionSetting setting)
@@ -194,6 +195,10 @@ partial class NinjaRotation
     static partial void ModifyHollowNozuchiPvE(ref ActionSetting setting)
     {
         setting.StatusNeed = [StatusID.Doton];
+        setting.CreateConfig = () => new ActionConfig()
+        {
+            AoeCount = 1,
+        };
     }
 
     static partial void ModifyForkedRaijuPvE(ref ActionSetting setting)

--- a/RotationSolver.Basic/Rotations/Basic/WarriorRotation.cs
+++ b/RotationSolver.Basic/Rotations/Basic/WarriorRotation.cs
@@ -122,7 +122,7 @@ partial class WarriorRotation
     static partial void ModifyInfuriatePvE(ref ActionSetting setting)
     {
         setting.StatusProvide = [StatusID.NascentChaos];
-        setting.ActionCheck = () => HasHostilesInRange && BeastGauge <= 50 && InCombat;
+        setting.ActionCheck = () => HasHostilesInRange && BeastGauge <= 50 && InCombat && !Player.HasStatus(true, StatusID.NascentChaos) && !Player.HasStatus(true, StatusID.PrimalRendReady) && !Player.HasStatus(true, StatusID.PrimalRuinationReady);
         setting.CreateConfig = () => new ActionConfig()
         {
             TimeToKill = 0,


### PR DESCRIPTION
WAR: Prevent the use of Infuriate if you currently have NascentChaos, Primal Rend or Primal Ruination to prevent overlapping and cancelling statueses
NIN: Prevents attemtped use of Kassatsu if you have TenChiJin active