### PR TITLE
Add targetQuestThings config and improve UI text labels

### DIFF
--- a/RotationSolver.Basic/Configuration/Configs.cs
+++ b/RotationSolver.Basic/Configuration/Configs.cs
@@ -267,8 +267,11 @@ internal partial class Configs : IPluginConfiguration
 
     [ConditionBool, UI("Target quest priority.",
         Filter = TargetConfig, Section = 1)]
-
     private static readonly bool _targetQuestPriority = true;
+
+    [ConditionBool, UI("Block targetting quest mobs belonging to other players (Broken).",
+        Filter = TargetConfig, Section = 1)]
+    private static readonly bool targetQuestThings = true;
 
     [ConditionBool, UI("Ignore target dummies",
                Filter = TargetConfig, Section = 1)]

--- a/RotationSolver.Basic/Helpers/ObjectHelper.cs
+++ b/RotationSolver.Basic/Helpers/ObjectHelper.cs
@@ -97,8 +97,8 @@ public static class ObjectHelper
             var tarFateId = battleChara.FateId();
             if (tarFateId != 0 && tarFateId != DataCenter.FateId) return false;
         }
-
-        if (battleChara.IsOthersPlayers()) return false;
+        
+        if (Service.Config.TargetQuestThings && battleChara.IsOthersPlayers()) return false;
 
         if (battleChara.IsTopPriorityHostile()) return true;
 

--- a/RotationSolver/UI/RotationConfigWindow.cs
+++ b/RotationSolver/UI/RotationConfigWindow.cs
@@ -2786,10 +2786,11 @@ public partial class RotationConfigWindow : Window
             ImGui.Text($"InView: {Svc.GameGui.WorldToScreen(battleChara.Position, out _)}");
             ImGui.Text($"Name Id: {battleChara.NameId}");
             ImGui.Text($"Data Id: {battleChara.DataId}");
-            ImGui.Text($"EnemyPositional: {battleChara.FindEnemyPositional()}");
+            ImGui.Text($"Enemy Positional: {battleChara.FindEnemyPositional()}");
             ImGui.Text($"NameplateKind: {battleChara.GetNameplateKind()}");
             ImGui.Text($"BattleNPCSubKind: {battleChara.GetBattleNPCSubKind()}");
-            ImGui.Text($"IsTopPriorityHostile: {battleChara.IsTopPriorityHostile()}");
+            ImGui.Text($"Is Top Priority Hostile: {battleChara.IsTopPriorityHostile()}");
+            ImGui.Text($"Is Others Players: {battleChara.IsOthersPlayers()}");
             ImGui.Text($"Targetable: {battleChara.Struct()->Character.GameObject.TargetableStatus}");
 
             var npc = battleChara.GetObjectNPC();


### PR DESCRIPTION
- Replaced `_targetQuestPriority` with `targetQuestThings` in `Configs.cs` to block targeting quest mobs of other players.
- Updated `ObjectHelper.cs` to use `targetQuestThings` for checking if a battle character belongs to other players.
- Improved UI text labels in `RotationConfigWindow.cs` for better readability and added a new line to display if a character belongs to other players.