### PR TITLE
Animation Lock Adjustment

### DIFF
--- a/RotationSolver.Basic/Actions/BaseAction.cs
+++ b/RotationSolver.Basic/Actions/BaseAction.cs
@@ -126,6 +126,8 @@ public class BaseAction : IBaseAction
     {
         act = this;
 
+        if (DataCenter.DefaultGCDRemain != 0 && act.AnimationLockTime > DataCenter.DefaultGCDRemain ) return false;
+
         if (IBaseAction.ActionPreview)
         {
             skipCastingCheck = true;


### PR DESCRIPTION
Sometimes when ability cooldown elapses close to the end of GCD it would use itself even tho the animation lock delays the GCD. Happened to me with GaussRound/Richochet. It happens rarely but after adding this line of code and hitting dummy for 1 hour it didn't happen again, so I presume it has been fixed. Normal oGCD usage at first glance seems unaffected negatively.

Tested on MCH lv 62, DNC lv 72, VPR lv 83.