### PR TITLE
Add validation for invalid territory id in ClientState

### DIFF
--- a/RotationSolver/RotationSolverPlugin.cs
+++ b/RotationSolver/RotationSolverPlugin.cs
@@ -131,6 +131,13 @@ public sealed class RotationSolverPlugin : IDalamudPlugin, IDisposable
         {
             DataCenter.ResetAllRecords();
 
+            // Check if the id is valid before proceeding
+            if (id == 0)
+            {
+                Svc.Log.Warning("Invalid territory id: 0");
+                return;
+            }
+
             var territory = Service.GetSheet<TerritoryType>().GetRow(id);
 
             DataCenter.Territory = territory;


### PR DESCRIPTION
Added a check in the `ClientState_TerritoryChanged` method to ensure the `id` is valid before proceeding. If the `id` is `0`, a warning log is generated stating "Invalid territory id: 0" and the method returns early. This prevents potential errors and provides better debugging information.