### PR TITLE
Handle null values in DataCenter's DispelTarget property more carefully

### DIFF
--- a/RotationSolver.Basic/DataCenter.cs
+++ b/RotationSolver.Basic/DataCenter.cs
@@ -463,10 +463,10 @@ internal static class DataCenter
     {
         get
         {
-            var weakenPeople = DataCenter.PartyMembers
-                .Where(o => o is IBattleChara b && b.StatusList != null && b.StatusList.Any(StatusHelper.CanDispel));
-            var weakenNPC = DataCenter.FriendlyNPCMembers
-                .Where(o => o is IBattleChara b && b.StatusList != null && b.StatusList.Any(StatusHelper.CanDispel));
+            var weakenPeople = DataCenter.PartyMembers?
+                .Where(o => o is IBattleChara b && b.StatusList != null && b.StatusList.Any(StatusHelper.CanDispel)) ?? Enumerable.Empty<IBattleChara>();
+            var weakenNPC = DataCenter.FriendlyNPCMembers?
+                .Where(o => o is IBattleChara b && b.StatusList != null && b.StatusList.Any(StatusHelper.CanDispel)) ?? Enumerable.Empty<IBattleChara>();
             var dyingPeople = weakenPeople
                 .Where(o => o is IBattleChara b && b.StatusList != null && b.StatusList.Any(StatusHelper.IsDangerous));
 


### PR DESCRIPTION
Added null-coalescing operators to the DispelTarget property in the DataCenter class to handle potential null values for DataCenter.PartyMembers and DataCenter.FriendlyNPCMembers. This ensures the code uses an empty enumerable if either collection is null, yet another attempt to prevent null reference exceptions.