### PR TITLE
Disable check for FriendlyBattleNPC nameplate kind and Improve exception handling and logging in MajorUpdater

### DIFF
--- a/RotationSolver.Basic/Helpers/ObjectHelper.cs
+++ b/RotationSolver.Basic/Helpers/ObjectHelper.cs
@@ -172,7 +172,7 @@ public static class ObjectHelper
             if (gameObject.GameObjectId == Player.Object?.GameObjectId) return true;
             if (Svc.Party.Any(p => p.GameObject?.GameObjectId == gameObject.GameObjectId)) return true;
             if (gameObject.SubKind == 9) return true;
-            if (gameObject.GetNameplateKind() == NameplateKind.FriendlyBattleNPC) return true;
+            //if (gameObject.GetNameplateKind() == NameplateKind.FriendlyBattleNPC) return true;
         }
 
         return false;


### PR DESCRIPTION
Commented out the line that checked if `gameObject.GetNameplateKind()` is equal to `NameplateKind.FriendlyBattleNPC` to test if

- Commented out a line in ObjectHelper checking for FriendlyBattleNPC.
- Added conditional logging for main thread exceptions in MajorUpdater.
- Changed HandleWorkUpdate from async to synchronous.
- Updated task handling in HandleWorkUpdate to use Task.Run with continuation options for better exception handling and logging.
- Added similar logging and warnings for exceptions in UpdateWork and HotbarHighlightManager.UpdateSettings.