### PR TITLE
Fix typos, update Configs, and enhance NPC handling

### DIFF
--- a/RotationSolver.Basic/Configuration/Configs.cs
+++ b/RotationSolver.Basic/Configuration/Configs.cs
@@ -436,7 +436,7 @@ internal partial class Configs : IPluginConfiguration
         PvEFilter = JobFilterType.None)]
     private static readonly bool _raisePlayerBySwift = true;
 
-    [ConditionBool, UI("Raise any player in range in Alliance Raids)",
+    [ConditionBool, UI("Raise any player in range in Alliance Raids",
         Filter = HealingActionCondition, Section = 2,
         PvEFilter = JobFilterType.Raise, PvPFilter = JobFilterType.NoJob)]
     private static readonly bool _raiseAll = false;
@@ -470,6 +470,10 @@ internal partial class Configs : IPluginConfiguration
     [ConditionBool, UI("Heal solo instance NPCs. (Experimental)",
         Filter = HealingActionCondition, Section = 3)]
     private static readonly bool _friendlyBattleNPCHeal = false;
+
+    [ConditionBool, UI("Heal and raise Party NPCs.",
+        Filter = HealingActionCondition, Section = 3)]
+    private static readonly bool _friendlyPartyNPCHeal = false;
 
     [ConditionBool, UI("Heal/Dance partner your chocobo. (Experimental)",
         Filter = HealingActionCondition, Section = 3)]

--- a/RotationSolver.Basic/DataCenter.cs
+++ b/RotationSolver.Basic/DataCenter.cs
@@ -329,7 +329,7 @@ internal static class DataCenter
 
                 // Filter and cast objects safely
                 return Svc.Objects
-                    .Where(obj => obj != null && obj.ObjectKind == ObjectKind.BattleNpc && obj.GetNameplateKind() == NameplateKind.FriendlyBattleNPC)
+                    .Where(obj => obj != null && obj.ObjectKind == Dalamud.Game.ClientState.Objects.Enums.ObjectKind.BattleNpc && (obj.GetNameplateKind() == NameplateKind.FriendlyBattleNPC || obj.GetBattleNPCSubKind() == BattleNpcSubKind.NpcPartyMember))
                     .OfType<IBattleChara>()
                     .ToArray();
             }
@@ -381,6 +381,7 @@ internal static class DataCenter
 
             var deathAll = AllianceMembers.GetDeath();
             var deathParty = PartyMembers.GetDeath();
+            var deathNPC = FriendlyNPCMembers.GetDeath();
 
             if (deathParty.Any())
             {
@@ -409,6 +410,23 @@ internal static class DataCenter
                 if (deathAllT.Any()) return deathAllT.FirstOrDefault();
 
                 return deathAll.FirstOrDefault();
+            }
+
+            if (deathNPC.Any() && Service.Config.FriendlyPartyNpcHeal)
+            {
+                var deathNPCT = deathNPC.GetJobCategory(JobRole.Tank).ToList();
+                var deathNPCH = deathNPC.GetJobCategory(JobRole.Healer).ToList();
+
+                if (deathNPCT.Count > 1)
+                {
+                    return deathNPCT.FirstOrDefault();
+                }
+
+                if (deathNPCH.Any()) return deathNPCH.FirstOrDefault();
+
+                if (deathNPCT.Any()) return deathNPCT.FirstOrDefault();
+
+                return deathNPC.FirstOrDefault();
             }
 
             return null;

--- a/RotationSolver.Basic/Helpers/ObjectHelper.cs
+++ b/RotationSolver.Basic/Helpers/ObjectHelper.cs
@@ -167,7 +167,7 @@ public static class ObjectHelper
             // Accessing Player.Object and Svc.Party within the lock to ensure thread safety
             if (gameObject.GameObjectId == Player.Object?.GameObjectId) return true;
             if (Svc.Party.Any(p => p.GameObject?.GameObjectId == gameObject.GameObjectId)) return true;
-            if (gameObject.SubKind == 9) return true;
+            if (Service.Config.FriendlyPartyNpcHeal && gameObject.GetBattleNPCSubKind() == BattleNpcSubKind.NpcPartyMember) return true;
 
             // Check if ChocoboPartyMember is enabled
             if (Service.Config.ChocoboPartyMember)
@@ -186,7 +186,6 @@ public static class ObjectHelper
             if (Service.Config.FriendlyBattleNpcHeal && gameObject.GetNameplateKind() == NameplateKind.FriendlyBattleNPC) return true;
 
         }
-
         return false;
     }
 

--- a/RotationSolver/UI/RotationConfigWindow.cs
+++ b/RotationSolver/UI/RotationConfigWindow.cs
@@ -2477,6 +2477,52 @@ public partial class RotationConfigWindow : Window
         ImGui.Text($"Combo Time: {DataCenter.ComboTime}");
         ImGui.Text($"Merged Status: {DataCenter.MergedStatus}");
         ImGui.Text($"TargetingType: {DataCenter.TargetingType}");
+        ImGui.Text($"DeathTarget: {DataCenter.DeathTarget}");
+
+        // Display dead party members
+        var deadPartyMembers = DataCenter.PartyMembers.GetDeath();
+        if (deadPartyMembers.Any())
+        {
+            ImGui.Text("Dead Party Members:");
+            foreach (var member in deadPartyMembers)
+            {
+                ImGui.Text($"- {member.Name}");
+            }
+        }
+        else
+        {
+            ImGui.Text("Dead Party Members: None");
+        }
+
+        // Display all party members
+        var partyMembers = DataCenter.PartyMembers;
+        if (partyMembers.Any())
+        {
+            ImGui.Text("Party Members:");
+            foreach (var member in partyMembers)
+            {
+                ImGui.Text($"- {member.Name}");
+            }
+        }
+        else
+        {
+            ImGui.Text("Party Members: None");
+        }
+
+        // Display all party members
+        var friendlyNPCMembers = DataCenter.FriendlyNPCMembers;
+        if (friendlyNPCMembers.Any())
+        {
+            ImGui.Text("Friendly NPC Members:");
+            foreach (var member in friendlyNPCMembers)
+            {
+                ImGui.Text($"- {member.Name}");
+            }
+        }
+        else
+        {
+            ImGui.Text("Friendly NPC Members: None");
+        }
 
         ImGui.Text($"TerritoryType: {DataCenter.TerritoryContentType}");
         ImGui.Text($"DPSTaken: {DataCenter.DPSTaken}");
@@ -2537,6 +2583,7 @@ public partial class RotationConfigWindow : Window
             ImGui.Text($"Rank: {battleChara.GetObjectNPC()?.Rank.ToString() ?? string.Empty}");
             ImGui.Text($"Has Positional: {battleChara.HasPositional()}");
             ImGui.Text($"Is Dying: {battleChara.IsDying()}");
+            ImGui.Text($"Is Party: {battleChara.IsParty()}");
             ImGui.Text($"EventType: {battleChara.GetEventType()}");
             ImGui.Text($"NamePlate: {battleChara.GetNamePlateIcon()}");
             ImGui.Text($"StatusFlags: {battleChara.StatusFlags}");


### PR DESCRIPTION
Fixed a typo in `_raiseAll` description. Added `_friendlyPartyNPCHeal` option. Updated `DataCenter` to handle NPC party members and their deaths. Added new using directive in `DataCenter.cs`. Enhanced `ObjectHelper` conditions for friendly NPCs. Updated `RotationConfigWindow` to display new NPC and party member information.