### PR TITLE
Add WrathCombo plugin to incompatible list and update ECommons

### DIFF
--- a/Resources/IncompatiblePlugins.json
+++ b/Resources/IncompatiblePlugins.json
@@ -28,6 +28,13 @@
     "Type": 5
   },
   {
+    "Name": "WrathCombo (formerly XIVSlothCombo)",
+    "Icon": "https://s3.puni.sh/media/plugin/60/icon-2bwhkn3zf1f.png",
+    "Url": "https://github.com/PunishXIV/WrathCombo",
+    "Features": "Auto rotation and targetting conflicts",
+    "Type": 5
+  },
+  {
     "Name": "BossMod Reborn",
     "Icon": "https://raw.githubusercontent.com/FFXIV-CombatReborn/RebornAssets/main/IconAssets/BMR_Icon.png",
     "Url": "https://github.com/FFXIV-CombatReborn/BossmodReborn",

--- a/RotationSolver/UI/RotationConfigWindow.cs
+++ b/RotationSolver/UI/RotationConfigWindow.cs
@@ -146,7 +146,7 @@ public partial class RotationConfigWindow : Window
         var incompatiblePlugins = DownloadHelper.IncompatiblePlugins ?? Array.Empty<IncompatiblePlugin>();
 
         bool hasIncompatiblePlugin = incompatiblePlugins.Any(item =>
-            (item.Name == "XIV Combo" || item.Name == "XIV Combo Expanded" || item.Name == "XIVSlothCombo") && item.IsInstalled);
+            (item.Name == "XIV Combo" || item.Name == "XIV Combo Expanded" || item.Name == "XIVSlothCombo" || item.Name == "Wrath Combo") && item.IsInstalled);
 
         if (hasIncompatiblePlugin)
         {
@@ -168,6 +168,11 @@ public partial class RotationConfigWindow : Window
                     else if (plugin.Name == "XIVSlothCombo")
                     {
                         message = "Disable XIVSlothCombo plugin";
+                        break;
+                    }
+                    else if (plugin.Name == "Wrath Combo")
+                    {
+                        message = "Disable Wrath Combo plugin";
                         break;
                     }
                 }


### PR DESCRIPTION
Updated the subproject commit in ECommons to `974a0ef35536b7f0a10a278539f7136d6966baa3`.

Added a new entry for the "WrathCombo (formerly XIVSlothCombo)" plugin in `IncompatiblePlugins.json`, including its name, icon URL, GitHub URL, features, and type.

Modified the `DrawErrorZone` method in `RotationConfigWindow.cs` to check for the "Wrath Combo" plugin and mark it as incompatible if installed.

Added a new condition in `RotationConfigWindow.cs` to display a message instructing users to disable the "Wrath Combo" plugin if it is detected.