### PR TITLE
Refactor Configs and MajorUpdater for flexible framework updates

### DIFF
--- a/RotationSolver.Basic/Configuration/Configs.cs
+++ b/RotationSolver.Basic/Configuration/Configs.cs
@@ -189,9 +189,9 @@ internal partial class Configs : IPluginConfiguration
         PvPFilter = JobFilterType.NoJob)]
     private static readonly bool _interruptibleMoreCheck = true;
 
-    [ConditionBool, UI("Use work task for acceleration. (EXPERIMENTAL, WILL CAUSE CRASHES AND OTHER ISSUES)",
+    [UI("Framework Update Method (Experimental: Changing this off of game thread will cause crashes)",
         Filter = BasicParams)]
-    private static readonly bool _useWorkTask = false;
+    public FrameworkStyle FrameworkStyle { get; set; } = FrameworkStyle.MainThread;
 
     [ConditionBool, UI("Stop casting if the target dies.", Filter = Extra)]
     private static readonly bool _useStopCasting = false;

--- a/RotationSolver.Basic/Data/FrameworkStyle.cs
+++ b/RotationSolver.Basic/Data/FrameworkStyle.cs
@@ -1,0 +1,25 @@
+﻿namespace RotationSolver.Basic.Data;
+
+/// <summary>
+/// The way the framework updates.
+/// </summary>
+public enum FrameworkStyle : byte
+{
+    /// <summary>
+    /// On the game thread.
+    /// </summary>
+    [Description("On the game thread")]
+    MainThread,
+
+    /// <summary>
+    /// Running outside of game thread.
+    /// </summary>
+    [Description("Running outside of game thread")]
+    WorkTask,
+
+    /// <summary>
+    /// Running on Game Tick.
+    /// </summary>
+    [Description("Running on Game Tick")]
+    RunOnTick,
+}


### PR DESCRIPTION
Replaced `_useWorkTask` boolean in `Configs` with `FrameworkStyle` property to allow selection of update method: `MainThread`, `WorkTask`, or `RunOnTick`. Added `FrameworkStyle` enum in new `FrameworkStyle.cs` file. Updated `MajorUpdater` to use `FrameworkStyle` for running `UpdateWork` method, including an async `HandleWorkUpdateAsync` method.