### PR TITLE
Refactor and enhance GCD and raid time management

### DIFF
--- a/RotationSolver.Basic/Helpers/StatusHelper.cs
+++ b/RotationSolver.Basic/Helpers/StatusHelper.cs
@@ -244,8 +244,6 @@ public static class StatusHelper
 
         if (!Player.Object.HasStatus(false, status))
         {
-            // Log or handle the case where the player does not have the status
-            PluginLog.Error($"Player does not have the status: {GetStatusName(status)}");
             return;
         }
 
@@ -254,6 +252,7 @@ public static class StatusHelper
             Chat.Instance.SendMessage($"/statusoff {GetStatusName(status)}");
             PluginLog.Error($"Status {GetStatusName(status)} removed successfully.");
         }
+
         catch (Exception ex)
         {
             // Log the exception


### PR DESCRIPTION
Update Ecommons

In `DataCenter.cs`:
- Added properties and methods for GCD calculations and raid time management.
- Updated `RaidTimeRaw`, `AllHostileTargets`, `AverageTimeToKill`, `GetPartyMemberHPRatio`, `PartyMembersMinHP`, `PartyMembersAverHP`, and `IsHostileCastingBase` with comments for clarity.

In `StatusHelper.cs`:
- Removed unused `using` directives, `DrawRotationsLibraries` method, `_allStatus` field, and `AllStatus` property.
- Added `_badStatus` field, `BadStatus` property, `DrawList` method, `_idsHeader` field, and `DrawListStatuses` method.
- Replaced `ImGui.TextWrapped` calls with `DrawStatusList` and `DrawActionsList`.
- Added constants for UI dimensions and text lengths.
- Updated various methods to use string interpolation and constants for better readability and maintainability.

General refactoring:
- Introduced `FriendSubKind` constant.
- Reformatted `EffectEntry` array initialization.
- Removed unnecessary `set.TargetEffects.Any()` check.
- Enhanced logic for dequeuing targets.
- Introduced `regexOptions` for compiling regular expressions with `RegexOptions.Compiled | RegexOptions.IgnoreCase`.