### PR TITLE
Add kenki configs and Zanshin prio toggle to SAM

### DIFF
--- a/BasicRotations/Melee/SAM_Default.cs
+++ b/BasicRotations/Melee/SAM_Default.cs
@@ -1,11 +1,34 @@
 ﻿namespace DefaultRotations.Melee;
 
-[Rotation("Default", CombatType.PvE, GameVersion = "7.11")]
+[Rotation("Default", CombatType.PvE, GameVersion = "7.15")]
 [SourceCode(Path = "main/BasicRotations/Melee/SAM_Default.cs")]
 [Api(4)]
 public sealed class SAM_Default : SamuraiRotation
 {
     #region Config Options
+
+    [Range(0, 100, ConfigUnitType.None, 1)]
+    [RotationConfig(CombatType.PvE, Name = "Kenki needed to use Shinten")]
+    public int ShintenKenki { get; set; } = 75;
+
+    [Range(0, 100, ConfigUnitType.None, 1)]
+    [RotationConfig(CombatType.PvE, Name = "Kenki needed to use Kyuten")]
+    public int KyutenKenki { get; set; } = 75;
+
+    [Range(0, 100, ConfigUnitType.None, 1)]
+    [RotationConfig(CombatType.PvE, Name = "Kenki needed to use Senei")]
+    public int SeneiKenki { get; set; } = 25;
+
+    [Range(0, 100, ConfigUnitType.None, 1)]
+    [RotationConfig(CombatType.PvE, Name = "Kenki needed to use Guren")]
+    public int GurenKenki { get; set; } = 25;
+
+    [Range(0, 100, ConfigUnitType.None, 1)]
+    [RotationConfig(CombatType.PvE, Name = "Kenki needed to use Zanshin")]
+    public int ZanshinKenki { get; set; } = 50;
+
+    [RotationConfig(CombatType.PvE, Name = "Prioritize Zanshin use over other Kenki abilties when available.")]
+    public bool ZanshinPrio { get; set; } = true;
 
     [RotationConfig(CombatType.PvE, Name = "Prevent Higanbana use if theres more than one target")]
     public bool HiganbanaTargets { get; set; } = false;
@@ -99,15 +122,15 @@ public sealed class SAM_Default : SamuraiRotation
             if (HagakurePvE.CanUse(out act)) return true;
         }
 
-        if (ZanshinPvE.CanUse(out act)) return true;
+        if (Kenki >= GurenKenki && ZanshinPvE.CanUse(out act)) return true;
 
         //ensures pooling Kenki for Zanshin if it's available
-        bool hasZanshinReady = Player.HasStatus(true, StatusID.ZanshinReady_3855);
+        bool hasZanshinReady = Player.HasStatus(true, StatusID.ZanshinReady_3855) && ZanshinPrio;
 
-        if (!hasZanshinReady && HissatsuGurenPvE.CanUse(out act, skipAoeCheck: !HissatsuSeneiPvE.EnoughLevel)) return true;
-        if (!hasZanshinReady && HissatsuSeneiPvE.CanUse(out act)) return true;
-        if (!hasZanshinReady && HissatsuKyutenPvE.CanUse(out act)) return true;
-        if (!hasZanshinReady && HissatsuShintenPvE.CanUse(out act)) return true;
+        if (!hasZanshinReady && Kenki >= GurenKenki && HissatsuGurenPvE.CanUse(out act, skipAoeCheck: !HissatsuSeneiPvE.EnoughLevel)) return true;
+        if (!hasZanshinReady && Kenki >= SeneiKenki && HissatsuSeneiPvE.CanUse(out act)) return true;
+        if (!hasZanshinReady && Kenki >= KyutenKenki && HissatsuKyutenPvE.CanUse(out act)) return true;
+        if (!hasZanshinReady && Kenki >= ShintenKenki && HissatsuShintenPvE.CanUse(out act)) return true;
 
         return base.AttackAbility(nextGCD, out act);
     }

--- a/RotationSolver.Basic/Rotations/Basic/SamuraiRotation.cs
+++ b/RotationSolver.Basic/Rotations/Basic/SamuraiRotation.cs
@@ -296,6 +296,10 @@ partial class SamuraiRotation
     {
         setting.ActionCheck = () => SenCount == 1 && MeditationStacks <= 2;
         setting.TargetStatusProvide = [StatusID.Higanbana];
+        setting.CreateConfig = () => new ActionConfig()
+        {
+            TimeToKill = 48,
+        };
     }
 
     static partial void ModifyTenkaGokenPvE(ref ActionSetting setting)


### PR DESCRIPTION
This pull request introduces several enhancements and adjustments to the Samurai rotation configuration and logic in the `BasicRotations/Melee/SAM_Default.cs` file. The key changes include updating the game version, adding new configuration options for Kenki abilities, and modifying the logic for ability usage based on Kenki thresholds and prioritization.

### Configuration Enhancements:
* Updated the game version for the Samurai rotation to "7.15". (`BasicRotations/Melee/SAM_Default.cs`)
* Added new configuration options for various Kenki abilities, including `Shinten`, `Kyuten`, `Senei`, `Guren`, and `Zanshin`. (`BasicRotations/Melee/SAM_Default.cs`)
* Introduced a configuration option to prioritize `Zanshin` usage over other Kenki abilities when available. (`BasicRotations/Melee/SAM_Default.cs`)

### Logic Adjustments:
* Modified the `AttackAbility` method to include checks for Kenki thresholds before using abilities such as `Zanshin`, `Guren`, `Senei`, `Kyuten`, and `Shinten`. (`BasicRotations/Melee/SAM_Default.cs`)
* Updated the `ModifyHiganbanaPvE` method to include a configuration for `TimeToKill`. (`RotationSolver.Basic/Rotations/Basic/SamuraiRotation.cs`)