### PR TITLE
Adjusted `WillHaveXCharges`

### DIFF
--- a/RotationSolver.Basic/Actions/ActionCooldownInfo.cs
+++ b/RotationSolver.Basic/Actions/ActionCooldownInfo.cs
@@ -169,7 +169,7 @@ public readonly struct ActionCooldownInfo : ICooldown
         if (charges <= CurrentCharges)
             return true;
 
-        float requiredTime = (charges - CurrentCharges) * RecastTimeOneChargeRaw;
+        float requiredTime = (charges - CurrentCharges - 1) * RecastTimeOneChargeRaw;
         return RecastTimeRemainOneCharge <= remain - requiredTime;
     }
 

--- a/RotationSolver.Basic/Rotations/Basic/BardRotation.cs
+++ b/RotationSolver.Basic/Rotations/Basic/BardRotation.cs
@@ -63,6 +63,7 @@ partial class BardRotation
         ImGui.Text("SongTimeRaw: " + SongTimeRaw.ToString());
         ImGui.Text("SongTime: " + SongTime.ToString());
         ImGui.Text("BloodletterMax: " + BloodletterMax.ToString());
+        ImGui.Text("Bloodlettercharges: " + BloodletterPvE.Cooldown.CurrentCharges.ToString());
     }
     #endregion
 


### PR DESCRIPTION
- Leftover debug text for bard
- `WillHaveXCharges` Fix

From my testing `requiredTime` in `WillHaveXCharges` was always one recast time too much. For example if we have Bard with 1 charge of bloodletter and `charges` is 2 then `requiredTime` was 15 when it probably should have been 0.