### PR TITLE
Refactor and improve null checks, add PvP handling

### DIFF
--- a/RotationSolver.Basic/Configuration/Configs.cs
+++ b/RotationSolver.Basic/Configuration/Configs.cs
@@ -135,6 +135,10 @@ internal partial class Configs : IPluginConfiguration
         Filter = TargetConfig)]
     private static readonly bool _filterStopMark = true;
 
+    [ConditionBool, UI("Treat 1hp targets as invincible.",
+        Filter = TargetConfig)]
+    private static readonly bool _filterOneHPInvincible = true;
+
     [ConditionBool, UI("Teaching mode", Filter = UiInformation)]
     private static readonly bool _teachingMode = false;
 

--- a/RotationSolver.Basic/DataCenter.cs
+++ b/RotationSolver.Basic/DataCenter.cs
@@ -295,14 +295,17 @@ internal static class DataCenter
         get
         {
             return AllTargets.Where(b =>
-            {
+            {               
+                //Not enemy.
                 if (!b.IsEnemy()) return false;
 
                 //Dead.
                 if (b.CurrentHp <= 1) return false;
 
+                //Not targetable.
                 if (!b.IsTargetable) return false;
 
+                //Invincible.
                 if (b.StatusList.Any(StatusHelper.IsInvincible)) return false;
                 return true;
             }).ToArray();
@@ -318,19 +321,21 @@ internal static class DataCenter
     {
         get
         {
+            // Ensure AllianceMembers and PartyMembers are not null
+            if (AllianceMembers == null || PartyMembers == null) return null;
+
             var deathAll = AllianceMembers.GetDeath();
             var deathParty = PartyMembers.GetDeath();
 
             if (deathParty.Any())
             {
-                var deathT = deathParty.GetJobCategory(JobRole.Tank);
+                var deathT = deathParty.GetJobCategory(JobRole.Tank).ToList();
+                var deathH = deathParty.GetJobCategory(JobRole.Healer).ToList();
 
-                if (deathT.Count() > 1)
+                if (deathT.Count > 1)
                 {
                     return deathT.FirstOrDefault();
                 }
-
-                var deathH = deathParty.GetJobCategory(JobRole.Healer);
 
                 if (deathH.Any()) return deathH.FirstOrDefault();
 
@@ -341,10 +346,11 @@ internal static class DataCenter
 
             if (deathAll.Any() && Service.Config.RaiseAll)
             {
-                var deathAllH = deathAll.GetJobCategory(JobRole.Healer);
+                var deathAllH = deathAll.GetJobCategory(JobRole.Healer).ToList();
+                var deathAllT = deathAll.GetJobCategory(JobRole.Tank).ToList();
+
                 if (deathAllH.Any()) return deathAllH.FirstOrDefault();
 
-                var deathAllT = deathAll.GetJobCategory(JobRole.Tank);
                 if (deathAllT.Any()) return deathAllT.FirstOrDefault();
 
                 return deathAll.FirstOrDefault();

--- a/RotationSolver.Basic/Helpers/ReflectionHelper.cs
+++ b/RotationSolver.Basic/Helpers/ReflectionHelper.cs
@@ -4,7 +4,7 @@ internal static class ReflectionHelper
 {
     internal static PropertyInfo[] GetStaticProperties<T>(this Type? type)
     {
-        if (type == null) return [];
+        if (type == null) return Array.Empty<PropertyInfo>();
 
         var props = from prop in type.GetRuntimeProperties()
                     where typeof(T).IsAssignableFrom(prop.PropertyType)
@@ -13,24 +13,22 @@ internal static class ReflectionHelper
                             && info.GetCustomAttribute<ObsoleteAttribute>() == null
                     select prop;
 
-        return props.Union(type.BaseType.GetStaticProperties<T>()).ToArray();
+        return props.Union(type.BaseType?.GetStaticProperties<T>() ?? Array.Empty<PropertyInfo>()).ToArray();
     }
 
     internal static IEnumerable<MethodInfo> GetAllMethodInfo(this Type? type)
     {
-        if (type == null) return [];
+        if (type == null) return Enumerable.Empty<MethodInfo>();
 
         var methods = from method in type.GetRuntimeMethods()
                       where !method.IsConstructor
                       select method;
 
-        return methods.Union(type.BaseType.GetAllMethodInfo());
+        return methods.Union(type.BaseType?.GetAllMethodInfo() ?? Enumerable.Empty<MethodInfo>());
     }
 
     internal static PropertyInfo? GetPropertyInfo(this Type type, string name)
     {
-        if (type == null) return null;
-
         foreach (var item in type.GetRuntimeProperties())
         {
             if (item.Name == name && item.GetMethod is MethodInfo info
@@ -50,6 +48,6 @@ internal static class ReflectionHelper
                       && !item.IsConstructor && item.ReturnType == typeof(bool)) return item;
         }
 
-        return type.BaseType.GetMethodInfo(name);
+        return type.BaseType?.GetMethodInfo(name);
     }
 }

--- a/RotationSolver/Extensions.cs
+++ b/RotationSolver/Extensions.cs
@@ -4,7 +4,11 @@
     {
         public static string ToStateString(this StateCommandType stateType, JobRole role)
         {
-            if (stateType == StateCommandType.Auto)
+            if (DataCenter.IsPvP && stateType == StateCommandType.Auto)
+            {
+                return $"{stateType} (LowHP)";
+            }
+            else if (stateType == StateCommandType.Auto)
             {
                 return $"{stateType} ({DataCenter.TargetingType})";
             }


### PR DESCRIPTION
Refactored various methods across multiple files to improve null checks, readability, and maintainability. Added new configuration options and specific handling for PvP scenarios. Removed unused code and imports, and updated documentation for better clarity.

- RSR defaults to LowHP targeting in PvP scenarios now
- Attempted fix of statuslist crash during large hunts, please report if issues persist
- New config allowing users to enable or disable RSR treating 1HP targets as invincible
- RSR will now prio marked fate targets over just any fate targets, since forlorn maidens are so important now