### PR TITLE
Rename and update NPC Heal/Raise config setting

### DIFF
--- a/RotationSolver.Basic/Configuration/Configs.cs
+++ b/RotationSolver.Basic/Configuration/Configs.cs
@@ -448,9 +448,9 @@ internal partial class Configs : IPluginConfiguration
         Filter = HealingActionCondition, Section = 3)]
     private static readonly bool _friendlyBattleNPCHeal = false;
 
-    [ConditionBool, UI("Heal and raise Party NPCs.",
+    [ConditionBool, UI("Heal and raise Party NPCs. (Breaks some fights due to status weirdness)", Description = "Experimental, only enable as needed.",
         Filter = HealingActionCondition, Section = 3)]
-    private static readonly bool _friendlyPartyNPCHealRaise = true;
+    private static readonly bool _friendlyPartyNPCHealRaise2 = false;
 
     [ConditionBool, UI("Heal/Dance partner your chocobo", Description = "Experimental.",
         Filter = HealingActionCondition, Section = 3)]

--- a/RotationSolver.Basic/DataCenter.cs
+++ b/RotationSolver.Basic/DataCenter.cs
@@ -327,7 +327,7 @@ internal static class DataCenter
         get
         {
             // Check if the configuration setting is true
-            if (!Service.Config.FriendlyBattleNpcHeal && !Service.Config.FriendlyPartyNpcHealRaise)
+            if (!Service.Config.FriendlyBattleNpcHeal && !Service.Config.FriendlyPartyNpcHealRaise2)
             {
                 return Array.Empty<IBattleChara>();
             }
@@ -449,7 +449,7 @@ internal static class DataCenter
                 }
 
                 // Check death in friendly NPC members
-                if (deathNPC.Any() && Service.Config.FriendlyPartyNpcHealRaise)
+                if (deathNPC.Any() && Service.Config.FriendlyPartyNpcHealRaise2)
                 {
                     var deathNPCT = deathNPC.GetJobCategory(JobRole.Tank).ToList();
                     var deathNPCH = deathNPC.GetJobCategory(JobRole.Healer).ToList();

--- a/RotationSolver.Basic/Helpers/ObjectHelper.cs
+++ b/RotationSolver.Basic/Helpers/ObjectHelper.cs
@@ -243,7 +243,7 @@ public static class ObjectHelper
             // Accessing Player.Object and Svc.Party within the lock to ensure thread safety
             if (gameObject.GameObjectId == Player.Object?.GameObjectId) return true;
             if (Svc.Party.Any(p => p.GameObject?.GameObjectId == gameObject.GameObjectId)) return true;
-            if (Service.Config.FriendlyPartyNpcHealRaise && gameObject.GetBattleNPCSubKind() == BattleNpcSubKind.NpcPartyMember) return true;
+            if (Service.Config.FriendlyPartyNpcHealRaise2 && gameObject.GetBattleNPCSubKind() == BattleNpcSubKind.NpcPartyMember) return true;
             if (Service.Config.ChocoboPartyMember && gameObject.GetNameplateKind() == NameplateKind.PlayerCharacterChocobo) return true;
             if (Service.Config.FriendlyBattleNpcHeal && gameObject.GetNameplateKind() == NameplateKind.FriendlyBattleNPC) return true;
 

--- a/RotationSolver/UI/RotationConfigWindow.cs
+++ b/RotationSolver/UI/RotationConfigWindow.cs
@@ -963,10 +963,10 @@ public partial class RotationConfigWindow : Window
         }
 
         // Display the current NPC Heal/Raise Support status
-        ImGui.TextWrapped($"NPC Heal/Raise Support Enabled: {Service.Config.FriendlyPartyNpcHealRaise}");
+        ImGui.TextWrapped($"NPC Heal/Raise Support Enabled: {Service.Config.FriendlyPartyNpcHealRaise2}");
         if (ImGui.Button("Enable NPC Heal/Raise Support"))
         {
-            Service.Config.FriendlyPartyNpcHealRaise.Value = true;
+            Service.Config.FriendlyPartyNpcHealRaise2.Value = true;
         }
         ImGui.Spacing();
         // Display the Auto Load Rotations status


### PR DESCRIPTION
Renamed `_friendlyPartyNPCHealRaise` to `_friendlyPartyNPCHealRaise2` and changed its default value from `true` to `false`. Updated the description to indicate that it is experimental and may cause issues in some fights. Updated all references in `DataCenter.cs`, `ObjectHelper.cs`, and `RotationConfigWindow.cs` to use the new setting name. Modified the UI text and button functionality in `RotationConfigWindow.cs` to reflect the new setting.