### PR TITLE
bypass ttk check

### DIFF
--- a/RotationSolver.Basic/Actions/BaseAction.cs
+++ b/RotationSolver.Basic/Actions/BaseAction.cs
@@ -122,7 +122,7 @@ public class BaseAction : IBaseAction
 
     /// <inheritdoc/>
     public bool CanUse(out IAction act, bool isLastAbility = false, bool isFirstAbility = false, bool skipStatusProvideCheck = false, bool skipComboCheck = false, bool skipCastingCheck = false,
-    bool usedUp = false, bool skipAoeCheck = false, byte gcdCountForAbility = 0)
+    bool usedUp = false, bool skipAoeCheck = false, bool skipTTKCheck = false, byte gcdCountForAbility = 0)
     {
         act = this;
 
@@ -149,7 +149,10 @@ public class BaseAction : IBaseAction
 
         if (Setting.SpecialType == SpecialActionType.MeleeRange && IActionHelper.IsLastAction(IActionHelper.MovingActions)) return false; // No range actions after moving.
 
-        if (!IsTimeToKillValid()) return false;
+        if (!skipTTKCheck)
+        {
+            if (!IsTimeToKillValid()) return false;
+        }
 
         PreviewTarget = TargetInfo.FindTarget(skipAoeCheck, skipStatusProvideCheck);
         if (PreviewTarget == null) return false;

--- a/RotationSolver.Basic/Actions/IBaseAction.cs
+++ b/RotationSolver.Basic/Actions/IBaseAction.cs
@@ -62,8 +62,9 @@ public interface IBaseAction : IAction
     /// <param name="skipCastingCheck">Skip Casting and Moving Check</param>
     /// <param name="usedUp">Is it used up all stacks</param>
     /// <param name="skipAoeCheck">Skip aoe Check</param>
+    /// <param name="skipTTKCheck">skip IsTimeToKillValid check in BaseAction</param>
     /// <param name="gcdCountForAbility">the gcd count for the ability.</param>
     /// <returns>can I use it</returns>
     bool CanUse(out IAction act, bool isLastAbility = false, bool isFirstAbility = false, bool skipStatusProvideCheck = false, bool skipComboCheck = false, bool skipCastingCheck = false,
-        bool usedUp = false, bool skipAoeCheck = false, byte gcdCountForAbility = 0);
+        bool usedUp = false, bool skipAoeCheck = false, bool skipTTKCheck = false, byte gcdCountForAbility = 0);
 }


### PR DESCRIPTION
A lot of GCDs couldn't be used at the end of the fights due to TTK check. This is a bypass, so no need to change every job's rotation file in RSR. Turn on true when used in RR if desired, otherwise it doesn't affect existing code because it's false by default.