### PR TITLE
Added Option to prioritize Targets based on name and territory

### DIFF
--- a/RotationSolver.Basic/Configuration/OtherConfiguration.cs
+++ b/RotationSolver.Basic/Configuration/OtherConfiguration.cs
@@ -10,6 +10,7 @@ internal class OtherConfiguration
 
     public static SortedList<uint, float> AnimationLockTime = [];
 
+    public static Dictionary<uint, string[]> PrioTargetNames = [];
     public static Dictionary<uint, string[]> NoHostileNames = [];
     public static Dictionary<uint, string[]> NoProvokeNames = [];
     public static Dictionary<uint, Vector3[]> BeneficialPositions = [];
@@ -31,6 +32,7 @@ internal class OtherConfiguration
         Task.Run(() => InitOne(ref DangerousStatus, nameof(DangerousStatus)));
         Task.Run(() => InitOne(ref PriorityStatus, nameof(PriorityStatus)));
         Task.Run(() => InitOne(ref InvincibleStatus, nameof(InvincibleStatus)));
+        Task.Run(() => InitOne(ref PrioTargetNames, nameof(PrioTargetNames)));
         Task.Run(() => InitOne(ref NoHostileNames, nameof(NoHostileNames)));
         Task.Run(() => InitOne(ref NoProvokeNames, nameof(NoProvokeNames)));
         Task.Run(() => InitOne(ref AnimationLockTime, nameof(AnimationLockTime)));
@@ -49,6 +51,7 @@ internal class OtherConfiguration
             await SavePriorityStatus();
             await SaveDangerousStatus();
             await SaveInvincibleStatus();
+            await SavePrioTargetNames();
             await SaveNoHostileNames();
             await SaveAnimationLockTime();
             await SaveHostileCastingArea();
@@ -108,6 +111,11 @@ internal class OtherConfiguration
     public static Task SaveInvincibleStatus()
     {
         return Task.Run(() => Save(InvincibleStatus, nameof(InvincibleStatus)));
+    }
+
+    public static Task SavePrioTargetNames()
+    {
+        return Task.Run(() => Save(PrioTargetNames, nameof(PrioTargetNames)));
     }
 
     public static Task SaveNoHostileNames()

--- a/RotationSolver.Basic/DataCenter.cs
+++ b/RotationSolver.Basic/DataCenter.cs
@@ -112,6 +112,15 @@ internal static class DataCenter
 
     public static bool IsInHighEndDuty => ContentFinder?.HighEndDuty ?? false;
 
+    #region UnComment if adding this is ok, Love ~~ Kirbo
+    //public static ushort TerritoryID => Svc.ClientState.TerritoryType;
+    //public static bool IsInUCoB => TerritoryID == 733;
+    //public static bool IsInUwU => TerritoryID == 777;
+    //public static bool IsInTEA => TerritoryID == 887;
+    //public static bool IsInDSR => TerritoryID == 968;
+    //public static bool IsInTOP => TerritoryID == 1122;
+    #endregion
+
     public static TerritoryContentType TerritoryContentType =>
         (TerritoryContentType)(ContentFinder?.ContentType?.Value?.RowId ?? 0);
 

--- a/RotationSolver.Basic/Helpers/ObjectHelper.cs
+++ b/RotationSolver.Basic/Helpers/ObjectHelper.cs
@@ -90,6 +90,16 @@ public static class ObjectHelper
 
         if (names.Any(n => !string.IsNullOrEmpty(n) && new Regex(n).Match(battleChara.Name.TextValue).Success)) return false;
 
+        // Fetch prioritized target names
+        if (OtherConfiguration.PrioTargetNames.TryGetValue(Svc.ClientState.TerritoryType, out var prioTargetNames))
+        {
+            // If the target's name matches any prioritized names, it is attackable
+            if (prioTargetNames.Any(n => !string.IsNullOrEmpty(n) && new Regex(n).Match(battleChara.Name.TextValue).Success))
+            {
+                return true;
+            }
+        }
+
         //Fate
         if (DataCenter.TerritoryContentType != TerritoryContentType.Eureka)
         {
@@ -115,8 +125,7 @@ public static class ObjectHelper
 
         if (Service.CountDownTime > 0 || DataCenter.IsPvP) return true;
 
-        return DataCenter.RightNowTargetToHostileType switch
-        {
+        return DataCenter.RightNowTargetToHostileType switch {
             TargetHostileType.AllTargetsCanAttack => true,
             TargetHostileType.TargetsHaveTarget => battleChara.TargetObject is IBattleChara,
             TargetHostileType.AllTargetsWhenSolo => DataCenter.PartyMembers.Length < 2 || battleChara.TargetObject is IBattleChara,

--- a/RotationSolver.Basic/Rotations/CustomRotation_OtherInfo.cs
+++ b/RotationSolver.Basic/Rotations/CustomRotation_OtherInfo.cs
@@ -266,6 +266,39 @@ partial class CustomRotation
     [Description("Is in the high-end duty")]
     public static bool IsInHighEndDuty => DataCenter.IsInHighEndDuty;
 
+    #region UnComment if adding this is ok, Love ~~ Kirbo
+
+    ///// <summary>
+    ///// Is player in UCoB duty.
+    ///// </summary>
+    //[Description("Is in UCoB duty")]
+    //public static bool IsInUCoB => DataCenter.IsInUCoB;
+
+    ///// <summary>
+    ///// Is player in UwU duty.
+    ///// </summary>
+    //[Description("Is in UwU duty")]
+    //public static bool IsInUwU => DataCenter.IsInUwU;
+
+    ///// <summary>
+    ///// Is player in TEA duty.
+    ///// </summary>
+    //[Description("Is in TEA duty")]
+    //public static bool IsInTEA => DataCenter.IsInTEA;
+
+    ///// <summary>
+    ///// Is player in DSR duty.
+    ///// </summary>
+    //[Description("Is in DSR duty")]
+    //public static bool IsInDSR => DataCenter.IsInDSR;
+
+    ///// <summary>
+    ///// Is player in TOP duty.
+    ///// </summary>
+    //[Description("Is in TOP duty")]
+    //public static bool IsInTOP => DataCenter.IsInTOP;
+    #endregion
+
     /// <summary>
     /// Is player in duty.
     /// </summary>

--- a/RotationSolver/Data/UiString.cs
+++ b/RotationSolver/Data/UiString.cs
@@ -256,6 +256,9 @@ namespace RotationSolver.Data
         [Description("Add Action")]
         ConfigWindow_List_AddAction,
 
+        [Description("Prio Target")]
+        ConfigWindow_List_PrioTarget,
+
         [Description("Don't target")]
         ConfigWindow_List_NoHostile,
 
@@ -265,8 +268,14 @@ namespace RotationSolver.Data
         [Description("Beneficial AoE locations")]
         ConfigWindow_List_BeneficialPositions,
 
+        [Description("Enemies that will be prioritized.")]
+        ConfigWindow_List_PrioTargetDesc,
+
         [Description("Enemies that will never be targeted.")]
         ConfigWindow_List_NoHostileDesc,
+
+        [Description("The name of the enemy that you want to be prioritized.")]
+        ConfigWindow_List_PrioTargetName,
 
         [Description("The name of the enemy that you don't want to be targeted")]
         ConfigWindow_List_NoHostilesName,

--- a/RotationSolver/UI/RotationConfigWindow.cs
+++ b/RotationSolver/UI/RotationConfigWindow.cs
@@ -42,8 +42,7 @@ public partial class RotationConfigWindow : Window
     {
         SizeCondition = ImGuiCond.FirstUseEver;
         Size = new Vector2(740f, 490f);
-        SizeConstraints = new WindowSizeConstraints()
-        {
+        SizeConstraints = new WindowSizeConstraints() {
             MinimumSize = new Vector2(250, 300),
             MaximumSize = new Vector2(5000, 5000),
         };
@@ -2091,7 +2090,7 @@ public partial class RotationConfigWindow : Window
 
         DrawContentFinder(DataCenter.ContentFinder);
 
-        using var table = ImRaii.Table("Rotation Solver List Territories", 3, ImGuiTableFlags.BordersInner | ImGuiTableFlags.Resizable | ImGuiTableFlags.SizingStretchSame);
+        using var table = ImRaii.Table("Rotation Solver List Territories", 4, ImGuiTableFlags.BordersInner | ImGuiTableFlags.Resizable | ImGuiTableFlags.SizingStretchSame);
         if (table)
         {
             ImGui.TableSetupScrollFreeze(0, 1);
@@ -2099,6 +2098,9 @@ public partial class RotationConfigWindow : Window
 
             ImGui.TableNextColumn();
             ImGui.TableHeader(UiString.ConfigWindow_List_NoHostile.GetDescription());
+
+            ImGui.TableNextColumn();
+            ImGui.TableHeader(UiString.ConfigWindow_List_PrioTarget.GetDescription());
 
             ImGui.TableNextColumn();
             ImGui.TableHeader(UiString.ConfigWindow_List_NoProvoke.GetDescription());
@@ -2147,6 +2149,65 @@ public partial class RotationConfigWindow : Window
                 OtherConfiguration.NoHostileNames[territoryId] = [.. list];
                 OtherConfiguration.SaveNoHostileNames();
             }
+
+
+
+
+            // Begin new column for Prioritized Target Names
+            ImGui.TableNextColumn();
+            ImGui.TextWrapped(UiString.ConfigWindow_List_PrioTargetDesc.GetDescription());
+
+            width = ImGui.GetColumnWidth() - ImGuiEx.CalcIconSize(FontAwesomeIcon.Ban).X - ImGui.GetStyle().ItemSpacing.X - 10 * Scale;
+
+            // Check if PrioritizedNames for the current territory exists
+            if (!OtherConfiguration.PrioTargetNames.TryGetValue(territoryId, out var prioNames))
+            {
+                // Initialize it as an empty list
+                OtherConfiguration.PrioTargetNames[territoryId] = prioNames = [];
+            }
+
+            // Add an empty entry if none exists
+            if (!prioNames.Any(string.IsNullOrEmpty))
+            {
+                OtherConfiguration.PrioTargetNames[territoryId] = [.. prioNames, string.Empty];
+            }
+
+            // Variable to track if we need to remove any entry
+            removeIndex = -1;
+
+            // Loop over each prioritized name to render input fields
+            for (int i = 0; i < prioNames.Length; i++)
+            {
+                ImGui.SetNextItemWidth(width);
+
+                // Render input field for prioritized name with a placeholder hint
+                if (ImGui.InputTextWithHint($"##Rotation Solver Prioritized Target Name {i}", UiString.ConfigWindow_List_PrioTargetName.GetDescription(), ref prioNames[i], 1024))
+                {
+                    // If input changes, update the list
+                    OtherConfiguration.PrioTargetNames[territoryId] = prioNames;
+                    OtherConfiguration.SavePrioTargetNames();
+                }
+                ImGui.SameLine();
+
+                // Render a button to remove a name
+                if (ImGuiEx.IconButton(FontAwesomeIcon.Ban, $"##Rotation Solver Remove Prioritized Target Name {i}"))
+                {
+                    removeIndex = i;
+                }
+            }
+
+            // If a remove button was clicked, remove the corresponding entry
+            if (removeIndex > -1)
+            {
+                var list = prioNames.ToList();
+                list.RemoveAt(removeIndex);
+                OtherConfiguration.PrioTargetNames[territoryId] = [.. list];
+                OtherConfiguration.SavePrioTargetNames();
+            }
+
+
+
+
             ImGui.TableNextColumn();
             ImGui.TextWrapped(UiString.ConfigWindow_List_NoProvokeDesc.GetDescription());
 


### PR DESCRIPTION
Added extra option to lists that lets user prioritize targets based on target name and territory

Added commented-out properties to Custom Rotation and Datacenter which if uncommented could be used in rotations to specifically target conditions for ultimates.

![image](https://github.com/user-attachments/assets/898afbbd-d615-40b2-bdd5-188bb912c989)
