### PR TITLE
Add new enum value and update targeting conditions

### DIFF
--- a/RotationSolver.Basic/Data/TargetHostileType.cs
+++ b/RotationSolver.Basic/Data/TargetHostileType.cs
@@ -34,10 +34,16 @@ public enum TargetHostileType : byte
     /// </summary>
     [Description("Only attack targets in your parties enemy list")]
     TargetIsInEnemiesList,
-
+    
     /// <summary>
     /// All targets when solo, or only attack targets in your parties enemy list.
     /// </summary>
     [Description("All targets when solo, or only attack targets in your parties enemy list")]
     AllTargetsWhenSoloTargetIsInEnemiesList,
+
+    /// <summary>
+    /// All targets when solo in duty, or only attack targets in your parties enemy list.
+    /// </summary>
+    [Description("All targets when solo in duty, or only attack targets in your parties enemy list")]
+    AllTargetsWhenSoloInDutyTargetIsInEnemiesList,
 }

--- a/RotationSolver.Basic/Helpers/ObjectHelper.cs
+++ b/RotationSolver.Basic/Helpers/ObjectHelper.cs
@@ -113,10 +113,11 @@ public static class ObjectHelper
             TargetHostileType.AllTargetsCanAttack => true,
             TargetHostileType.TargetsHaveTarget => battleChara.TargetObject is IBattleChara,
             TargetHostileType.AllTargetsWhenSolo => DataCenter.PartyMembers.Length < 2 || battleChara.TargetObject is IBattleChara,
-            TargetHostileType.AllTargetsWhenSoloInDuty => (DataCenter.PartyMembers.Length < 2 && Svc.Condition[ConditionFlag.BoundByDuty])
+            TargetHostileType.AllTargetsWhenSoloInDuty => (DataCenter.PartyMembers.Length < 2 && (Svc.Condition[ConditionFlag.BoundByDuty] || Svc.Condition[ConditionFlag.BoundByDuty56]))
                 || battleChara.TargetObject is IBattleChara,
             TargetHostileType.TargetIsInEnemiesList => battleChara.TargetObject is IBattleChara target && target.IsInEnemiesList(),
-            TargetHostileType.AllTargetsWhenSoloTargetIsInEnemiesList => DataCenter.PartyMembers.Length < 2 || battleChara.TargetObject is IBattleChara target && target.IsInEnemiesList(),
+            TargetHostileType.AllTargetsWhenSoloTargetIsInEnemiesList => (DataCenter.PartyMembers.Length < 2 && (Svc.Condition[ConditionFlag.BoundByDuty] || Svc.Condition[ConditionFlag.BoundByDuty56])) || battleChara.TargetObject is IBattleChara target && target.IsInEnemiesList(),
+            TargetHostileType.AllTargetsWhenSoloInDutyTargetIsInEnemiesList => DataCenter.PartyMembers.Length < 2 || battleChara.TargetObject is IBattleChara target && target.IsInEnemiesList(),
             _ => true,
         };
     }


### PR DESCRIPTION
Introduced `AllTargetsWhenSoloInDutyTargetIsInEnemiesList` to `TargetHostileType` enum. Updated conditions for `AllTargetsWhenSoloInDuty` and `AllTargetsWhenSoloTargetIsInEnemiesList` to include `Svc.Condition[ConditionFlag.BoundByDuty56]`. Added handling logic for the new enum value in `ObjectHelper.cs`.