### PR TITLE
Ignore Target for Self-Targeted Area Buffs

### DIFF
--- a/RotationSolver.Basic/Actions/ActionTargetInfo.cs
+++ b/RotationSolver.Basic/Actions/ActionTargetInfo.cs
@@ -488,7 +488,7 @@ public struct ActionTargetInfo(IBaseAction action)
                 break;
 
             case BeneficialAreaStrategy.OnTarget: // Target
-                if (Svc.Targets.Target != null && Svc.Targets.Target.DistanceToPlayer() < range)
+                if (Svc.Targets.Target != null && range != 0 && Svc.Targets.Target.DistanceToPlayer() < range)
                 {
                     var target = Svc.Targets.Target as IBattleChara;
                     return new TargetResult(target, GetAffects(target?.Position, canAffects).ToArray(), target?.Position);
@@ -496,7 +496,7 @@ public struct ActionTargetInfo(IBaseAction action)
                 break;
         }
 
-        if (Svc.Targets.Target is IBattleChara b && b.DistanceToPlayer() < range &&
+        if (Svc.Targets.Target is IBattleChara b && range != 0 && b.DistanceToPlayer() < range &&
             b.IsBossFromIcon() && b.HasPositional() && b.HitboxRadius <= 8)
         {
             return new TargetResult(b, GetAffects(b.Position, canAffects).ToArray(), b.Position);


### PR DESCRIPTION
## Description

This fixes a bug that I and a couple other people could reproduce while playing as Pictomancer, where the skill would get stuck loop casting-and-cancelling itself until you were either outside the boss' target ring or behind their model.

Starry Muse is a Self-Targeted Area Buff and as such the skill's range is 0 from what I understood. When RSR calculates if the player's target is valid for that skill, it disregards if it's a self-targeted action and thus calculates the distance between player and boss against the skill's range.
When you're inside the boss' ring, your distance from it becomes negative aka "below 0" and then since RSR is considering the hostile target instead of yourself, Starry Muse becomes invalid.

The real tricky part, which I fully admit I don't understand, is why RSR casts before canceling it and why some people cannot reproduce it. Regardless, I don't think there's a reason for a self-targeted area buff to consider the boss' distance relative to the player or the skill range.