### PR TITLE
Refactor target access methods for consistency

### DIFF
--- a/RotationSolver.Basic/Actions/ActionTargetInfo.cs
+++ b/RotationSolver.Basic/Actions/ActionTargetInfo.cs
@@ -206,7 +206,7 @@ public struct ActionTargetInfo(IBaseAction action)
             return false;
         }
 
-        if (MarkingHelper.StopTargets.Contains((long)gameObject.GameObjectId) && Service.Config.FilterStopMark)
+        if (MarkingHelper.GetStopTargets().Contains((long)gameObject.GameObjectId) && Service.Config.FilterStopMark)
         {
             return false;
         }

--- a/RotationSolver.Basic/Helpers/MarkingHelper.cs
+++ b/RotationSolver.Basic/Helpers/MarkingHelper.cs
@@ -48,64 +48,36 @@ namespace RotationSolver.Basic.Helpers
         /// <summary>
         /// Gets a value indicating whether there are any attack characters.
         /// </summary>
-        internal static bool HaveAttackChara => AttackSignTargets.Any(id => id != 0);
+        internal static bool HaveAttackChara => GetAttackSignTargets().Any(id => id != 0);
 
-        private static long[]? _attackSignTargets;
         /// <summary>
         /// Gets the attack sign targets.
         /// </summary>
-        internal static long[] AttackSignTargets
+        internal static long[] GetAttackSignTargets()
         {
-            get
+            return new long[]
             {
-                if (_attackSignTargets == null)
-                {
-                    lock (_lock)
-                    {
-                        if (_attackSignTargets == null)
-                        {
-                            _attackSignTargets = new long[]
-                            {
-                                GetMarker(HeadMarker.Attack1),
-                                GetMarker(HeadMarker.Attack2),
-                                GetMarker(HeadMarker.Attack3),
-                                GetMarker(HeadMarker.Attack4),
-                                GetMarker(HeadMarker.Attack5),
-                                GetMarker(HeadMarker.Attack6),
-                                GetMarker(HeadMarker.Attack7),
-                                GetMarker(HeadMarker.Attack8),
-                            };
-                        }
-                    }
-                }
-                return _attackSignTargets;
-            }
+                GetMarker(HeadMarker.Attack1),
+                GetMarker(HeadMarker.Attack2),
+                GetMarker(HeadMarker.Attack3),
+                GetMarker(HeadMarker.Attack4),
+                GetMarker(HeadMarker.Attack5),
+                GetMarker(HeadMarker.Attack6),
+                GetMarker(HeadMarker.Attack7),
+                GetMarker(HeadMarker.Attack8),
+            };
         }
 
-        private static long[]? _stopTargets;
         /// <summary>
         /// Gets the stop targets.
         /// </summary>
-        internal static long[] StopTargets
+        internal static long[] GetStopTargets()
         {
-            get
+            return new long[]
             {
-                if (_stopTargets == null)
-                {
-                    lock (_lock)
-                    {
-                        if (_stopTargets == null)
-                        {
-                            _stopTargets = new long[]
-                            {
-                                GetMarker(HeadMarker.Stop1),
-                                GetMarker(HeadMarker.Stop2),
-                            };
-                        }
-                    }
-                }
-                return _stopTargets;
-            }
+                GetMarker(HeadMarker.Stop1),
+                GetMarker(HeadMarker.Stop2),
+            };
         }
 
         /// <summary>
@@ -115,7 +87,7 @@ namespace RotationSolver.Basic.Helpers
         /// <returns>The filtered characters.</returns>
         internal unsafe static IEnumerable<IBattleChara> FilterStopCharacters(IEnumerable<IBattleChara> charas)
         {
-            var ids = new HashSet<long>(StopTargets.Where(id => id != 0));
+            var ids = new HashSet<long>(GetStopTargets().Where(id => id != 0));
             return charas.Where(b => !ids.Contains((long)b.GameObjectId));
         }
     }

--- a/RotationSolver.Basic/Helpers/ObjectHelper.cs
+++ b/RotationSolver.Basic/Helpers/ObjectHelper.cs
@@ -348,7 +348,7 @@ public static class ObjectHelper
             if (b.StatusList != null && b.StatusList.Any(StatusHelper.IsPriority)) return true;
         }
 
-        if (Service.Config.ChooseAttackMark && MarkingHelper.AttackSignTargets.FirstOrDefault(id => id != 0) == (long)obj.GameObjectId) return true;
+        if (Service.Config.ChooseAttackMark && MarkingHelper.GetAttackSignTargets().FirstOrDefault(id => id != 0) == (long)obj.GameObjectId) return true;
 
         // Fate
         if (Service.Config.TargetFatePriority && fateId != 0 && obj.FateId() == fateId) return true;


### PR DESCRIPTION
### Refactor `MarkingHelper` class and fix marker feature:

* [`RotationSolver.Basic/Actions/ActionTargetInfo.cs`](diffhunk://#diff-c48c5d8b4fd41fe622aa573e5ca583106eb40f1fc24db44fcc12935cd35c1774L209-R209): Updated the `GeneralCheck` method to use `MarkingHelper.GetStopTargets()` instead of directly accessing the `StopTargets` array.

* `RotationSolver.Basic/Helpers/MarkingHelper.cs`: 
  - Replaced the `AttackSignTargets` property with the `GetAttackSignTargets` method. [[1]](diffhunk://#diff-de82347d61ca8a4a315f086549c731dea28d12b08fc6209bdc3ac82919c32913L51-R58) [[2]](diffhunk://#diff-de82347d61ca8a4a315f086549c731dea28d12b08fc6209bdc3ac82919c32913L79-L109)
  - Replaced the `StopTargets` property with the `GetStopTargets` method. [[1]](diffhunk://#diff-de82347d61ca8a4a315f086549c731dea28d12b08fc6209bdc3ac82919c32913L79-L109) [[2]](diffhunk://#diff-de82347d61ca8a4a315f086549c731dea28d12b08fc6209bdc3ac82919c32913L118-R90)

* [`RotationSolver.Basic/Helpers/ObjectHelper.cs`](diffhunk://#diff-44cc6e98dcd8c3d2aa47210ec76d800058560df9bbff9ce225b3116c47ddc1fcL351-R351): Updated the `IsTopPriorityHostile` method to use `MarkingHelper.GetAttackSignTargets()` instead of directly accessing the `AttackSignTargets` array.