### PR TITLE
Fix NullReferenceException in IsActionEnabled method

### DIFF
--- a/RotationSolver.Basic/Actions/ActionBasicInfo.cs
+++ b/RotationSolver.Basic/Actions/ActionBasicInfo.cs
@@ -163,7 +163,7 @@ public readonly struct ActionBasicInfo
         return true;
     }
 
-    private bool IsActionEnabled() => _action.Config.IsEnabled;
+    private bool IsActionEnabled() => _action.Config?.IsEnabled ?? false;
 
     private bool IsActionDisabled() => !IBaseAction.ForceEnable && (DataCenter.DisabledActionSequencer?.Contains(ID) ?? false); 
 


### PR DESCRIPTION
Modified IsActionEnabled to handle null _action.Config safely. Now returns false if _action.Config is null, preventing runtime errors.