### PR TITLE
Refactor CanUse method, update resources, and fix UI

### DIFF
--- a/RotationSolver.Basic/Actions/BaseItem.cs
+++ b/RotationSolver.Basic/Actions/BaseItem.cs
@@ -162,7 +162,7 @@ public class BaseItem : IBaseItem
     /// <param name="item"></param>
     /// <param name="clippingCheck"></param>
     /// <returns></returns>
-    public virtual unsafe bool CanUse(out IAction item, bool clippingCheck = true)
+    public virtual unsafe bool CanUse(out IAction item, bool clippingCheck = false)
     {
         item = this;
         if (_item == null) return false;
@@ -176,8 +176,6 @@ public class BaseItem : IBaseItem
         var remain = Cooldown.RecastTimeOneChargeRaw - Cooldown.RecastTimeElapsedRaw;
 
         if (remain > DataCenter.DefaultGCDRemain) return false;
-
-        if (clippingCheck && DataCenter.DefaultGCDRemain > 0) return false;
 
         if (ItemCheck != null && !ItemCheck()) return false;
 

--- a/RotationSolver.Basic/Actions/HpPotionItem.cs
+++ b/RotationSolver.Basic/Actions/HpPotionItem.cs
@@ -32,6 +32,6 @@ internal class HpPotionItem : BaseItem
         if (!Player.Available) return false;
         if (Player.Object.GetHealthRatio() > Service.Config.HealthSingleAbilityHot) return false;
         if (Player.Object.MaxHp - Player.Object.CurrentHp < MaxHp) return false;
-        return base.CanUse(out item, clippingCheck);
+        return base.CanUse(out item);
     }
 }

--- a/RotationSolver.Basic/Actions/IBaseItem.cs
+++ b/RotationSolver.Basic/Actions/IBaseItem.cs
@@ -19,5 +19,5 @@ public interface IBaseItem : IAction
     /// <param name="item"></param>
     /// <param name="clippingCheck"></param>
     /// <returns></returns>
-    bool CanUse(out IAction item, bool clippingCheck = true);
+    bool CanUse(out IAction item, bool clippingCheck = false);
 }

--- a/RotationSolver.Basic/Actions/MpPotionItem.cs
+++ b/RotationSolver.Basic/Actions/MpPotionItem.cs
@@ -19,6 +19,6 @@ internal class MpPotionItem : BaseItem
         item = this;
         if (!Player.Available) return false;
         if (Player.Object.MaxMp - DataCenter.CurrentMp < MaxMp) return false;
-        return base.CanUse(out item, clippingCheck);
+        return base.CanUse(out item);
     }
 }

--- a/RotationSolver.Basic/Rotations/Basic/ViperRotation.cs
+++ b/RotationSolver.Basic/Rotations/Basic/ViperRotation.cs
@@ -186,8 +186,6 @@ public partial class ViperRotation
     static partial void ModifyWrithingSnapPvE(ref ActionSetting setting)
     {
         setting.SpecialType = SpecialActionType.MeleeRange;
-        setting.ActionCheck = () => SerpentCombo == SerpentCombo.NONE;
-
     }
 
     static partial void ModifySlitherPvE(ref ActionSetting setting)
@@ -409,7 +407,7 @@ public partial class ViperRotation
 
     static partial void ModifyUncoiledFuryPvE(ref ActionSetting setting)
     {
-        setting.ActionCheck = () => RattlingCoilStacks >= 1 && SerpentCombo == SerpentCombo.NONE;
+        setting.ActionCheck = () => RattlingCoilStacks >= 1;
         setting.StatusProvide = [StatusID.PoisedForTwinfang];
         setting.CreateConfig = () => new ActionConfig()
         {

--- a/RotationSolver/Commands/RSCommands_StateSpecialCommand.cs
+++ b/RotationSolver/Commands/RSCommands_StateSpecialCommand.cs
@@ -8,7 +8,7 @@ namespace RotationSolver.Commands
 {
     public static partial class RSCommands
     {
-        private static string _stateString = "Off", _specialString = string.Empty;
+        public static string _stateString = "Off", _specialString = string.Empty;
 
         internal static string EntryString => _stateString + (DataCenter.SpecialTimeLeft < 0 ? string.Empty : $" - {_specialString}: {DataCenter.SpecialTimeLeft:F2}s");
 
@@ -22,7 +22,7 @@ namespace RotationSolver.Commands
             });
         }
 
-        private static unsafe void DoStateCommandType(StateCommandType stateType, int index = -1) => DoOneCommandType((type, role) => type.ToStateString(role), role =>
+        public static unsafe void DoStateCommandType(StateCommandType stateType, int index = -1) => DoOneCommandType((type, role) => type.ToStateString(role), role =>
         {
             if (DataCenter.State)
             {

--- a/RotationSolver/Data/UiString.cs
+++ b/RotationSolver/Data/UiString.cs
@@ -412,7 +412,7 @@ namespace RotationSolver.Data
         [Description("Speed Forced Condition")]
         ConfigWindow_Auto_SpeedConditionSet,
 
-        [Description("Limit Break Forced Condition")]
+        [Description("Limit Break Forced Condition (Unsupported)")]
         ConfigWindow_Auto_LimitBreakConditionSet,
 
         [Description("This will change the way that RSR uses actions.")]

--- a/RotationSolver/Updaters/PreviewUpdater.cs
+++ b/RotationSolver/Updaters/PreviewUpdater.cs
@@ -2,6 +2,7 @@
 using Dalamud.Game.Text.SeStringHandling;
 using Dalamud.Game.Text.SeStringHandling.Payloads;
 using ECommons.DalamudServices;
+using ECommons.ExcelServices;
 using ECommons.GameHelpers;
 using FFXIVClientStructs.FFXIV.Client.Game.UI;
 using FFXIVClientStructs.FFXIV.Client.System.Framework;
@@ -9,6 +10,9 @@ using FFXIVClientStructs.FFXIV.Client.UI;
 using FFXIVClientStructs.FFXIV.Client.UI.Misc;
 using RotationSolver.Basic.Configuration;
 using RotationSolver.Commands;
+using Dalamud.Game.ClientState.Keys;
+using Lumina.Excel.GeneratedSheets;
+using ECommons;
 
 namespace RotationSolver.Updaters;
 
@@ -20,12 +24,43 @@ internal static class PreviewUpdater
         UpdateCancelCast();
     }
 
+    //public static byte Job => Job;
     static IDtrBarEntry? _dtrEntry;
+
     private static void UpdateEntry()
     {
         var showStr = RSCommands.EntryString;
-        if (Service.Config.ShowInfoOnDtr
-            && !string.IsNullOrEmpty(showStr))
+        var icon = Player.Job switch
+        {
+            Job.WAR => BitmapFontIcon.Warrior,
+            Job.PLD => BitmapFontIcon.Paladin,
+            Job.DRK => BitmapFontIcon.DarkKnight,
+            Job.GNB => BitmapFontIcon.Gunbreaker,
+
+            Job.AST => BitmapFontIcon.Astrologian,
+            Job.WHM => BitmapFontIcon.WhiteMage,
+            Job.SGE => BitmapFontIcon.Sage,
+            Job.SCH => BitmapFontIcon.Scholar,
+
+            Job.BLM => BitmapFontIcon.BlackMage,
+            Job.SMN => BitmapFontIcon.Summoner,
+            Job.RDM => BitmapFontIcon.RedMage,
+            Job.PCT => BitmapFontIcon.Pictomancer,
+
+            Job.MNK => BitmapFontIcon.Monk,
+            Job.SAM => BitmapFontIcon.Samurai,
+            Job.DRG => BitmapFontIcon.Dragoon,
+            Job.RPR => BitmapFontIcon.Reaper,
+            Job.NIN => BitmapFontIcon.Ninja,
+            Job.VPR => BitmapFontIcon.Viper,
+
+            Job.BRD => BitmapFontIcon.Bard,
+            Job.MCH => BitmapFontIcon.Machinist,
+            Job.DNC => BitmapFontIcon.Dancer,
+            _ => BitmapFontIcon.ExclamationRectangle,
+        };
+
+        if (Service.Config.ShowInfoOnDtr && !string.IsNullOrEmpty(showStr))
         {
             try
             {
@@ -41,9 +76,9 @@ internal static class PreviewUpdater
             if (!_dtrEntry.Shown) _dtrEntry.Shown = true;
 
             _dtrEntry.Text = new SeString(
-                new IconPayload(BitmapFontIcon.DPS),
+                new IconPayload(icon),
                 new TextPayload(showStr)
-                );
+            );
             _dtrEntry.OnClick = RSCommands.IncrementState;
         }
         else if (_dtrEntry != null && _dtrEntry.Shown)


### PR DESCRIPTION
Refactored the `CanUse` method in `BaseItem` and related classes to have a default `clippingCheck` parameter value of `false`. Removed `clippingCheck` and `ActionCheck` conditions in various methods. Updated cure potency and added new descriptions in `Resources.resx`. Changed access modifiers in `RSCommands_StateSpecialCommand.cs`. Updated `PreviewUpdater.cs` to set job-specific icons and added new using directives. Updated `UiString.cs` to indicate unsupported `Limit Break Forced Condition`.