### PR TITLE
Dancer AoE adjustment

### DIFF
--- a/RotationSolver.Basic/Rotations/Basic/DancerRotation.cs
+++ b/RotationSolver.Basic/Rotations/Basic/DancerRotation.cs
@@ -140,7 +140,7 @@ partial class DancerRotation
         setting.StatusProvide = [StatusID.ThreefoldFanDance];
         setting.CreateConfig = () => new ActionConfig()
         {
-            AoeCount = 3,
+            AoeCount = 2,
         };
     }
 


### PR DESCRIPTION
Changed the default AoE count for Fan Dance II to 2 enemies instead of 3, as it deals more damage than Fan Dance on 2+ instead on 3+.