### PR TITLE
Guren shall be used when 2 or more targets

### DIFF
--- a/RotationSolver.Basic/Rotations/Basic/SamuraiRotation.cs
+++ b/RotationSolver.Basic/Rotations/Basic/SamuraiRotation.cs
@@ -219,7 +219,7 @@ partial class SamuraiRotation
         setting.UnlockedByQuestID = 68106;
         setting.CreateConfig = () => new ActionConfig()
         {
-            AoeCount = 1,
+            AoeCount = 2,
         };
     }
 


### PR DESCRIPTION
*Read Balance before you write code, kids*
Balance: 'Guren is a gain starting on two targets' 
If you manually overrode this in Actions -> oGCD-Attack -> Guren -> How many targets from 1 to 2 already, you can ignore this update. If the settings above was 1 for you by default, and your SAM rotation was using Guren instead of Senei at Level 100 when hitting single target, do 'Reset plugin data and reload', then 1 shall become 2 automatically. And sennei shall be used correctly on single target. If this update affects your own code for using Guren at lower level, for example uww etc, use this instead: if (HissatsuGurenPvE.CanUse(out act, skipAoeCheck: !HissatsuSeneiPvE.EnoughLevel)) return true;