### PR TITLE
Update ECommons submodule and improve null safety

### DIFF
--- a/RotationSolver.Basic/DataCenter.cs
+++ b/RotationSolver.Basic/DataCenter.cs
@@ -463,12 +463,12 @@ internal static class DataCenter
     {
         get
         {
-            var weakenPeople =
-                DataCenter.PartyMembers.Where(o => o is IBattleChara b && b.StatusList.Any(StatusHelper.CanDispel));
-            var weakenNPC =
-                DataCenter.FriendlyNPCMembers.Where(o => o is IBattleChara b && b.StatusList.Any(StatusHelper.CanDispel));
-            var dyingPeople =
-                weakenPeople.Where(o => o is IBattleChara b && b.StatusList.Any(StatusHelper.IsDangerous));
+            var weakenPeople = DataCenter.PartyMembers
+                .Where(o => o is IBattleChara b && b.StatusList != null && b.StatusList.Any(StatusHelper.CanDispel));
+            var weakenNPC = DataCenter.FriendlyNPCMembers
+                .Where(o => o is IBattleChara b && b.StatusList != null && b.StatusList.Any(StatusHelper.CanDispel));
+            var dyingPeople = weakenPeople
+                .Where(o => o is IBattleChara b && b.StatusList != null && b.StatusList.Any(StatusHelper.IsDangerous));
 
             return dyingPeople.OrderBy(ObjectHelper.DistanceToPlayer).FirstOrDefault()
                    ?? weakenPeople.OrderBy(ObjectHelper.DistanceToPlayer).FirstOrDefault()

--- a/RotationSolver/RotationSolverPlugin.cs
+++ b/RotationSolver/RotationSolverPlugin.cs
@@ -42,7 +42,10 @@ public sealed class RotationSolverPlugin : IDalamudPlugin, IDisposable
     public RotationSolverPlugin(IDalamudPluginInterface pluginInterface)
     {
         ECommonsMain.Init(pluginInterface, this, ECommons.Module.DalamudReflector, ECommons.Module.ObjectFunctions);
-        ThreadLoadImageHandler.TryGetIconTextureWrap(0, true, out _);
+        Svc.Framework.RunOnTick(() =>
+        {
+            ThreadLoadImageHandler.TryGetIconTextureWrap(0, true, out _);
+        });
         IconSet.Init();
 
         _dis.Add(new Service());


### PR DESCRIPTION
Updated ECommons submodule to commit 4011a66. Added null checks for StatusList in DataCenter's DispelTarget property to prevent NullReferenceException. Moved TryGetIconTextureWrap call in RotationSolverPlugin to Svc.Framework.RunOnTick lambda for thread safety.