### PR TITLE
Update GNB_Default, GunbreakerRotation, and dependencies

### DIFF
--- a/BasicRotations/Tank/GNB_Default.cs
+++ b/BasicRotations/Tank/GNB_Default.cs
@@ -1,6 +1,6 @@
 namespace DefaultRotations.Tank;
 
-[Rotation("Default", CombatType.PvE, GameVersion = "7.00")]
+[Rotation("Default", CombatType.PvE, GameVersion = "7.11")]
 [SourceCode(Path = "main/BasicRotations/Tank/GNB_Default.cs")]
 [Api(4)]
 public sealed class GNB_Default : GunbreakerRotation
@@ -103,7 +103,7 @@ public sealed class GNB_Default : GunbreakerRotation
 
         if (IsLastGCD(false, NobleBloodPvE) && LionHeartPvE.CanUse(out act, skipComboCheck: true)) return true;
         if (IsLastGCD(false, ReignOfBeastsPvE) && NobleBloodPvE.CanUse(out act, skipComboCheck: true)) return true;
-        if (ReignOfBeastsPvE.CanUse(out act)) return true;
+        if (ReignOfBeastsPvE.CanUse(out act, skipAoeCheck: true)) return true;
 
         if (Player.HasStatus(true, StatusID.NoMercy) && SonicBreakPvE.CanUse(out act)) return true;
 

--- a/RotationSolver.Basic/Rotations/Basic/GunbreakerRotation.cs
+++ b/RotationSolver.Basic/Rotations/Basic/GunbreakerRotation.cs
@@ -18,7 +18,7 @@ partial class GunbreakerRotation
 
     #region Job Gauge
     /// <summary>
-    /// 
+    /// Gets the amount of ammo available.
     /// </summary>
     public static byte Ammo => JobGauge.Ammo;
 
@@ -32,12 +32,18 @@ partial class GunbreakerRotation
     /// </summary>
     public static byte MaxAmmo => CartridgeChargeIiTrait.EnoughLevel ? (byte)3 : (byte)2;
 
+    /// <summary>
+    /// Gets the max combo time of the Gnashing Fang combo.
+    /// </summary>
+    public static short MaxTimerDuration => JobGauge.MaxTimerDuration;
+
     /// <inheritdoc/>
     public override void DisplayStatus()
     {
         ImGui.Text("Ammo: " + Ammo.ToString());
         ImGui.Text("AmmoComboStep: " + AmmoComboStep.ToString());
         ImGui.Text("MaxAmmo: " + MaxAmmo.ToString());
+        ImGui.Text("MaxTimerDuration: " + MaxTimerDuration.ToString());
     }
     #endregion
 

--- a/RotationSolver.SourceGenerators/RotationSolver.SourceGenerators.csproj
+++ b/RotationSolver.SourceGenerators/RotationSolver.SourceGenerators.csproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.11.0" />
+		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.12.0" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
Updated GNB_Default.cs to change GameVersion to 7.11 and modified ReignOfBeastsPvE.CanUse to include skipAoeCheck: true. Added MaxTimerDuration property to GunbreakerRotation class and updated DisplayStatus method to display it. Updated ECommons subproject commit and Microsoft.CodeAnalysis.CSharp package reference version in RotationSolver.SourceGenerators.csproj.