### PR TITLE
Rename and update default for friendly NPC heal config for Autoduty users

### DIFF
--- a/RotationSolver.Basic/Configuration/Configs.cs
+++ b/RotationSolver.Basic/Configuration/Configs.cs
@@ -473,7 +473,7 @@ internal partial class Configs : IPluginConfiguration
 
     [ConditionBool, UI("Heal and raise Party NPCs.",
         Filter = HealingActionCondition, Section = 3)]
-    private static readonly bool _friendlyPartyNPCHeal = false;
+    private static readonly bool _friendlyPartyNPCHealRaise = true;
 
     [ConditionBool, UI("Heal/Dance partner your chocobo. (Experimental)",
         Filter = HealingActionCondition, Section = 3)]

--- a/RotationSolver.Basic/DataCenter.cs
+++ b/RotationSolver.Basic/DataCenter.cs
@@ -410,7 +410,7 @@ internal static class DataCenter
                 return deathAll.FirstOrDefault();
             }
 
-            if (deathNPC.Any() && Service.Config.FriendlyPartyNpcHeal)
+            if (deathNPC.Any() && Service.Config.FriendlyPartyNpcHealRaise)
             {
                 var deathNPCT = deathNPC.GetJobCategory(JobRole.Tank).ToList();
                 var deathNPCH = deathNPC.GetJobCategory(JobRole.Healer).ToList();

--- a/RotationSolver.Basic/Helpers/ObjectHelper.cs
+++ b/RotationSolver.Basic/Helpers/ObjectHelper.cs
@@ -167,7 +167,7 @@ public static class ObjectHelper
             // Accessing Player.Object and Svc.Party within the lock to ensure thread safety
             if (gameObject.GameObjectId == Player.Object?.GameObjectId) return true;
             if (Svc.Party.Any(p => p.GameObject?.GameObjectId == gameObject.GameObjectId)) return true;
-            if (Service.Config.FriendlyPartyNpcHeal && gameObject.GetBattleNPCSubKind() == BattleNpcSubKind.NpcPartyMember) return true;
+            if (Service.Config.FriendlyPartyNpcHealRaise && gameObject.GetBattleNPCSubKind() == BattleNpcSubKind.NpcPartyMember) return true;
 
             // Check if ChocoboPartyMember is enabled
             if (Service.Config.ChocoboPartyMember)


### PR DESCRIPTION
Renamed `_friendlyPartyNPCHeal` to `_friendlyPartyNPCHealRaise` in the `Configs` class and changed its default value from `false` to `true`. Updated condition checks in `DataCenter` and `ObjectHelper` classes to use the new variable name `FriendlyPartyNpcHealRaise`.