### PR TITLE
TTK, Ability checks, Raise logic adjustments

### DIFF
--- a/BasicRotations/Melee/MNK_Default.cs
+++ b/BasicRotations/Melee/MNK_Default.cs
@@ -138,7 +138,8 @@ public sealed class MNK_Default : MonkRotation
             if (HowlingFistPvE.CanUse(out act, skipAoeCheck: true)) return true; // Howling Fist
         }
         else
-            if (TheForbiddenChakraPvE.CanUse(out act)) return true;
+        if (SteelPeakPvE.CanUse(out act)) return true;
+        if (TheForbiddenChakraPvE.CanUse(out act)) return true;
 
         // use bh when bh and rof are ready (opener) or ask bh to wait for rof's cd to be close and then use bh
         if (!CombatElapsedLessGCD(2)

--- a/RotationSolver.Basic/Actions/BaseAction.cs
+++ b/RotationSolver.Basic/Actions/BaseAction.cs
@@ -167,12 +167,30 @@ public class BaseAction : IBaseAction
 
     private bool IsLastAbilityUsable()
     {
+        if (Service.Config.UseV2AbilityChecks)
+        {
+            return IsLastAbilityv2Usable();
+        }
         return DataCenter.InCombat && (DataCenter.NextAbilityToNextGCD <= Math.Max(ActionManagerHelper.GetCurrentAnimationLock(), DataCenter.MinAnimationLock) + Service.Config.isLastAbilityTimer);
     }
 
     private bool IsFirstAbilityUsable()
     {
+        if (Service.Config.UseV2AbilityChecks)
+        {
+            return IsFirstAbilityv2Usable();
+        }
         return DataCenter.InCombat && (DataCenter.NextAbilityToNextGCD >= Math.Max(ActionManagerHelper.GetCurrentAnimationLock(), DataCenter.MinAnimationLock) + Service.Config.isFirstAbilityTimer);
+    }
+
+    private bool IsLastAbilityv2Usable()
+    {
+        return DataCenter.InCombat && (DataCenter.DefaultGCDElapsed >= DataCenter.DefaultGCDRemain);
+    }
+
+    private bool IsFirstAbilityv2Usable()
+    {
+        return DataCenter.InCombat && (DataCenter.DefaultGCDRemain >= DataCenter.DefaultGCDElapsed);
     }
 
     private bool IsTimeToKillValid()

--- a/RotationSolver.Basic/Configuration/Configs.cs
+++ b/RotationSolver.Basic/Configuration/Configs.cs
@@ -334,6 +334,10 @@ internal partial class Configs : IPluginConfiguration
         Filter = Extra)]
     private static readonly bool _autoOpenChest = true;
 
+    [ConditionBool, UI("Use experimental FirstAbility and LastAbility checks",
+        Filter = Extra)]
+    private static readonly bool _useV2AbilityChecks = false;
+
     [ConditionBool, UI("Auto close the loot window when auto opened the chest.",
         Parent = nameof(AutoOpenChest))]
     private static readonly bool _autoCloseChestWindow = true;

--- a/RotationSolver.Basic/Configuration/Configs.cs
+++ b/RotationSolver.Basic/Configuration/Configs.cs
@@ -338,6 +338,10 @@ internal partial class Configs : IPluginConfiguration
         Filter = Extra)]
     private static readonly bool _useV2AbilityChecks = false;
 
+    [ConditionBool, UI("Enable RSR click counter in main menu",
+        Filter = Extra)]
+    private static readonly bool _enableClickingCount = true;
+
     [ConditionBool, UI("Auto close the loot window when auto opened the chest.",
         Parent = nameof(AutoOpenChest))]
     private static readonly bool _autoCloseChestWindow = true;

--- a/RotationSolver.Basic/Data/ObjectListDelay.cs
+++ b/RotationSolver.Basic/Data/ObjectListDelay.cs
@@ -10,8 +10,8 @@ public class ObjectListDelay<T> : IEnumerable<T> where T : IGameObject
 {
     private IEnumerable<T> _list = new List<T>();
     private readonly Func<(float min, float max)> _getRange;
-    private SortedList<ulong, DateTime> _revealTime = new();
-    private readonly Random _ran = new(DateTime.Now.Millisecond);
+    private Dictionary<ulong, DateTime> _revealTime = new();
+    private readonly Random _ran = new();
 
     /// <summary>
     /// Initializes a new instance of the <see cref="ObjectListDelay{T}"/> class.
@@ -41,8 +41,8 @@ public class ObjectListDelay<T> : IEnumerable<T> where T : IGameObject
     /// <param name="originData">The original list of objects.</param>
     public void Delay(IEnumerable<T> originData)
     {
-        var outList = new List<T>(originData.Count());
-        var revealTime = new SortedList<ulong, DateTime>();
+        var outList = new List<T>();
+        var revealTime = new Dictionary<ulong, DateTime>();
         var now = DateTime.Now;
 
         foreach (var item in originData)
@@ -51,7 +51,7 @@ public class ObjectListDelay<T> : IEnumerable<T> where T : IGameObject
             {
                 var (min, max) = _getRange();
                 var delaySecond = min + (float)_ran.NextDouble() * (max - min);
-                time = now + new TimeSpan(0, 0, 0, 0, (int)(delaySecond * 1000));
+                time = now + TimeSpan.FromMilliseconds(delaySecond * 1000);
             }
             revealTime[item.GameObjectId] = time;
 

--- a/RotationSolver.Basic/DataCenter.cs
+++ b/RotationSolver.Basic/DataCenter.cs
@@ -251,6 +251,9 @@ internal static class DataCenter
     public static float GCDTime(uint gcdCount = 0, float offset = 0)
         => ActionManagerHelper.GetDefaultRecastTime() * gcdCount + offset;
 
+    public static bool LastAbilityv2 => DataCenter.InCombat && (DataCenter.DefaultGCDElapsed >= DataCenter.DefaultGCDRemain);
+    public static bool FirstAbilityv2 => DataCenter.InCombat && (DataCenter.DefaultGCDRemain >= DataCenter.DefaultGCDElapsed);
+
     public static bool LastAbilityorNot => DataCenter.InCombat && (DataCenter.NextAbilityToNextGCD <= Math.Max(ActionManagerHelper.GetCurrentAnimationLock(), DataCenter.MinAnimationLock) + Service.Config.isLastAbilityTimer);
     public static bool FirstAbilityorNot => DataCenter.InCombat && (DataCenter.NextAbilityToNextGCD >= Math.Max(ActionManagerHelper.GetCurrentAnimationLock(), DataCenter.MinAnimationLock) + Service.Config.isFirstAbilityTimer);
     #endregion

--- a/RotationSolver.Basic/DataCenter.cs
+++ b/RotationSolver.Basic/DataCenter.cs
@@ -11,8 +11,6 @@ using Lumina.Excel.Sheets;
 using RotationSolver.Basic.Configuration;
 using RotationSolver.Basic.Configuration.Conditions;
 using RotationSolver.Basic.Rotations.Duties;
-using Svg.FilterEffects;
-using System.Linq;
 using Action = Lumina.Excel.Sheets.Action;
 using CharacterManager = FFXIVClientStructs.FFXIV.Client.Game.Character.CharacterManager;
 
@@ -251,8 +249,8 @@ internal static class DataCenter
     public static float GCDTime(uint gcdCount = 0, float offset = 0)
         => ActionManagerHelper.GetDefaultRecastTime() * gcdCount + offset;
 
-    public static bool LastAbilityv2 => DataCenter.InCombat && (DataCenter.DefaultGCDElapsed >= DataCenter.DefaultGCDRemain);
-    public static bool FirstAbilityv2 => DataCenter.InCombat && (DataCenter.DefaultGCDRemain >= DataCenter.DefaultGCDElapsed);
+    public static bool LastAbilityv2 => DataCenter.InCombat && !ActionHelper.CanUseGCD && (ActionManagerHelper.GetCurrentAnimationLock() == 0) && !Player.Object.IsCasting && (DataCenter.DefaultGCDElapsed >= DataCenter.DefaultGCDRemain);
+    public static bool FirstAbilityv2 => DataCenter.InCombat && !ActionHelper.CanUseGCD && (ActionManagerHelper.GetCurrentAnimationLock() == 0) && !Player.Object.IsCasting && (DataCenter.DefaultGCDRemain >= DataCenter.DefaultGCDElapsed);
 
     public static bool LastAbilityorNot => DataCenter.InCombat && (DataCenter.NextAbilityToNextGCD <= Math.Max(ActionManagerHelper.GetCurrentAnimationLock(), DataCenter.MinAnimationLock) + Service.Config.isLastAbilityTimer);
     public static bool FirstAbilityorNot => DataCenter.InCombat && (DataCenter.NextAbilityToNextGCD >= Math.Max(ActionManagerHelper.GetCurrentAnimationLock(), DataCenter.MinAnimationLock) + Service.Config.isFirstAbilityTimer);
@@ -692,7 +690,7 @@ internal static class DataCenter
     #region Action Record
     public const float MinAnimationLock = 0.6f;
 
-    const int QUEUECAPACITY = 16;
+    const int QUEUECAPACITY = 32;
     private static readonly Queue<ActionRec> _actions = new(QUEUECAPACITY);
     private static readonly Queue<DamageRec> _damages = new(QUEUECAPACITY);
 

--- a/RotationSolver.Basic/Rotations/CustomRotation_GCD.cs
+++ b/RotationSolver.Basic/Rotations/CustomRotation_GCD.cs
@@ -25,14 +25,6 @@ partial class CustomRotation
 
             if (EmergencyGCD(out act)) return act;
 
-            IBaseAction.TargetOverride = TargetType.Death;
-
-            if (RaiseSpell(out act, false)) return act;
-
-            if (Service.Config.RaisePlayerByCasting && SwiftcastPvE.Cooldown.IsCoolingDown && RaiseSpell(out act, true)) return act;
-
-            IBaseAction.TargetOverride = null;
-
             if (DataCenter.MergedStatus.HasFlag(AutoStatus.MoveForward)
                 && MoveForwardGCD(out act))
             {
@@ -77,6 +69,14 @@ partial class CustomRotation
             IBaseAction.TargetOverride = TargetType.Dispel;
             if (DataCenter.MergedStatus.HasFlag(AutoStatus.Dispel)
                 && DispelGCD(out act)) return act;
+
+            IBaseAction.TargetOverride = TargetType.Death;
+
+            if (RaiseSpell(out act, false)) return act;
+
+            if (Service.Config.RaisePlayerByCasting && SwiftcastPvE.Cooldown.IsCoolingDown && RaiseSpell(out act, true)) return act;
+
+            IBaseAction.TargetOverride = null;
 
             IBaseAction.ShouldEndSpecial = false;
             IBaseAction.TargetOverride = null;

--- a/RotationSolver/Commands/RSCommands_Actions.cs
+++ b/RotationSolver/Commands/RSCommands_Actions.cs
@@ -70,7 +70,11 @@ namespace RotationSolver.Commands
 
             if (nextAction.Use())
             {
-                OtherConfiguration.RotationSolverRecord.ClickingCount++;
+                // Check if the setting to enable clicking count increment is enabled
+                if (Service.Config.EnableClickingCount)
+                {
+                    OtherConfiguration.RotationSolverRecord.ClickingCount++;
+                }
 
                 _lastActionID = nextAction.AdjustedID;
                 _lastUsedTime = DateTime.Now;

--- a/RotationSolver/UI/RotationConfigWindow.cs
+++ b/RotationSolver/UI/RotationConfigWindow.cs
@@ -2826,6 +2826,8 @@ public partial class RotationConfigWindow : Window
         ImGui.Text(ActionUpdater.NextAction?.Name ?? "null");
         ImGui.Text($"LastAbilityorNot: {DataCenter.LastAbilityorNot}");
         ImGui.Text($"FirstAbilityorNot: {DataCenter.FirstAbilityorNot}");
+        ImGui.Text($"LastAbilityv2: {DataCenter.LastAbilityv2}");
+        ImGui.Text($"FirstAbilityv2: {DataCenter.FirstAbilityv2}");
         ImGui.Text($"GCD Total: {DataCenter.DefaultGCDTotal}");
         ImGui.Text($"GCD Remain: {DataCenter.DefaultGCDRemain}");
         ImGui.Text($"GCD Elapsed: {DataCenter.DefaultGCDElapsed}");

--- a/RotationSolver/Watcher.cs
+++ b/RotationSolver/Watcher.cs
@@ -8,7 +8,6 @@ using FFXIVClientStructs.FFXIV.Client.Game;
 using Lumina.Excel.Sheets;
 using RotationSolver.Basic.Configuration;
 using System.Text.RegularExpressions;
-using Action = Lumina.Excel.Sheets.Action;
 
 namespace RotationSolver;
 


### PR DESCRIPTION
Add V2 ability checks and refactor code for clarity
Updated subproject commit to e746021d184cf53e7cbab228e326ffdd5f5c4d3e.

BaseAction.cs:
- Added logic to use new V2 ability checks based on config option.
- Introduced IsLastAbilityv2Usable and IsFirstAbilityv2Usable methods.

Configs.cs:
- Added _useV2AbilityChecks configuration option.

DataCenter.cs:
- Added LastAbilityv2 and FirstAbilityv2 properties for new simplified oGCD timer checks.

ObjectHelper.cs:
- Renamed variables for clarity.
- Changed recordedHPCopy from List to Array for performance.
- Refactored health ratio and elapsed time calculations to attempt to fix early TTK calculations.

RotationConfigWindow.cs:
- Added debug info for LastAbilityv2 and FirstAbilityv2.

Enhance action handling and add new configuration options
- Added `SteelPeakPvE` action in `MNK_Default.cs` for lower level support.
- Introduced `_enableClickingCount` option in `Configs.cs` for RSR click counter, allowing users to disable it if they want.
- Replaced `SortedList` with `Dictionary` in `ObjectListDelay.cs` and simplified `Random` initialization.
- Updated `LastAbilityv2` and `FirstAbilityv2` conditions in `DataCenter.cs` to include additional checks.
- Increased `QUEUECAPACITY` for actions and damages in `DataCenter` from 16 to 32.
- Moved `RaiseSpell` logic in `CustomRotation_GCD.cs` to ensure RSR prioritizes keeping people alive over rezing.
- Made `ClickingCount` increment conditional in `RSCommands_Actions.cs` based on `_enableClickingCount`.
- Added "GCD Cooldown Visualization" section in `RotationConfigWindow.cs` with progress bar and markers.
- Removed unused `Action` import in `Watcher.cs`.