### PR TITLE
Update ECommons submodule and validate ClassJob in BaseAction

### DIFF
--- a/RotationSolver.Basic/Actions/BaseAction.cs
+++ b/RotationSolver.Basic/Actions/BaseAction.cs
@@ -85,7 +85,15 @@ public class BaseAction : IBaseAction
                 value = Setting.CreateConfig?.Invoke() ?? new ActionConfig();
                 Service.Config.RotationActionConfig[ID] = value;
 
+                if (!Action.ClassJob.IsValid)
+                {
+                    // Log the error for debugging purposes
+                    Svc.Log.Debug($"ClassJob is not valid for Action ID: {ID}");
+                    return value;
+                }
+
                 var classJob = Action.ClassJob.Value;
+
                 if (classJob.RowId != 0 && classJob.GetJobRole() == JobRole.Tank)
                 {
                     value.AoeCount = 2;


### PR DESCRIPTION
Updated ECommons submodule to commit 110b75972e45aa0765ce99d99b69d928e2d3e747.

In BaseAction, added validation for Action.ClassJob within the RotationActionConfig check. If ClassJob is invalid, log an error and return the value.