### PR TITLE
Fix VfxDataQueue copy in IsCastingVfx method

### DIFF
--- a/RotationSolver.Basic/DataCenter.cs
+++ b/RotationSolver.Basic/DataCenter.cs
@@ -810,7 +810,8 @@ internal static class DataCenter
     public static bool IsCastingVfx(Func<VfxNewData, bool> isVfx)
     {
         // Create a copy of the VfxDataQueue to avoid modifying the collection while enumerating
-        var vfxDataQueueCopy = VfxDataQueue.ToList();
+        var vfxDataQueueCopy = new List<VfxNewData>(VfxDataQueue.Count);
+        vfxDataQueueCopy.AddRange(VfxDataQueue);
 
         foreach (var vfx in vfxDataQueueCopy)
         {


### PR DESCRIPTION
This pull request includes an optimization to the `IsCastingVfx` method in the `RotationSolver.Basic/DataCenter.cs` file. The change improves the performance by creating a new list with a predefined capacity and adding the elements from `VfxDataQueue` to it.

Performance optimization:

* [`RotationSolver.Basic/DataCenter.cs`](diffhunk://#diff-2c3e758beb8d040501567ca05ffcedd46534840df24596c1119e971896e8eb42L813-R814): Modified the `IsCastingVfx` method to create a new list with a predefined capacity and add elements from `VfxDataQueue` to it, instead of using `ToList()`.Explicitly initializes the vfxDataQueueCopy list with the capacity of VfxDataQueue, ensuring that it can hold all the elements.