### PR TITLE
Suppress warnings and refactor time handling in MajorUpdater

### DIFF
--- a/RotationSolver/RotationSolverPlugin.cs
+++ b/RotationSolver/RotationSolverPlugin.cs
@@ -149,6 +149,7 @@ public sealed class RotationSolverPlugin : IDalamudPlugin, IDisposable
             if (DataCenter.IsInHighEndDuty)
             {
                 var warning = string.Format(UiString.HighEndWarning.GetDescription(), DataCenter.ContentFinderName);
+#pragma warning disable CS0436
                 WarningHelper.AddSystemWarning(warning);
             }
         }

--- a/RotationSolver/UI/RotationConfigWindow.cs
+++ b/RotationSolver/UI/RotationConfigWindow.cs
@@ -2349,6 +2349,7 @@ public partial class RotationConfigWindow : Window
         // Add a button to test adding a system warning
         if (ImGui.Button("Add Test Warning"))
         {
+#pragma warning disable CS0436
             WarningHelper.AddSystemWarning("This is a test warning.");
         }
     }


### PR DESCRIPTION
Added `#pragma warning disable CS0436` to suppress type conflict warnings in RotationSolverPlugin.cs, RotationConfigWindow.cs, and MajorUpdater.cs. Refactored MajorUpdater.cs to use a `now` variable for consistent and potentially improved performance in `HandleWorkUpdate` and `UpdateWork`. Simplified conditions and improved exception handling. Removed unused methods `BuildWarningChatEntry` and `OpenWarningChatHandler`.