### PR TITLE
Refactor StateUpdater and update ObjectHelper logic

### DIFF
--- a/RotationSolver.Basic/Helpers/ObjectHelper.cs
+++ b/RotationSolver.Basic/Helpers/ObjectHelper.cs
@@ -410,7 +410,7 @@ public static class ObjectHelper
     internal static bool IsAttacked(this IBattleChara b)
     {
         if (b == null) return false;
-        var now = DateTime.UtcNow;
+        var now = DateTime.Now;
         foreach (var (id, time) in DataCenter.AttackedTargets)
         {
             if (id == b.GameObjectId)

--- a/RotationSolver/UI/RotationConfigWindow.cs
+++ b/RotationSolver/UI/RotationConfigWindow.cs
@@ -1,4 +1,5 @@
 ﻿using Dalamud.Game.ClientState.Keys;
+using Dalamud.Game.ClientState.Objects.SubKinds;
 using Dalamud.Interface.Colors;
 using Dalamud.Interface.Utility;
 using Dalamud.Interface.Utility.Raii;
@@ -213,9 +214,11 @@ public partial class RotationConfigWindow : Window
             }
         }
 
-        if (Player.Job == Job.CRP || Player.Job == Job.BSM || Player.Job == Job.ARM || Player.Job == Job.GSM ||
-    Player.Job == Job.LTW || Player.Job == Job.WVR || Player.Job == Job.ALC || Player.Job == Job.CUL ||
-    Player.Job == Job.MIN || Player.Job == Job.FSH || Player.Job == Job.BTN)
+        IPlayerCharacter localPlayer = Player.Object;
+
+        if (localPlayer != null && (Player.Job == Job.CRP || Player.Job == Job.BSM || Player.Job == Job.ARM || Player.Job == Job.GSM ||
+        Player.Job == Job.LTW || Player.Job == Job.WVR || Player.Job == Job.ALC || Player.Job == Job.CUL ||
+        Player.Job == Job.MIN || Player.Job == Job.FSH || Player.Job == Job.BTN))
         {
             float availableWidth = ImGui.GetContentRegionAvail().X; // Get the available width dynamically
             ImGui.PushTextWrapPos(ImGui.GetCursorPos().X + availableWidth); // Set text wrapping position dynamically

--- a/RotationSolver/Updaters/StateUpdater.cs
+++ b/RotationSolver/Updaters/StateUpdater.cs
@@ -158,56 +158,7 @@ internal static class StateUpdater
                     }
                 }
 
-                else if (DataCenter.Job == ECommons.ExcelServices.Job.PLD) // PLD Specific defensive abilties.
-                {
-                    if (DataCenter.PartyMembers.Any((tank) =>
-                    {
-                        var attackingTankObj = DataCenter.AllHostileTargets.Where(t => t.TargetObjectId == tank.GameObjectId);
-
-                        if (attackingTankObj.Count() != 1) return false;
-
-                        return DataCenter.IsHostileCastingToTank;
-                    }))
-                    {
-                        if (Service.Config.InDebug)
-                        {
-                            Svc.Log.Information("Triggering DefenseSingle for Healer/PLD.");
-                        }
-                        status |= AutoStatus.DefenseSingle;
-                    }
-
-                    var movingHere = (float)DataCenter.NumberOfHostilesInRange / DataCenter.NumberOfHostilesInMaxRange > 0.3f;
-
-                    var tarOnMe = DataCenter.AllHostileTargets.Where(t => t.DistanceToPlayer() <= 3
-                    && t.TargetObject == Player.Object);
-                    var tarOnMeCount = tarOnMe.Count();
-                    var attackedCount = tarOnMe.Count(ObjectHelper.IsAttacked);
-                    var attacked = (float)attackedCount / tarOnMeCount > 0.7f;
-
-                    //A lot targets are targeting on me.
-                    if (tarOnMeCount >= Service.Config.AutoDefenseNumber
-                        && Player.Object.GetHealthRatio() <= Service.Config.HealthForAutoDefense
-                        && movingHere && attacked)
-                    {
-                        if (Service.Config.InDebug)
-                        {
-                            Svc.Log.Information("Triggering DefenseSingle for Tank.");
-                        }
-                        status |= AutoStatus.DefenseSingle;
-                    }
-
-                    //Big damage casting action.
-                    if (DataCenter.IsHostileCastingToTank)
-                    {
-                        if (Service.Config.InDebug)
-                        {
-                            Svc.Log.Information("Triggering DefenseSingle for Tank (Hostile Casting).");
-                        }
-                        status |= AutoStatus.DefenseSingle;
-                    }
-                }
-
-                else if (DataCenter.Role == JobRole.Tank || DataCenter.Job == ECommons.ExcelServices.Job.PLD) // Tank defensive abilties.
+                if (DataCenter.Role == JobRole.Tank) // Tank defensive abilties.
                 {
                     var movingHere = (float)DataCenter.NumberOfHostilesInRange / DataCenter.NumberOfHostilesInMaxRange > 0.3f;
 


### PR DESCRIPTION
Refactored the StateUpdater class to remove job-specific logic for PLD and consolidate tank defensive ability checks under a single Tank role check. Added a namespace to RotationConfigWindow and introduced a localPlayer variable with a null check for unsupported classes.