### PR TITLE
Complete PB CanUse Condition

### DIFF
--- a/RotationSolver.Basic/Rotations/Basic/MonkRotation.cs
+++ b/RotationSolver.Basic/Rotations/Basic/MonkRotation.cs
@@ -170,6 +170,7 @@ partial class MonkRotation
 
     static partial void ModifyPerfectBalancePvE(ref ActionSetting setting)
     {
+        setting.ActionCheck = () => BeastChakras.Distinct().Count() == 1 && BeastChakras.Any(chakra => chakra == BeastChakra.NONE);
         setting.UnlockedByQuestID = 66602;
         setting.StatusProvide = [StatusID.PerfectBalance];
     }


### PR DESCRIPTION
PB is only allowed to be pressed if the gauge shows nothing but empty symbols. Without this condition, RSR would try to spam pressing PB when the last PB has been used by the finisher Blitz wasn't pressed yet - which jams other oGCDs.
