### PR TITLE
Bug fix for Issue 291

### DIFF
--- a/RotationSolver.Basic/Actions/BaseAction.cs
+++ b/RotationSolver.Basic/Actions/BaseAction.cs
@@ -1,6 +1,7 @@
 ﻿using ECommons.DalamudServices;
 using ECommons.GameHelpers;
 using FFXIVClientStructs.FFXIV.Client.Game;
+using RotationSolver.Basic.Configuration;
 using Action = Lumina.Excel.GeneratedSheets.Action;
 
 namespace RotationSolver.Basic.Actions;

--- a/RotationSolver.Basic/Actions/BaseAction.cs
+++ b/RotationSolver.Basic/Actions/BaseAction.cs
@@ -86,17 +86,16 @@ public class BaseAction : IBaseAction
                     = Setting.CreateConfig?.Invoke() ?? new();
                 if (Action.ClassJob.Value?.GetJobRole() == JobRole.Tank)
                 {
-                    value.AoeCount = 2;
+                    value.AoeCount = Math.Min(value.AoeCount, (byte)2);
                 }
-
                 if (value.TimeToUntargetable == 0)
                 {
                     value.TimeToUntargetable = value.TimeToKill;
                 }
-
-                if (Setting.TargetStatusProvide != null)
+                if (OtherConfiguration.TargetStatusProvide.TryGetValue(ID, out var targetStatusProvide)
+                    && targetStatusProvide.Length > 0)
                 {
-                    value.TimeToKill = 10;
+                    value.TimeToKill = MathF.Max(value.TimeToKill, 10);
                 }
             }
             return value;

--- a/RotationSolver.Basic/Configuration/OtherConfiguration.cs
+++ b/RotationSolver.Basic/Configuration/OtherConfiguration.cs
@@ -21,6 +21,9 @@ internal class OtherConfiguration
 
     public static RotationSolverRecord RotationSolverRecord = new();
 
+    public static Dictionary<uint, StatusID[]> StatusProvide = [];
+    public static Dictionary<uint, StatusID[]> TargetStatusProvide = [];
+    
     public static void Init()
     {
         if (!Directory.Exists(Svc.PluginInterface.ConfigDirectory.FullName))
@@ -28,6 +31,8 @@ internal class OtherConfiguration
             Directory.CreateDirectory(Svc.PluginInterface.ConfigDirectory.FullName);
         }
 
+        Task.Run(() => InitOne(ref StatusProvide, nameof(StatusProvide)));
+        Task.Run(() => InitOne(ref TargetStatusProvide, nameof(TargetStatusProvide)));
         Task.Run(() => InitOne(ref DangerousStatus, nameof(DangerousStatus)));
         Task.Run(() => InitOne(ref PriorityStatus, nameof(PriorityStatus)));
         Task.Run(() => InitOne(ref InvincibleStatus, nameof(InvincibleStatus)));
@@ -58,9 +63,20 @@ internal class OtherConfiguration
             await SaveNoProvokeNames();
             await SaveNoCastingStatus();
             await SaveHostileCastingKnockback();
+            await SaveStatusProvide();
+            await SaveTargetStatusProvide();
         });
     }
 
+    private static Task SaveStatusProvide()
+    {
+        return Task.Run(() => Save(StatusProvide, nameof(StatusProvide)));
+    }
+
+    private static Task SaveTargetStatusProvide()
+    {
+        return Task.Run(() => Save(TargetStatusProvide, nameof(TargetStatusProvide)));
+    }
     private static Task SaveHostileCastingKnockback()
     {
         return Task.Run(() => Save(HostileCastingKnockback, nameof(HostileCastingKnockback)));


### PR DESCRIPTION
Added the bug fix from Archi's RS which fixes the issue listed here: https://github.com/FFXIV-CombatReborn/RotationSolverReborn/issues/291#issue-2439278494

Tank AOEs and TTKs in Base Rotations should update properly now. A reset of the plugin is still needed to pull the correct numbers.
I tested the Kardia issue with LTS' workaround in the SGE_Default.cs removed and it deployed Kardia while not in battle.
I tested my issue with GNB AOEs not pulling from the base rotation and now they pull correctly, they still default to 2 if AOECount is greater than 2 in base.