### PR TITLE
Changes to MNK, BRD, and chat feedback

### DIFF
--- a/BasicRotations/Melee/MNK_Default.cs
+++ b/BasicRotations/Melee/MNK_Default.cs
@@ -1,6 +1,6 @@
 namespace DefaultRotations.Melee;
 
-[Rotation("Default", CombatType.PvE, GameVersion = "7.00", Description = "Uses Lunar Solar Opener from The Balance")]
+[Rotation("Default", CombatType.PvE, GameVersion = "7.15", Description = "Uses Lunar Solar Opener from The Balance")]
 [SourceCode(Path = "main/BasicRotations/Melee/MNK_Default.cs")]
 [Api(4)]
 
@@ -15,6 +15,9 @@ public sealed class MNK_Default : MonkRotation
 
     [RotationConfig(CombatType.PvE, Name = "Auto Use Perfect Balance (aoe aggressive PB dump, turn me off if you don't want to waste PB in boss fight)")]
     public bool AutoPB_AOE { get; set; } = true;
+
+    [RotationConfig(CombatType.PvE, Name = "Use Howling Fist as a ranged attack verses single target enemies")]
+    public bool HowlingSingle { get; set; } = false;
 
     [RotationConfig(CombatType.PvE, Name = "Enable TEA Checker.")]
     public bool EnableTEAChecker { get; set; } = false;
@@ -245,7 +248,7 @@ public sealed class MNK_Default : MonkRotation
 
         // i'm clever and i can do kame hame ha, so i won't stand still and keep refreshing form shift
         if (EnlightenmentPvE.CanUse(out act, skipAoeCheck: true)) return true; // Enlightment
-        if (HowlingFistPvE.CanUse(out act, skipAoeCheck: true)) return true; // Howling Fist
+        if (HowlingFistPvE.CanUse(out act, skipAoeCheck: HowlingSingle)) return true; // Howling Fist
 
         return base.GeneralGCD(out act);
     }

--- a/BasicRotations/Ranged/BRD_Default.cs
+++ b/BasicRotations/Ranged/BRD_Default.cs
@@ -1,6 +1,6 @@
 namespace DefaultRotations.Ranged;
 
-[Rotation("Default", CombatType.PvE, GameVersion = "7.11",
+[Rotation("Default", CombatType.PvE, GameVersion = "7.15",
     Description = "Please make sure that the three song times add up to 120 seconds, Wanderers default first song for now.")]
 [SourceCode(Path = "main/BasicRotations/Ranged/BRD_Default.cs")]
 [Api(4)]
@@ -153,7 +153,7 @@ public sealed class BRD_Default : BardRotation
 
         if (RadiantFinalePvE.EnoughLevel && RadiantFinalePvE.Cooldown.IsCoolingDown && BattleVoicePvE.EnoughLevel && !BattleVoicePvE.Cooldown.IsCoolingDown) return false;
 
-        if (Song != Song.NONE && EmpyrealArrowPvE.CanUse(out act)) return true;
+        if ((RagingStrikesPvE.Cooldown.IsCoolingDown || !RagingStrikesPvE.Cooldown.WillHaveOneCharge(15)) && Song != Song.NONE && EmpyrealArrowPvE.CanUse(out act)) return true;
 
         if (PitchPerfectPvE.CanUse(out act, skipCastingCheck: true, skipAoeCheck: true, skipComboCheck: true))
         {

--- a/RotationSolver.Basic/Configuration/Configs.cs
+++ b/RotationSolver.Basic/Configuration/Configs.cs
@@ -355,7 +355,7 @@ internal partial class Configs : IPluginConfiguration
         PvPFilter = JobFilterType.NoHealer, PvEFilter = JobFilterType.NoHealer)]
     private static readonly bool _onlyHealSelfWhenNoHealer = false;
 
-    [ConditionBool, UI("Show action toggle feedback in chat.",
+    [ConditionBool, UI("Show action toggled action and state feedback in chat.",
         Filter = UiInformation)]
     private static readonly bool _showToggledActionInChat = false;
 

--- a/RotationSolver/Commands/RSCommands_OtherCommand.cs
+++ b/RotationSolver/Commands/RSCommands_OtherCommand.cs
@@ -131,7 +131,10 @@ public static partial class RSCommands
             property.SetValue(Service.Config, convertedValue);
             command = convertedValue.ToString();
 
-            Svc.Chat.Print(string.Format(UiString.CommandsChangeSettingsValue.GetDescription(), property.Name, command));
+            if (Service.Config.ShowToggledActionInChat)
+            {
+                Svc.Chat.Print(string.Format(UiString.CommandsChangeSettingsValue.GetDescription(), property.Name, command));
+            }
 
             return;
         }
@@ -283,10 +286,13 @@ public static partial class RSCommands
         {
             if (config.DoCommand(configs, str))
             {
-                Svc.Chat.Print(string.Format(UiString.CommandsChangeSettingsValue.GetDescription(),
+                if (Service.Config.ShowToggledActionInChat)
+                {
+                    Svc.Chat.Print(string.Format(UiString.CommandsChangeSettingsValue.GetDescription(),
                     config.DisplayName, config.Value));
 
-                return;
+                    return;
+                }
             }
         }
 


### PR DESCRIPTION
This pull request includes several changes to the rotation configurations for the Monk and Bard classes, as well as some updates to the chat feedback functionality and configuration descriptions. The most important changes include adding a new configuration option for the Monk class, modifying the logic for using certain abilities, updating game version references, and enhancing chat feedback for toggled actions.

### Rotation Configuration Updates:

* [`BasicRotations/Melee/MNK_Default.cs`](diffhunk://#diff-c8f54622438b0935ab3c9c0d37c4ef394d8a28f6a371bdf821005760f98f7ca3R19-R21): Added a new configuration option `HowlingSingle` to control the use of Howling Fist as a ranged attack against single target enemies.
* [`BasicRotations/Melee/MNK_Default.cs`](diffhunk://#diff-c8f54622438b0935ab3c9c0d37c4ef394d8a28f6a371bdf821005760f98f7ca3L248-R251): Modified the logic in `GeneralGCD` to respect the new `HowlingSingle` configuration when using Howling Fist.
* [`BasicRotations/Ranged/BRD_Default.cs`](diffhunk://#diff-32d51b00c2413595ebf02ffcf158ea69662158220f85737637d079def6a74312L156-R156): Updated the condition for using Empyreal Arrow to include a check for the cooldown status of Raging Strikes.

### Game Version Updates:

* [`BasicRotations/Melee/MNK_Default.cs`](diffhunk://#diff-c8f54622438b0935ab3c9c0d37c4ef394d8a28f6a371bdf821005760f98f7ca3L3-R3): Updated the game version reference from `7.00` to `7.15` in the rotation attribute.
* [`BasicRotations/Ranged/BRD_Default.cs`](diffhunk://#diff-32d51b00c2413595ebf02ffcf158ea69662158220f85737637d079def6a74312L3-R3): Updated the game version reference from `7.11` to `7.15` in the rotation attribute.

### Chat Feedback Enhancements:

* [`RotationSolver/Commands/RSCommands_OtherCommand.cs`](diffhunk://#diff-6f34e5cd212cf642403b6a9931049b34e4a2576efe0313b67ae27fc3e2d34ab4R134-R137): Added logic to print feedback in chat when a setting is toggled, based on the `ShowToggledActionInChat` configuration. [[1]](diffhunk://#diff-6f34e5cd212cf642403b6a9931049b34e4a2576efe0313b67ae27fc3e2d34ab4R134-R137) [[2]](diffhunk://#diff-6f34e5cd212cf642403b6a9931049b34e4a2576efe0313b67ae27fc3e2d34ab4R288-R297)
* [`RotationSolver.Basic/Configuration/Configs.cs`](diffhunk://#diff-8146c07f057c08a985ecf11930f19a1ce5444efc69fcc45f0edd4e6c341dbe16L358-R358): Updated the description for the `ShowToggledActionInChat` configuration to clarify its purpose.