### PR TITLE
Adjusting code for adding chocobo companion to party list

### DIFF
--- a/RotationSolver.Basic/Helpers/ObjectHelper.cs
+++ b/RotationSolver.Basic/Helpers/ObjectHelper.cs
@@ -169,11 +169,9 @@ public static class ObjectHelper
             // Add Player Chocobo Companion to Party List
             unsafe
             {
-                BattleChara* companionChocobo = DataCenter.GetCompanion();
-                if (companionChocobo != null)
-                {
+                BattleChara companionChocobo = *DataCenter.GetCompanion();
+                if (&companionChocobo != null && companionChocobo.GetGameObjectId() == gameObject.GameObjectId)
                     return true;
-                }
             }
 
             if (Service.Config.FriendlyBattleNpcHeal && gameObject.GetNameplateKind() == NameplateKind.FriendlyBattleNPC) return true;


### PR DESCRIPTION
I think without `gameObject` check, `IsParty` returns true as long as Chocobo Companion is found, this results in objects that are probably not party members be identified as party members. Correct me if im wrong.