### PR TITLE
Code cleanup pass

### DIFF
--- a/BasicRotations/Healer/AST_Default.cs
+++ b/BasicRotations/Healer/AST_Default.cs
@@ -179,9 +179,9 @@ public sealed class AST_Default : AstrologianRotation
         act = null;
         if (BubbleProtec && Player.HasStatus(true, StatusID.CollectiveUnconscious_848)) return false;
 
-        if (!Player.HasStatus(true, StatusID.Lightspeed) 
-            && InCombat 
-            && DivinationPvE.Cooldown.ElapsedAfter(115) 
+        if (!Player.HasStatus(true, StatusID.Lightspeed)
+            && InCombat
+            && DivinationPvE.Cooldown.ElapsedAfter(115)
             && LightspeedPvE.CanUse(out act, usedUp: true)) return true;
 
         if (IsBurst && !IsMoving
@@ -189,9 +189,9 @@ public sealed class AST_Default : AstrologianRotation
 
         if (AstralDrawPvE.CanUse(out act, usedUp: IsBurst)) return true;
 
-        if (!Player.HasStatus(true, StatusID.Lightspeed) 
-            && (InBurstStatus || DivinationPvE.Cooldown.ElapsedAfter(115)) 
-            && InCombat 
+        if (!Player.HasStatus(true, StatusID.Lightspeed)
+            && (InBurstStatus || DivinationPvE.Cooldown.ElapsedAfter(115))
+            && InCombat
             && LightspeedPvE.CanUse(out act, usedUp: true)) return true;
 
         if (InCombat)
@@ -266,7 +266,7 @@ public sealed class AST_Default : AstrologianRotation
     }
     #endregion
 
-    
+
 
     #region Extra Methods
     public override bool CanHealSingleSpell => base.CanHealSingleSpell && (GCDHeal || PartyMembers.GetJobCategory(JobRole.Healer).Count() < 2);

--- a/BasicRotations/Limited Jobs/BLU_Default.cs
+++ b/BasicRotations/Limited Jobs/BLU_Default.cs
@@ -141,7 +141,7 @@ public sealed class Blue_Default : BlueMageRotation
     protected override bool MoveForwardGCD(out IAction? act)
     {
         act = null;
-        
+
         return base.MoveForwardGCD(out act);
     }
 

--- a/BasicRotations/Magical/SMN_Default.cs
+++ b/BasicRotations/Magical/SMN_Default.cs
@@ -153,7 +153,7 @@ public sealed class SMN_Default : SummonerRotation
 
         return base.EmergencyAbility(nextGCD, out act);
     }
-    
+
     #endregion
 
     #region GCD Logic

--- a/BasicRotations/Melee/MNK_Default.cs
+++ b/BasicRotations/Melee/MNK_Default.cs
@@ -17,7 +17,7 @@ public sealed class MNK_Default : MonkRotation
     public bool AutoPB_AOE { get; set; } = true;
 
     [RotationConfig(CombatType.PvE, Name = "Enable TEA Checker.")]
-    public bool EnableTEAChecker { get; set; } = false; 
+    public bool EnableTEAChecker { get; set; } = false;
     #endregion
 
     #region Countdown Logic
@@ -44,7 +44,7 @@ public sealed class MNK_Default : MonkRotation
         {
             return false;
         }
-        
+
         // PerfectBalancePvE after first gcd + TheForbiddenChakraPvE after second gcd
         // fail to weave both after first gcd - rsr doesn't have enough time to react to both spells
         // you pot -2s (real world -3s) prepull or after 2nd gcd!!! 
@@ -194,7 +194,7 @@ public sealed class MNK_Default : MonkRotation
         {
             return false;
         }
-        
+
         // bullet proofed finisher - use when during burst
         // or if burst was missed, and next burst is not arriving in time, use it better than waste it, otherwise, hold it for next rof
         if (!BeastChakras.Contains(BeastChakra.NONE) && (Player.HasStatus(true, StatusID.RiddleOfFire) || RiddleOfFirePvE.Cooldown.JustUsedAfter(42)))

--- a/BasicRotations/Melee/RPR_Default.cs
+++ b/BasicRotations/Melee/RPR_Default.cs
@@ -97,7 +97,7 @@ public sealed class RPR_Default : ReaperRotation
         {
             if (ShadowOfDeathPvE.CanUse(out act)) return true;
         }
-        
+
         if (HasEnshrouded)
         {
             if (ShadowOfDeathPvE.CanUse(out act)) return true;

--- a/BasicRotations/Melee/SAM_Default.cs
+++ b/BasicRotations/Melee/SAM_Default.cs
@@ -15,7 +15,7 @@ public sealed class SAM_Default : SamuraiRotation
     public bool HiganbanaTargets { get; set; } = false;
 
     [RotationConfig(CombatType.PvE, Name = "Enable TEA Checker.")]
-    public bool EnableTEAChecker { get; set; } = false; 
+    public bool EnableTEAChecker { get; set; } = false;
     #endregion
 
     #region Countdown Logic
@@ -65,7 +65,7 @@ public sealed class SAM_Default : SamuraiRotation
         {
             return false;
         }
-        
+
         var IsTargetBoss = HostileTarget?.IsBossFromTTK() ?? false;
         var IsTargetDying = HostileTarget?.IsDying() ?? false;
 
@@ -100,7 +100,7 @@ public sealed class SAM_Default : SamuraiRotation
         {
             return false;
         }
-        
+
         var IsTargetBoss = HostileTarget?.IsBossFromTTK() ?? false;
         var IsTargetDying = HostileTarget?.IsDying() ?? false;
 
@@ -160,7 +160,7 @@ public sealed class SAM_Default : SamuraiRotation
         if ((!HasMoon || IsMoonTimeLessThanFlower || !OkaPvE.EnoughLevel) && MangetsuPvE.CanUse(out act, skipComboCheck: HaveMeikyoShisui && !HasGetsu)) return true;
         if ((!HasFlower || !IsMoonTimeLessThanFlower) && OkaPvE.CanUse(out act, skipComboCheck: HaveMeikyoShisui && !HasKa)) return true;
 
-        if (!HasSetsu && SamBuffs.All(SamBuffs => Player.HasStatus(true, SamBuffs)) && 
+        if (!HasSetsu && SamBuffs.All(SamBuffs => Player.HasStatus(true, SamBuffs)) &&
             YukikazePvE.CanUse(out act, skipComboCheck: HaveMeikyoShisui && HasGetsu && HasKa)) return true;
 
         // single target 123 combo's 3 or used 3 directly during burst when MeikyoShisui is active, while also trying to start with the one that player is in position for extra DMG

--- a/BasicRotations/Melee/VPR_Default.cs
+++ b/BasicRotations/Melee/VPR_Default.cs
@@ -172,7 +172,7 @@ public sealed class VPR_Default : ViperRotation
 
         if (HuntersCoilPvE.CanUse(out act, skipComboCheck: true)) return true;
         if (SwiftskinsCoilPvE.CanUse(out act, skipComboCheck: true)) return true;
-        
+
 
         if (VicewinderPvE.Cooldown.CurrentCharges == 1 && VicewinderPvE.Cooldown.RecastTimeRemainOneCharge < 10)
         {

--- a/BasicRotations/Ranged/DNC_Default.cs
+++ b/BasicRotations/Ranged/DNC_Default.cs
@@ -60,7 +60,7 @@ public sealed class DNC_Default : DancerRotation
             && UseBurstMedicine(out act)) return true;
 
         //If dancing or about to dance avoid using abilities to avoid animation lock delaying the dance, except for Devilment
-        if(!IsDancing && !(StandardStepPvE.Cooldown.ElapsedAfter(28) || TechnicalStepPvE.Cooldown.ElapsedAfter(118)))
+        if (!IsDancing && !(StandardStepPvE.Cooldown.ElapsedAfter(28) || TechnicalStepPvE.Cooldown.ElapsedAfter(118)))
             return base.EmergencyAbility(nextGCD, out act); // Fallback to base class method if none of the above conditions are met
 
         act = null;
@@ -193,7 +193,7 @@ public sealed class DNC_Default : DancerRotation
     // Helper method to handle attack actions during GCD based on certain conditions
     private bool AttackGCD(out IAction? act, bool burst)
     {
-       act = null;
+        act = null;
 
         if (IsDancing) return false;
 

--- a/BasicRotations/Ranged/zMCH_Beta.cs
+++ b/BasicRotations/Ranged/zMCH_Beta.cs
@@ -47,11 +47,11 @@ public sealed class zMCH_Beta : MachinistRotation
         bool isReassembleUsable =
             //Reassemble current # of charges and double proc protection
             ReassemblePvE.Cooldown.CurrentCharges > 0 && !Player.HasStatus(true, StatusID.Reassembled) &&
-            (nextGCD.IsTheSameTo(true, [ChainSawPvE, ExcavatorPvE]) 
+            (nextGCD.IsTheSameTo(true, [ChainSawPvE, ExcavatorPvE])
             || (!ChainSawPvE.EnoughLevel && nextGCD.IsTheSameTo(true, SpreadShotPvE) && ((IBaseAction)nextGCD).Target.AffectedTargets.Length >= (SpreadShotMasteryTrait.EnoughLevel ? 4 : 5))
-            || nextGCD.IsTheSameTo(false, [AirAnchorPvE]) 
-            || (!ChainSawPvE.EnoughLevel && nextGCD.IsTheSameTo(true, DrillPvE)) 
-            || (!DrillPvE.EnoughLevel && nextGCD.IsTheSameTo(true, CleanShotPvE)) 
+            || nextGCD.IsTheSameTo(false, [AirAnchorPvE])
+            || (!ChainSawPvE.EnoughLevel && nextGCD.IsTheSameTo(true, DrillPvE))
+            || (!DrillPvE.EnoughLevel && nextGCD.IsTheSameTo(true, CleanShotPvE))
             || (!CleanShotPvE.EnoughLevel && nextGCD.IsTheSameTo(false, HotShotPvE)));
         // Attempt to use Reassemble if it's ready
         if (isReassembleUsable)
@@ -75,7 +75,7 @@ public sealed class zMCH_Beta : MachinistRotation
     {
         // Keeps Ricochet and Gauss cannon Even
         bool isRicochetMore = RicochetPvE.EnoughLevel && GaussRoundPvE.Cooldown.RecastTimeElapsed <= RicochetPvE.Cooldown.RecastTimeElapsed;
-        
+
         // If Wildfire is active, use Hypercharge.....Period
         if (Player.HasStatus(true, StatusID.Wildfire_1946) && HyperchargePvE.CanUse(out act)) return true;
 
@@ -150,9 +150,9 @@ public sealed class zMCH_Beta : MachinistRotation
         if (FullMetalFieldPvE.CanUse(out act)) return true;
 
         // dont use the second charge of Drill if it's in opener, also save Drill for burst  --- need to combine this with the logic above!!!
-        if (EnhancedMultiweaponTrait.EnoughLevel 
-            && !CombatElapsedLessGCD(6) 
-            && !ChainSawPvE.Cooldown.WillHaveOneCharge(6) 
+        if (EnhancedMultiweaponTrait.EnoughLevel
+            && !CombatElapsedLessGCD(6)
+            && !ChainSawPvE.Cooldown.WillHaveOneCharge(6)
             && (!HoldDrillForCombo || !(LiveComboTime <= 5) || (!CleanShotPvE.CanUse(out _) && !SlugShotPvE.CanUse(out _)))
             && DrillPvE.CanUse(out act, usedUp: true)) return true;
 
@@ -200,7 +200,7 @@ public sealed class zMCH_Beta : MachinistRotation
         }
     }
 
-    private bool TimeForBurstMeds(out IAction? act, IAction nextGCD) 
+    private bool TimeForBurstMeds(out IAction? act, IAction nextGCD)
     {
         if (AirAnchorPvE.Cooldown.WillHaveOneChargeGCD(1) && BarrelStabilizerPvE.Cooldown.WillHaveOneChargeGCD(6) && WildfirePvE.Cooldown.WillHaveOneChargeGCD(6)) return UseBurstMedicine(out act);
         act = null;
@@ -209,9 +209,9 @@ public sealed class zMCH_Beta : MachinistRotation
 
     private bool CanUseQueenMeow(out IAction? act, IAction nextGCD)
     {
-        if (WildfirePvE.Cooldown.WillHaveOneChargeGCD(4) 
+        if (WildfirePvE.Cooldown.WillHaveOneChargeGCD(4)
             || !WildfirePvE.Cooldown.ElapsedAfter(10)
-            || (nextGCD.IsTheSameTo(true, CleanShotPvE) && Battery == 100) 
+            || (nextGCD.IsTheSameTo(true, CleanShotPvE) && Battery == 100)
             || (nextGCD.IsTheSameTo(true, HotShotPvE, AirAnchorPvE, ChainSawPvE, ExcavatorPvE) && (Battery == 90 || Battery == 100)))
         {
             if (RookAutoturretPvE.CanUse(out act)) return true;

--- a/BasicRotations/Ranged/zMCH_Beta_2.cs
+++ b/BasicRotations/Ranged/zMCH_Beta_2.cs
@@ -37,7 +37,7 @@ public sealed class zMCH_Beta_2 : MachinistRotation
         if (IsBurst && MidfightBurstMeds && !CombatElapsedLessGCD(10) && TimeForBurstMeds(out act, nextGCD)) return true;
         if (IsBurst)
         {
-            
+
             if (FullMetalFieldPvE.EnoughLevel)
             {
                 // Use Wildfire before FMF in the second half of the GCD window to avoid wasting time in status
@@ -46,11 +46,11 @@ public sealed class zMCH_Beta_2 : MachinistRotation
                     && WildfirePvE.CanUse(out act, isLastAbility: true)) return true;
             }
             // Legacy logic for <100
-            else if ((IsLastAbility(false, HyperchargePvE) 
-                    || Heat >= 50 
-                    || Player.HasStatus(true, StatusID.Hypercharged)) 
-                && ToolChargeSoon(out _) 
-                && !LowLevelHyperCheck 
+            else if ((IsLastAbility(false, HyperchargePvE)
+                    || Heat >= 50
+                    || Player.HasStatus(true, StatusID.Hypercharged))
+                && ToolChargeSoon(out _)
+                && !LowLevelHyperCheck
                 && WildfirePvE.CanUse(out act)) return true;
         }
 
@@ -103,8 +103,8 @@ public sealed class zMCH_Beta_2 : MachinistRotation
 
         // Use Hypercharge if wildfire will not be up in 30 seconds or if you hit 100 heat and it will not break your combo
         if (!LowLevelHyperCheck
-            && !Player.HasStatus(true, StatusID.Reassembled) 
-            && (!WildfirePvE.Cooldown.WillHaveOneCharge(30) || Heat == 100) 
+            && !Player.HasStatus(true, StatusID.Reassembled)
+            && (!WildfirePvE.Cooldown.WillHaveOneCharge(30) || Heat == 100)
             && !(LiveComboTime <= HYPERCHARGE_DURATION && LiveComboTime > 0f)
             && ToolChargeSoon(out act)) return true;
 
@@ -117,7 +117,7 @@ public sealed class zMCH_Beta_2 : MachinistRotation
                 && RicochetPvE.CanUse(out act, skipAoeCheck: true, usedUp: true))
                 return true;
         }
-            
+
         if ((IsLastGCD(true, BlazingShotPvE, HeatBlastPvE)
             || GaussRoundPvE.Cooldown.RecastTimeElapsed >= 45
             || !BarrelStabilizerPvE.Cooldown.ElapsedAfter(20))
@@ -167,7 +167,7 @@ public sealed class zMCH_Beta_2 : MachinistRotation
 
         // save Drill for burst
         if (EnhancedMultiweaponTrait.EnoughLevel
-            && !ChainSawPvE.Cooldown.WillHaveOneCharge(6) 
+            && !ChainSawPvE.Cooldown.WillHaveOneCharge(6)
             && (!(LiveComboTime <= 6) || (!CleanShotPvE.CanUse(out _) && !SlugShotPvE.CanUse(out _)))
             && DrillPvE.CanUse(out act, usedUp: true)) return true;
 

--- a/RotationSolver.Basic/Actions/ActionBasicInfo.cs
+++ b/RotationSolver.Basic/Actions/ActionBasicInfo.cs
@@ -165,7 +165,7 @@ public readonly struct ActionBasicInfo
 
     private bool IsActionEnabled() => _action.Config?.IsEnabled ?? false;
 
-    private bool IsActionDisabled() => !IBaseAction.ForceEnable && (DataCenter.DisabledActionSequencer?.Contains(ID) ?? false); 
+    private bool IsActionDisabled() => !IBaseAction.ForceEnable && (DataCenter.DisabledActionSequencer?.Contains(ID) ?? false);
 
     private bool HasEnoughMP() => DataCenter.CurrentMp >= MPNeed;
 
@@ -230,8 +230,8 @@ public readonly struct ActionBasicInfo
         }
 
         var comboActions = _action.Action.ActionCombo.RowId != 0
-    ?       new ActionID[] { (ActionID)_action.Action.ActionCombo.RowId }
-    :       Array.Empty<ActionID>();
+    ? new ActionID[] { (ActionID)_action.Action.ActionCombo.RowId }
+    : Array.Empty<ActionID>();
 
         if (_action.Setting.ComboIds != null) comboActions = [.. comboActions, .. _action.Setting.ComboIds];
 

--- a/RotationSolver.Basic/Actions/ActionTargetInfo.cs
+++ b/RotationSolver.Basic/Actions/ActionTargetInfo.cs
@@ -6,8 +6,6 @@ using ECommons.GameHelpers;
 using FFXIVClientStructs.FFXIV.Client.Game;
 using FFXIVClientStructs.FFXIV.Client.Graphics.Scene;
 using RotationSolver.Basic.Configuration;
-using RotationSolver.Basic.Helpers;
-using static FFXIVClientStructs.FFXIV.Client.Game.Character.ActionEffectHandler;
 using static RotationSolver.Basic.Configuration.ConfigTypes;
 
 namespace RotationSolver.Basic.Actions;

--- a/RotationSolver.Basic/Configuration/ConditionBoolean.cs
+++ b/RotationSolver.Basic/Configuration/ConditionBoolean.cs
@@ -1,6 +1,4 @@
-﻿using Newtonsoft.Json;
-
-namespace RotationSolver.Basic.Configuration;
+﻿namespace RotationSolver.Basic.Configuration;
 
 /// <summary>
 /// Represents a boolean condition with additional configuration options.

--- a/RotationSolver.Basic/Configuration/Conditions/TargetCondition.cs
+++ b/RotationSolver.Basic/Configuration/Conditions/TargetCondition.cs
@@ -67,7 +67,7 @@ internal class TargetCondition : DelayCondition
             TargetConditionType.MP => CheckMP(tar),
             TargetConditionType.TargetName => CheckTargetName(tar),
             TargetConditionType.TargetRole => CheckTargetRole(tar),
-	    _ => false,
+            _ => false,
         };
     }
 

--- a/RotationSolver.Basic/Configuration/RotationConfig/RotationConfigCombo.cs
+++ b/RotationSolver.Basic/Configuration/RotationConfig/RotationConfigCombo.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Reflection;
-
-namespace RotationSolver.Basic.Configuration.RotationConfig;
+﻿namespace RotationSolver.Basic.Configuration.RotationConfig;
 
 /// <summary>
 /// Represents a combo box rotation configuration.

--- a/RotationSolver.Basic/Configuration/RotationConfig/RotationConfigInt.cs
+++ b/RotationSolver.Basic/Configuration/RotationConfig/RotationConfigInt.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Reflection;
-
-namespace RotationSolver.Basic.Configuration.RotationConfig;
+﻿namespace RotationSolver.Basic.Configuration.RotationConfig;
 
 /// <summary>
 /// Represents an integer rotation configuration.

--- a/RotationSolver.Basic/Configuration/RotationConfig/RotationConfigSet.cs
+++ b/RotationSolver.Basic/Configuration/RotationConfig/RotationConfigSet.cs
@@ -1,6 +1,5 @@
 ﻿using ECommons.DalamudServices;
 using System.Collections;
-using System.Reflection;
 
 namespace RotationSolver.Basic.Configuration.RotationConfig;
 

--- a/RotationSolver.Basic/Data/Countdown.cs
+++ b/RotationSolver.Basic/Data/Countdown.cs
@@ -1,5 +1,4 @@
-﻿using ECommons.DalamudServices;
-using FFXIVClientStructs.FFXIV.Client.System.Framework;
+﻿using FFXIVClientStructs.FFXIV.Client.System.Framework;
 using FFXIVClientStructs.FFXIV.Client.UI.Agent;
 using System.Runtime.InteropServices;
 

--- a/RotationSolver.Basic/Data/JobGaugeManager.cs
+++ b/RotationSolver.Basic/Data/JobGaugeManager.cs
@@ -1,6 +1,4 @@
-﻿using Dalamud.Game.ClientState.JobGauge;
-using Dalamud.Plugin.Services;
-using System;
+﻿using Dalamud.Plugin.Services;
 
 namespace RotationSolver.Basic.Data
 {

--- a/RotationSolver.Basic/Data/TargetHostileType.cs
+++ b/RotationSolver.Basic/Data/TargetHostileType.cs
@@ -34,7 +34,7 @@ public enum TargetHostileType : byte
     /// </summary>
     [Description("Only attack targets in your parties enemy list")]
     TargetIsInEnemiesList,
-    
+
     /// <summary>
     /// All targets when solo, or only attack targets in your parties enemy list.
     /// </summary>

--- a/RotationSolver.Basic/DataCenter.cs
+++ b/RotationSolver.Basic/DataCenter.cs
@@ -2,7 +2,6 @@
 using Dalamud.Game.ClientState.Objects.Enums;
 using ECommons.DalamudServices;
 using ECommons.ExcelServices;
-using ECommons.GameFunctions;
 using ECommons.GameHelpers;
 using FFXIVClientStructs.FFXIV.Client.Game;
 using FFXIVClientStructs.FFXIV.Client.Game.Character;
@@ -177,7 +176,7 @@ internal static class DataCenter
 
     public static TargetHostileType RightNowTargetToHostileType => Service.Config.HostileType;
     public static TinctureUseType RightNowTinctureUseType => Service.Config.TinctureType;
-    
+
     public static unsafe ActionID LastComboAction => (ActionID)ActionManager.Instance()->Combo.Action;
     public static unsafe float ComboTime => ActionManager.Instance()->Combo.Timer;
 
@@ -227,14 +226,14 @@ internal static class DataCenter
     #region GCD
     // Returns the time remaining until the next GCD (Global Cooldown) after considering the current animation lock.
     public static float NextAbilityToNextGCD => DefaultGCDRemain - Math.Max(ActionManagerHelper.GetCurrentAnimationLock(), DataCenter.MinAnimationLock);
-    
+
     // Returns the total duration of the default GCD.
     public static float DefaultGCDTotal => ActionManagerHelper.GetDefaultRecastTime();
 
     // Returns the remaining time for the default GCD by subtracting the elapsed time from the total recast time.
     public static float DefaultGCDRemain =>
         ActionManagerHelper.GetDefaultRecastTime() - ActionManagerHelper.GetDefaultRecastTimeElapsed();
-    
+
     // Returns the elapsed time since the start of the default GCD.
     public static float DefaultGCDElapsed => ActionManagerHelper.GetDefaultRecastTimeElapsed();
 

--- a/RotationSolver.Basic/Helpers/ObjectHelper.cs
+++ b/RotationSolver.Basic/Helpers/ObjectHelper.cs
@@ -5,9 +5,7 @@ using ECommons;
 using ECommons.DalamudServices;
 using ECommons.GameFunctions;
 using ECommons.GameHelpers;
-using ECommons.Reflection;
 using FFXIVClientStructs.FFXIV.Client.Game;
-using FFXIVClientStructs.FFXIV.Client.Game.Character;
 using FFXIVClientStructs.FFXIV.Client.Game.Event;
 using FFXIVClientStructs.FFXIV.Client.Graphics;
 using FFXIVClientStructs.FFXIV.Client.UI;
@@ -101,7 +99,7 @@ public static class ObjectHelper
             var tarFateId = battleChara.FateId();
             if (tarFateId != 0 && tarFateId != DataCenter.FateId) return false;
         }
-        
+
         if (Service.Config.TargetQuestThings && battleChara.IsOthersPlayers()) return false;
 
         if (battleChara.IsTopPriorityNamedHostile()) return true;

--- a/RotationSolver.Basic/Helpers/PriorityTargetHelper.cs
+++ b/RotationSolver.Basic/Helpers/PriorityTargetHelper.cs
@@ -1,7 +1,5 @@
-﻿using System.IO;
-using System.Text.Json;
+﻿using RotationSolver.Basic.Configuration;
 using JsonSerializer = System.Text.Json.JsonSerializer;
-using RotationSolver.Basic.Configuration;
 
 namespace RotationSolver.Basic.Helpers
 {

--- a/RotationSolver.Basic/Rotations/Basic/BlueMageRotation.cs
+++ b/RotationSolver.Basic/Rotations/Basic/BlueMageRotation.cs
@@ -69,7 +69,7 @@ partial class BlueMageRotation
 
     static partial void ModifySonicBoomPvE(ref ActionSetting setting)
     {
-        
+
     }
 
     static partial void ModifyWhistlePvE(ref ActionSetting setting)
@@ -211,7 +211,7 @@ partial class BlueMageRotation
 
     static partial void ModifySeaShantyPvE(ref ActionSetting setting)
     {
-        
+
     }
 
     static partial void ModifyBeingMortalPvE(ref ActionSetting setting)
@@ -227,7 +227,7 @@ partial class BlueMageRotation
     //Optional
     static partial void ModifyFlyingSardinePvE(ref ActionSetting setting)
     {
-        
+
     }
 
     static partial void ModifyWhiteWindPvE(ref ActionSetting setting)

--- a/RotationSolver.Basic/Rotations/Basic/MachinistRotation.cs
+++ b/RotationSolver.Basic/Rotations/Basic/MachinistRotation.cs
@@ -20,7 +20,7 @@ partial class MachinistRotation
     /// Gets the current Heat level.
     /// </summary>
     public static byte Heat => JobGauge.Heat;
-    
+
     /// <summary>
     /// Gets the current Overheated Stacks.
     /// </summary>

--- a/RotationSolver.Basic/Rotations/CustomRotation_OtherInfo.cs
+++ b/RotationSolver.Basic/Rotations/CustomRotation_OtherInfo.cs
@@ -129,7 +129,7 @@ partial class CustomRotation
         if (!enemy.HasPositional()) return true;
 
         EnemyPositional enemy_positional = enemy.FindEnemyPositional();
-        
+
         if (enemy_positional == positional)
             return true;
         return false;

--- a/RotationSolver.Basic/Service.cs
+++ b/RotationSolver.Basic/Service.cs
@@ -1,12 +1,12 @@
-﻿using System.Collections.Concurrent;
-using System.Text;
-using Dalamud.Utility.Signatures;
+﻿using Dalamud.Utility.Signatures;
 using ECommons.DalamudServices;
 using ECommons.EzHookManager;
 using FFXIVClientStructs.Attributes;
 using FFXIVClientStructs.FFXIV.Client.Game;
 using Lumina.Excel;
 using RotationSolver.Basic.Configuration;
+using System.Collections.Concurrent;
+using System.Text;
 
 namespace RotationSolver.Basic;
 
@@ -134,9 +134,9 @@ internal class Service : IDisposable
     {
         // Check the cache for the attribute or add it if not present
         var addon = AddonCache.GetOrAdd(typeof(T), t => t.GetCustomAttribute<AddonAttribute>());
-    
+
         if (addon is null) return Array.Empty<nint>();
-    
+
         return addon.AddonIdentifiers
             .Select(str => Svc.GameGui.GetAddonByName(str, 1))
             .Where(ptr => ptr != IntPtr.Zero);

--- a/RotationSolver/Helpers/DownloadHelper.cs
+++ b/RotationSolver/Helpers/DownloadHelper.cs
@@ -1,5 +1,4 @@
-﻿using ECommons.DalamudServices;
-using RotationSolver.UI;
+﻿using RotationSolver.UI;
 
 namespace RotationSolver.Helpers;
 

--- a/RotationSolver/Helpers/RotationLoadContext.cs
+++ b/RotationSolver/Helpers/RotationLoadContext.cs
@@ -1,5 +1,4 @@
 ﻿using Dalamud.Plugin;
-using ECommons.DalamudServices;
 using Lumina.Excel;
 //using Lumina.Excel.CustomSheets;
 using System.Runtime.Loader;

--- a/RotationSolver/UI/RotationConfigWindow.cs
+++ b/RotationSolver/UI/RotationConfigWindow.cs
@@ -15,7 +15,6 @@ using ExCSS;
 using FFXIVClientStructs.FFXIV.Client.Game;
 using FFXIVClientStructs.FFXIV.Client.Game.Fate;
 using FFXIVClientStructs.FFXIV.Client.System.Framework;
-using FFXIVClientStructs.FFXIV.Client.System.Scheduler;
 using FFXIVClientStructs.FFXIV.Common.Component.BGCollision;
 using Lumina.Excel.Sheets;
 using RotationSolver.Basic.Configuration;
@@ -2699,7 +2698,7 @@ public partial class RotationConfigWindow : Window
         {
             ImGui.Text($"Owner: {owner.Name}");
         }
-        
+
         if (target is IBattleChara battleChara)
         {
             ImGui.Text($"HP: {battleChara.CurrentHp} / {battleChara.MaxHp}");

--- a/RotationSolver/UI/RotationConfigWindow_Config.cs
+++ b/RotationSolver/UI/RotationConfigWindow_Config.cs
@@ -3,7 +3,6 @@ using Dalamud.Interface.Colors;
 using Dalamud.Interface.Utility.Raii;
 using ECommons.DalamudServices;
 using ECommons.ImGuiMethods;
-using Lumina.Excel.Sheets;
 using RotationSolver.Basic.Configuration;
 using RotationSolver.Basic.Configuration.Conditions;
 using RotationSolver.Data;

--- a/RotationSolver/UI/WelcomeWindow.cs
+++ b/RotationSolver/UI/WelcomeWindow.cs
@@ -2,7 +2,6 @@
 using Dalamud.Interface.Windowing;
 using ECommons.DalamudServices;
 using RotationSolver.Data;
-using RotationSolver.Updaters;
 
 namespace RotationSolver.UI
 {

--- a/RotationSolver/Updaters/ActionUpdater.cs
+++ b/RotationSolver/Updaters/ActionUpdater.cs
@@ -13,7 +13,8 @@ internal static class ActionUpdater
 {
     internal static DateTime AutoCancelTime { get; set; } = DateTime.MinValue;
 
-    static ActionUpdater() {
+    static ActionUpdater()
+    {
         EzIPC.Init(typeof(ActionUpdater), "RotationSolverReborn.ActionUpdater");
     }
 

--- a/RotationSolver/Updaters/RotationUpdater.cs
+++ b/RotationSolver/Updaters/RotationUpdater.cs
@@ -2,7 +2,6 @@
 using ECommons.ExcelServices;
 using ECommons.GameHelpers;
 using Lumina.Excel.Sheets;
-using RotationSolver.Basic.Configuration;
 using RotationSolver.Basic.Rotations.Duties;
 using RotationSolver.Data;
 using RotationSolver.Helpers;
@@ -569,10 +568,10 @@ internal static class RotationUpdater
             {
                 return (ICustomRotation?)Activator.CreateInstance(t);
             }
-            catch (Exception ex)
+            catch (Exception)
             {
 #if DEBUG
-                Svc.Log.Error(ex, $"Failed to create the rotation: {t.Name}");
+                Svc.Log.Error($"Failed to create the rotation: {t.Name}");
 #endif
                 return null;
             }

--- a/RotationSolver/Updaters/StateUpdater.cs
+++ b/RotationSolver/Updaters/StateUpdater.cs
@@ -1,5 +1,4 @@
-﻿using ECommons.DalamudServices;
-using ECommons.GameHelpers;
+﻿using ECommons.GameHelpers;
 using RotationSolver.Basic.Configuration.Conditions;
 
 namespace RotationSolver.Updaters;

--- a/RotationSolver/Updaters/TargetUpdater.cs
+++ b/RotationSolver/Updaters/TargetUpdater.cs
@@ -3,7 +3,6 @@ using ECommons.DalamudServices;
 using ECommons.ExcelServices;
 using ECommons.GameFunctions;
 using ECommons.GameHelpers;
-using FFXIVClientStructs.FFXIV.Client.UI.Misc;
 
 namespace RotationSolver.Updaters;
 


### PR DESCRIPTION
This pull request primarily focuses on cleaning up unused `using` directives in various files within the `RotationSolver.Basic` project. The most important changes include the removal of unnecessary `using` statements and the simplification of namespaces.

Codebase cleanup:

* [`RotationSolver.Basic/Actions/ActionTargetInfo.cs`](diffhunk://#diff-c48c5d8b4fd41fe622aa573e5ca583106eb40f1fc24db44fcc12935cd35c1774L9-L10): Removed `using RotationSolver.Basic.Helpers` and static import of `ActionEffectHandler`.
* [`RotationSolver.Basic/Configuration/ConditionBoolean.cs`](diffhunk://#diff-083bd6af3e35cb12cd01c883c1c5d2a9d0f672d3ca5122c69db3f870bccb62e4L1-R1): Removed `using Newtonsoft.Json`.
* [`RotationSolver.Basic/Configuration/RotationConfig/RotationConfigCombo.cs`](diffhunk://#diff-ec295cb204749481923e23b14c2b140292aa891da1221aec0da42b7ff8592762L1-R1): Removed `using System`, `using System.Collections.Generic`, and `using System.Reflection`.
* [`RotationSolver.Basic/Data/Countdown.cs`](diffhunk://#diff-9ff2ba7b8b6fb6f2ba97b0439aa816c5243a6013e5ba11a876acf004e0b764bcL1-R1): Removed `using ECommons.DalamudServices`.
* [`RotationSolver.Basic/Data/JobGaugeManager.cs`](diffhunk://#diff-e263c1815536d7e7dc878ee780c26789135c3a88aae56e859f019ee272d3f473L1-R1): Removed `using Dalamud.Game.ClientState.JobGauge` and `using System`.