### PR TITLE
Additional changed and new config

### DIFF
--- a/BasicRotations/Limited Jobs/BLU_Default.cs
+++ b/BasicRotations/Limited Jobs/BLU_Default.cs
@@ -1,6 +1,6 @@
 namespace DefaultRotations.Magical;
 
-[Rotation("DOES NOT WORK", CombatType.PvE, GameVersion = "7.05")]
+[Rotation("DOES NOT WORK", CombatType.PvE, GameVersion = "7.11")]
 [SourceCode(Path = "main/BasicRotations/Limited Jobs/BLU_Default.cs")]
 [Api(4)]
 public sealed class Blue_Default : BlueMageRotation
@@ -24,15 +24,7 @@ public sealed class Blue_Default : BlueMageRotation
     }
     #endregion
 
-    #region oGCD Logic
-    protected override bool AttackAbility(IAction nextGCD, out IAction? act)
-    {
-        act = null;
-
-
-        return base.AttackAbility(nextGCD, out act);
-    }
-
+    #region Move oGCD Logic
     protected override bool MoveForwardAbility(IAction nextGCD, out IAction? act)
     {
         act = null;
@@ -40,9 +32,111 @@ public sealed class Blue_Default : BlueMageRotation
 
         return base.MoveForwardAbility(nextGCD, out act);
     }
+
+    protected override bool MoveBackAbility(IAction nextGCD, out IAction? act)
+    {
+        act = null;
+
+
+        return base.MoveBackAbility(nextGCD, out act);
+    }
+
+    protected override bool SpeedAbility(IAction nextGCD, out IAction? act)
+    {
+        act = null;
+
+
+        return base.SpeedAbility(nextGCD, out act);
+    }
+    #endregion
+
+    #region Heal/Defense oGCD Logic
+    protected override bool HealSingleAbility(IAction nextGCD, out IAction? act)
+    {
+        act = null;
+
+
+        return base.HealSingleAbility(nextGCD, out act);
+    }
+
+    protected override bool DefenseAreaAbility(IAction nextGCD, out IAction? act)
+    {
+        act = null;
+
+
+        return base.DefenseAreaAbility(nextGCD, out act);
+    }
+
+    protected override bool DefenseSingleAbility(IAction nextGCD, out IAction? act)
+    {
+        act = null;
+
+
+        return base.DefenseSingleAbility(nextGCD, out act);
+    }
+    #endregion
+
+    #region oGCD Logic
+    protected override bool AttackAbility(IAction nextGCD, out IAction? act)
+    {
+        act = null;
+        if (JKickPvE.CanUse(out act))
+        {
+            if (Player.HasStatus(true, StatusID.Harmonized)) return true;
+        }
+
+        return base.AttackAbility(nextGCD, out act);
+    }
+
+    protected override bool GeneralAbility(IAction nextGCD, out IAction? act)
+    {
+        act = null;
+
+        if (AethericMimicryPvE_19239.CanUse(out act)) return true;
+        return base.GeneralAbility(nextGCD, out act);
+    }
     #endregion
 
     #region GCD Logic
+
+    protected override bool EmergencyGCD(out IAction? act)
+    {
+        act = null;
+
+        return base.EmergencyGCD(out act);
+    }
+
+    protected override bool MyInterruptGCD(out IAction? act)
+    {
+        if (FlyingSardinePvE.CanUse(out act)) return true;
+        return base.MyInterruptGCD(out act);
+    }
+
+    protected override bool DefenseAreaGCD(out IAction? act)
+    {
+        if (ColdFogPvE.CanUse(out act)) return true;
+        return base.DefenseAreaGCD(out act);
+    }
+
+    protected override bool DefenseSingleGCD(out IAction? act)
+    {
+        act = null;
+
+        return base.DefenseSingleGCD(out act);
+    }
+
+    protected override bool HealAreaGCD(out IAction? act)
+    {
+        if (WhiteWindPvE.CanUse(out act)) return true;
+        return base.HealAreaGCD(out act);
+    }
+
+    protected override bool HealSingleGCD(out IAction? act)
+    {
+        if (WhiteWindPvE.CanUse(out act)) return true;
+        return base.HealSingleGCD(out act);
+    }
+
     protected override bool MoveForwardGCD(out IAction? act)
     {
         act = null;
@@ -50,21 +144,33 @@ public sealed class Blue_Default : BlueMageRotation
         return base.MoveForwardGCD(out act);
     }
 
-    protected override bool GeneralGCD(out IAction? act)
+    protected override bool DispelGCD(out IAction? act)
     {
         act = null;
+
+        return base.DispelGCD(out act);
+    }
+
+    protected override bool RaiseGCD(out IAction? act)
+    {
+        if (AngelWhisperPvE.CanUse(out act)) return true;
+        return base.RaiseGCD(out act);
+    }
+
+    protected override bool GeneralGCD(out IAction? act)
+    {
+        if (WhiteDeathPvE.CanUse(out act)) return true;
+
+        if (BreathOfMagicPvE.CanUse(out act)) return true;
+        if (SongOfTormentPvE.CanUse(out act)) return true;
+
+        if (MatraMagicPvE.CanUse(out act)) return true;
+        if (TheRoseOfDestructionPvE.CanUse(out act)) return true;
+
+        if (TripleTridentPvE.CanUse(out act) && IsLastGCD(ActionID.TinglePvE)) return true;
         if (TinglePvE.CanUse(out act)) return true;
-        if (WaterCannonPvE.CanUse(out act)) return true;
+        if (SonicBoomPvE.CanUse(out act)) return true;
         return base.GeneralGCD(out act);
     }
-    #endregion
-
-    #region Extra Methods
-    // Extra private helper methods for determining the usability of specific abilities under certain conditions.
-    // These methods simplify the main logic by encapsulating specific checks related to abilities' cooldowns and prerequisites.
-    //private bool CanUseExamplePvE(out IAction? act)
-    //{
-
-    //}
     #endregion
 }

--- a/RotationSolver.Basic/Configuration/Configs.cs
+++ b/RotationSolver.Basic/Configuration/Configs.cs
@@ -421,6 +421,11 @@ internal partial class Configs : IPluginConfiguration
         PvEFilter = JobFilterType.Raise, PvPFilter = JobFilterType.NoJob)]
     private static readonly bool _raisePlayerBySwift = true;
 
+    [JobConfig, UI("Prioritize raising dead players over Healing/Defense.",
+        Filter = HealingActionCondition, Section = 2,
+        PvEFilter = JobFilterType.Raise, PvPFilter = JobFilterType.NoJob)]
+    private static readonly bool _raisePlayerFirst = false;
+
     [JobConfig, UI("Raise styles",
         Filter = HealingActionCondition, Section = 2,
         PvEFilter = JobFilterType.Raise, PvPFilter = JobFilterType.NoJob)]

--- a/RotationSolver.Basic/Rotations/Basic/BlueMageRotation.cs
+++ b/RotationSolver.Basic/Rotations/Basic/BlueMageRotation.cs
@@ -7,6 +7,8 @@ partial class BlueMageRotation
     /// </summary>
     public override MedicineType MedicineType => MedicineType.Intelligence;
 
+    private protected sealed override IBaseAction Raise => AngelWhisperPvE;
+
     /// <summary>
     /// Tye ID card for Blu.
     /// </summary>
@@ -31,11 +33,33 @@ partial class BlueMageRotation
     /// <summary>
     /// 
     /// </summary>
-    protected BLUID BlueId { get; set; } = BLUID.DPS;
+    protected static BLUID BlueId { get; set; } = BLUID.DPS;
 
-    private protected sealed override IBaseAction Raise => AngelWhisperPvE;
+    static partial void ModifySongOfTormentPvE(ref ActionSetting setting)
+    {
+        setting.TargetStatusProvide = [StatusID.Bleeding_1714];
+    }
+
+    static partial void ModifyBristlePvE(ref ActionSetting setting)
+    {
+        setting.StatusProvide = [StatusID.Boost_1716];
+    }
+
+    static partial void ModifyMoonFlutePvE(ref ActionSetting setting)
+    {
+        setting.StatusProvide = [StatusID.WaxingNocturne];
+    }
 
     static partial void ModifyFeatherRainPvE(ref ActionSetting setting)
+    {
+        setting.TargetStatusProvide = [StatusID.Windburn_1723];
+        setting.CreateConfig = () => new ActionConfig()
+        {
+            AoeCount = 1,
+        };
+    }
+
+    static partial void ModifyShockStrikePvE(ref ActionSetting setting)
     {
         setting.CreateConfig = () => new ActionConfig()
         {
@@ -43,12 +67,171 @@ partial class BlueMageRotation
         };
     }
 
-    static partial void ModifyEruptionPvE(ref ActionSetting setting)
+    static partial void ModifySonicBoomPvE(ref ActionSetting setting)
+    {
+        
+    }
+
+    static partial void ModifyWhistlePvE(ref ActionSetting setting)
+    {
+        setting.StatusProvide = [StatusID.Harmonized];
+    }
+
+
+    static partial void ModifyAngelWhisperPvE(ref ActionSetting setting)
+    {
+
+    }
+
+    static partial void ModifyAethericMimicryPvE(ref ActionSetting setting)
+    {
+        setting.CanTarget = (IBattleChara chara) =>
+        {
+            switch (BlueId)
+            {
+                case BLUID.DPS:
+                    if (!Player.HasStatus(true, StatusID.AethericMimicryDps))
+                    {
+                        return TargetFilter.GetJobCategory(new[] { chara }, JobRole.Melee, JobRole.RangedMagical, JobRole.RangedPhysical).FirstOrDefault() != null;
+                    }
+                    break;
+
+                case BLUID.Tank:
+                    if (!Player.HasStatus(true, StatusID.AethericMimicryTank))
+                    {
+                        return TargetFilter.GetJobCategory(new[] { chara }, JobRole.Tank).FirstOrDefault() != null;
+                    }
+                    break;
+
+                case BLUID.Healer:
+                    if (!Player.HasStatus(true, StatusID.AethericMimicryHealer))
+                    {
+                        return TargetFilter.GetJobCategory(new[] { chara }, JobRole.Healer).FirstOrDefault() != null;
+                    }
+                    break;
+            }
+            return false;
+        };
+    }
+
+    static partial void ModifySurpanakhaPvE(ref ActionSetting setting)
+    {
+        setting.StatusProvide = [StatusID.SurpanakhasFury];
+        setting.IsFriendly = false;
+        setting.CreateConfig = () => new ActionConfig()
+        {
+            AoeCount = 1,
+        };
+    }
+
+    static partial void ModifyJKickPvE(ref ActionSetting setting)
     {
         setting.CreateConfig = () => new ActionConfig()
         {
             AoeCount = 1,
         };
+    }
+
+    static partial void ModifyTripleTridentPvE(ref ActionSetting setting)
+    {
+
+    }
+
+    static partial void ModifyTinglePvE(ref ActionSetting setting)
+    {
+        setting.StatusProvide = [StatusID.Tingling];
+        setting.CreateConfig = () => new ActionConfig()
+        {
+            AoeCount = 1,
+        };
+    }
+
+    static partial void ModifyColdFogPvE(ref ActionSetting setting)
+    {
+        setting.StatusProvide = [StatusID.ColdFog];
+        setting.TargetType = TargetType.Self;
+        setting.IsFriendly = true;
+    }
+
+    static partial void ModifyWhiteDeathPvE(ref ActionSetting setting)
+    {
+        setting.StatusNeed = [StatusID.TouchOfFrost];
+        setting.TargetStatusProvide = [StatusID.DeepFreeze_1731];
+    }
+
+    static partial void ModifyTheRoseOfDestructionPvE(ref ActionSetting setting)
+    {
+
+    }
+
+    static partial void ModifyMatraMagicPvE(ref ActionSetting setting)
+    {
+
+    }
+
+    static partial void ModifyPhantomFlurryPvE(ref ActionSetting setting)
+    {
+        setting.IsFriendly = false;
+        setting.ActionCheck = () => !IsMoving;
+        setting.StatusProvide = [StatusID.PhantomFlurry];
+        setting.CreateConfig = () => new ActionConfig()
+        {
+            AoeCount = 1,
+        };
+    }
+
+    static partial void ModifyNightbloomPvE(ref ActionSetting setting)
+    {
+        setting.IsFriendly = false;
+        setting.TargetStatusProvide = [StatusID.Bleeding_1714];
+        setting.CreateConfig = () => new ActionConfig()
+        {
+            AoeCount = 1,
+        };
+    }
+
+    static partial void ModifyWingedReprobationPvE(ref ActionSetting setting)
+    {
+        setting.StatusProvide = [StatusID.WingedReprobation, StatusID.WingedRedemption];
+        setting.CreateConfig = () => new ActionConfig()
+        {
+            AoeCount = 1,
+        };
+    }
+
+    static partial void ModifySeaShantyPvE(ref ActionSetting setting)
+    {
+        
+    }
+
+    static partial void ModifyBeingMortalPvE(ref ActionSetting setting)
+    {
+        setting.IsFriendly = false;
+        setting.CreateConfig = () => new ActionConfig()
+        {
+            AoeCount = 1,
+        };
+    }
+
+
+    //Optional
+    static partial void ModifyFlyingSardinePvE(ref ActionSetting setting)
+    {
+        setting.TargetType = TargetType.Interrupt;
+    }
+
+    static partial void ModifyWhiteWindPvE(ref ActionSetting setting)
+    {
+        setting.IsFriendly = true;
+    }
+
+    /// <summary>
+    ///
+    /// </summary>
+    public override void DisplayStatus()
+    {
+        ImGui.TextWrapped(BlueId.ToString());
+        base.DisplayStatus();
     }
 }
 
@@ -79,23 +262,10 @@ partial class BlueMageRotation
 //    /// <summary>
 //    /// 
 //    /// </summary>
-//    public static IBLUAction SongOfTorment { get; } = new BLUAction(ActionID.SongOfTorment, ActionOption.Dot)
-//    {
-//        TargetStatus = new[] { StatusID.Bleeding }
-//    };
-
-//    /// <summary>
-//    /// 
-//    /// </summary>
 //    public static IBLUAction BloodDrain { get; } = new BLUAction(ActionID.BloodDrain)
 //    {
 //        ActionCheck = (b, m) => Player.CurrentMp <= 9500,
 //    };
-
-//    /// <summary>
-//    /// 
-//    /// </summary>
-//    public static IBLUAction SonicBoom { get; } = new BLUAction(ActionID.SonicBoom);
 
 //    /// <summary>
 //    /// 
@@ -111,16 +281,6 @@ partial class BlueMageRotation
 //    /// 
 //    /// </summary>
 //    public static IBLUAction Devour { get; } = new BLUAction(ActionID.Devour, ActionOption.Heal);
-
-//    /// <summary>
-//    /// 
-//    /// </summary>
-//    public static IBLUAction TheRoseOfDestruction { get; } = new BLUAction(ActionID.TheRoseOfDestruction);
-
-//    /// <summary>
-//    /// 
-//    /// </summary>
-//    public static IBLUAction MatraMagic { get; } = new BLUAction(ActionID.MatraMagic);
 
 //    /// <summary>
 //    /// 
@@ -930,14 +1090,5 @@ partial class BlueMageRotation
 
 //        if (WhiteWind.CanUse(out act, CanUseOption.MustUse)) return true;
 //        return base.HealAreaGCD(out act);
-//    }
-
-//    /// <summary>
-//    /// 
-//    /// </summary>
-//    public override void DisplayStatus()
-//    {
-//        ImGui.TextWrapped(BlueId.ToString());
-//        base.DisplayStatus();
 //    }
 //}

--- a/RotationSolver.Basic/Rotations/Basic/PaladinRotation.cs
+++ b/RotationSolver.Basic/Rotations/Basic/PaladinRotation.cs
@@ -169,7 +169,6 @@ partial class PaladinRotation
     static partial void ModifyBulwarkPvE(ref ActionSetting setting)
     {
         setting.StatusProvide = [StatusID.Bulwark];
-        setting.UnlockedByQuestID = 66596;
     }
 
     static partial void ModifyGoringBladePvE(ref ActionSetting setting)

--- a/RotationSolver.Basic/Rotations/CustomRotation_GCD.cs
+++ b/RotationSolver.Basic/Rotations/CustomRotation_GCD.cs
@@ -22,8 +22,12 @@ partial class CustomRotation
                 && UseLimitBreak(out act)) return act;
 
             IBaseAction.ShouldEndSpecial = false;
-
             if (EmergencyGCD(out act)) return act;
+
+            if (DataCenter.CommandStatus.HasFlag(AutoStatus.Interrupt))
+            {
+                if (MyInterruptGCD(out act)) return act;
+            }
 
             if (DataCenter.MergedStatus.HasFlag(AutoStatus.MoveForward)
                 && MoveForwardGCD(out act))
@@ -178,6 +182,20 @@ partial class CustomRotation
             act = null!;
             return false;
         }
+    }
+
+    /// <summary>
+    /// Attempts to use the Interrupt GCD action.
+    /// </summary>
+    /// <param name="act">The action to be performed.</param>
+    /// <returns>True if the action can be used; otherwise, false.</returns>
+    protected virtual bool MyInterruptGCD(out IAction? act)
+    {
+        act = null;
+        if (ShouldSkipAction()) return false;
+
+        if (DataCenter.RightNowDutyRotation?.MyInterruptGCD(out act) ?? false) return true;
+        act = null; return false;
     }
 
     /// <summary>

--- a/RotationSolver.Basic/Rotations/CustomRotation_GCD.cs
+++ b/RotationSolver.Basic/Rotations/CustomRotation_GCD.cs
@@ -29,6 +29,17 @@ partial class CustomRotation
                 if (MyInterruptGCD(out act)) return act;
             }
 
+            IBaseAction.TargetOverride = TargetType.Death;
+
+            if (Service.Config.RaisePlayerFirst)
+            {
+                if (RaiseSpell(out act, false)) return act;
+
+                if (Service.Config.RaisePlayerByCasting && SwiftcastPvE.Cooldown.IsCoolingDown && RaiseSpell(out act, true)) return act;
+            }
+
+            IBaseAction.TargetOverride = null;
+
             if (DataCenter.MergedStatus.HasFlag(AutoStatus.MoveForward)
                 && MoveForwardGCD(out act))
             {
@@ -76,9 +87,12 @@ partial class CustomRotation
 
             IBaseAction.TargetOverride = TargetType.Death;
 
-            if (RaiseSpell(out act, false)) return act;
+            if (!Service.Config.RaisePlayerFirst)
+            {
+                if (RaiseSpell(out act, false)) return act;
 
-            if (Service.Config.RaisePlayerByCasting && SwiftcastPvE.Cooldown.IsCoolingDown && RaiseSpell(out act, true)) return act;
+                if (Service.Config.RaisePlayerByCasting && SwiftcastPvE.Cooldown.IsCoolingDown && RaiseSpell(out act, true)) return act;
+            }
 
             IBaseAction.TargetOverride = null;
 

--- a/RotationSolver.Basic/Rotations/Duties/DutyRotation.cs
+++ b/RotationSolver.Basic/Rotations/Duties/DutyRotation.cs
@@ -12,6 +12,11 @@ partial class DutyRotation : IDisposable
         act = null; return false;
     }
 
+    public virtual bool MyInterruptGCD(out IAction? act)
+    {
+        act = null; return false;
+    }
+
     public virtual bool GeneralGCD(out IAction? act)
     {
         act = null; return false;


### PR DESCRIPTION
### Updates and Enhancements:

* `BasicRotations/Limited Jobs/BLU_Default.cs`:
  - Updated the game version from "7.05" to "7.11".
  - Added new methods for handling various out-of-GCD (oGCD) and GCD abilities, including movement, healing, defense, and attack abilities.

* `RotationSolver.Basic/Configuration/Configs.cs`:
  - Introduced a new configuration option `_raisePlayerFirst` to prioritize raising dead players over healing or defense.

### Action Modifications:

* `RotationSolver.Basic/Rotations/Basic/BlueMageRotation.cs`:
  - Added a new override for the `Raise` action to use `AngelWhisperPvE`.
  - Modified various action settings to provide specific statuses and configurations, such as `SongOfTormentPvE`, `BristlePvE`, `MoonFlutePvE`, and others.
  - Removed outdated or redundant action definitions and methods. [[1]](diffhunk://#diff-1178167386c0a6f4a44d37f4f71e3a5b758c56096ae715b0a11110196540402eL79-L86) [[2]](diffhunk://#diff-1178167386c0a6f4a44d37f4f71e3a5b758c56096ae715b0a11110196540402eL95-L99) [[3]](diffhunk://#diff-1178167386c0a6f4a44d37f4f71e3a5b758c56096ae715b0a11110196540402eL115-L124) [[4]](diffhunk://#diff-1178167386c0a6f4a44d37f4f71e3a5b758c56096ae715b0a11110196540402eL934-L942)

* `RotationSolver.Basic/Rotations/CustomRotation_GCD.cs`:
  - Added new logic to handle interrupt GCD actions and prioritize raising dead players based on configuration. [[1]](diffhunk://#diff-192fd0ef405353938d960500b67712b32ab136a58326f13789b3f384ac07bb8eL25-R42) [[2]](diffhunk://#diff-192fd0ef405353938d960500b67712b32ab136a58326f13789b3f384ac07bb8eR90-R95) [[3]](diffhunk://#diff-192fd0ef405353938d960500b67712b32ab136a58326f13789b3f384ac07bb8eR201-R214)

* `RotationSolver.Basic/Rotations/Duties/DutyRotation.cs`:
  - Introduced a new virtual method `MyInterruptGCD` to handle interrupt actions.

These changes collectively improve the flexibility and functionality of the rotation logic, ensuring better handling of various combat scenarios and player configurations.