### PR TITLE
Submodule update and fix TopPriorityHostile causing redtext

### DIFF
--- a/RotationSolver.Basic/Configuration/Conditions/ActionCondition.cs
+++ b/RotationSolver.Basic/Configuration/Conditions/ActionCondition.cs
@@ -67,8 +67,6 @@ internal class ActionCondition : DelayCondition
                 break;
             case ActionConditionType.CanUse:
                 return _action.CanUse(out var act);
-                break;
-
         }
         return false;
     }

--- a/RotationSolver.Basic/Helpers/ObjectHelper.cs
+++ b/RotationSolver.Basic/Helpers/ObjectHelper.cs
@@ -318,7 +318,10 @@ public static class ObjectHelper
 
         var fateId = DataCenter.FateId;
 
-        if (obj is IBattleChara b && b.StatusList?.Any(StatusHelper.IsPriority) == true) return true;
+        if (obj is IBattleChara b)
+        {
+            if (b.StatusList != null && b.StatusList.Any(StatusHelper.IsPriority)) return true;
+        }
 
         if (Service.Config.ChooseAttackMark && MarkingHelper.AttackSignTargets.FirstOrDefault(id => id != 0) == (long)obj.GameObjectId) return true;
 

--- a/RotationSolver.Basic/RotationSolver.Basic.csproj
+++ b/RotationSolver.Basic/RotationSolver.Basic.csproj
@@ -68,7 +68,7 @@
 		  <PrivateAssets>all</PrivateAssets>
 	  </ProjectReference>
 	  
-	  <PackageReference Include="System.Drawing.Common" Version="8.0.8" />
+	  <PackageReference Include="System.Drawing.Common" Version="8.0.10" />
 	  <ProjectReference Include="..\RotationSolver.SourceGenerators\RotationSolver.SourceGenerators.csproj" OutputItemType="Analyzer" ExcludeAssets="All" />
 
 	  <None Include="..\COPYING.LESSER">

--- a/RotationSolver.SourceGenerators/RotationSolver.SourceGenerators.csproj
+++ b/RotationSolver.SourceGenerators/RotationSolver.SourceGenerators.csproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.10.0" />
+		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.11.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/RotationSolver/Updaters/ActionUpdater.cs
+++ b/RotationSolver/Updaters/ActionUpdater.cs
@@ -17,15 +17,16 @@ internal static class ActionUpdater
         EzIPC.Init(typeof(ActionUpdater), "RotationSolverReborn.ActionUpdater");
     }
 
-    [EzIPCEvent] public static Action<uint>? NextGCDActionChanged;
-    [EzIPCEvent] public static Action<uint>? NextActionChanged;
+    [EzIPCEvent] public static Action<uint> NextGCDActionChanged = delegate { };
+    [EzIPCEvent] public static Action<uint> NextActionChanged = delegate { };
 
     private static IAction? _nextAction;
-    internal static IAction? NextAction 
+    internal static IAction? NextAction
     {
         get => _nextAction;
-        set {
-            if (_nextAction != value) 
+        set
+        {
+            if (_nextAction != value)
             {
                 _nextAction = value;
                 NextActionChanged?.Invoke(_nextAction?.ID ?? 0);


### PR DESCRIPTION
Updated ECommons subproject commit to bf66e3d-dirty.
Fixed ObjectHelper class in ObjectHelper.cs for null checks on TopPriorityHostile causing redtext events.
Updated System.Drawing.Common to 8.0.10 in RotationSolver.Basic.csproj.
Updated Microsoft.CodeAnalysis.CSharp to 4.11.0 in RotationSolver.SourceGenerators.csproj.
Removed `break` statements in `ActionCondition.cs` and directly returned `false` if conditions are not met. Changed `NextGCDActionChanged` and `NextActionChanged` events in `ActionUpdater.cs` from nullable `Action<uint>?` to non-nullable `Action<uint>` with default empty delegates to avoid null reference issues.