### PR TITLE
Update targeting config, add tracking fields, enhance methods

### DIFF
--- a/RotationSolver.Basic/Configuration/Configs.cs
+++ b/RotationSolver.Basic/Configuration/Configs.cs
@@ -176,7 +176,7 @@ internal partial class Configs : IPluginConfiguration
         PvEFilter = JobFilterType.NoHealer, PvPFilter = JobFilterType.NoJob)]
     private static readonly bool _useHealWhenNotAHealer = true;
 
-    [ConditionBool, UI("Target allies for friendly actions.", Description = "If this is disabled, RSR will only softtarget allies for heals, shields, etc.",
+    [ConditionBool, UI("Hard Target enemies for hostile actions", Description = "If this is disabled, RSR will only softtarget allies for heals, shields, etc.",
         Filter = TargetConfig, Section = 3)]
     private static readonly bool _switchTargetFriendly = false;
 

--- a/RotationSolver.Basic/Rotations/CustomRotation_Ability.cs
+++ b/RotationSolver.Basic/Rotations/CustomRotation_Ability.cs
@@ -265,14 +265,14 @@ partial class CustomRotation
         if (nextGCD is BaseAction action)
         {
             if (Role is JobRole.RangedMagical &&
-            action.Info.CastTime >= 5 && SwiftcastPvE.CanUse(out act)) return true;
+            action.Info.CastTime >= 5 && SwiftcastPvE.CanUse(out act, isFirstAbility: true)) return true;
 
         }
 
         if (DataCenter.CommandStatus.HasFlag(AutoStatus.Raise))
         {
 
-            if (Role is JobRole.Healer && SwiftcastPvE.CanUse(out act)) return true;
+            if (Role is JobRole.Healer && SwiftcastPvE.CanUse(out act, isFirstAbility: true)) return true;
         }
 
         if (DataCenter.RightNowDutyRotation?.EmergencyAbility(nextGCD, out act) ?? false) return true;

--- a/RotationSolver.Basic/Rotations/CustomRotation_GCD.cs
+++ b/RotationSolver.Basic/Rotations/CustomRotation_GCD.cs
@@ -203,7 +203,7 @@ partial class CustomRotation
             if (Role is JobRole.Healer && HasSwift) return false;
         }
 
-        if (EsunaPvE.CanUse(out act)) return true;
+        if (!HasSwift && EsunaPvE.CanUse(out act)) return true;
         if (DataCenter.RightNowDutyRotation?.DispelGCD(out act) ?? false) return true;
         return false;
     }

--- a/RotationSolver/Commands/RSCommands_Actions.cs
+++ b/RotationSolver/Commands/RSCommands_Actions.cs
@@ -40,6 +40,7 @@ public static partial class RSCommands
 
         return true;
     }
+
     internal static DateTime _lastUsedTime = DateTime.MinValue;
     internal static uint _lastActionID;
     public static void DoAction()


### PR DESCRIPTION
Renamed `_switchTargetFriendly` to "Hard Target enemies for hostile actions" and updated its description in `Configs.cs`.

In `CustomRotation_Ability.cs`, added `isFirstAbility: true` parameter to `SwiftcastPvE.CanUse` for actions with a cast time of 5+ and for healers when `AutoStatus.Raise` is set.

In `CustomRotation_GCD.cs`, added a condition to `EsunaPvE.CanUse` to check if `HasSwift` is false.

In `RSCommands_Actions.cs`, added `_lastUsedTime` and `_lastActionID` fields, and introduced `DoAction` method utilizing these fields.