### PR TITLE
Attempt to fix mudra and fix for Ninki cap protection

### DIFF
--- a/RotationSolver.Basic/Configuration/Configs.cs
+++ b/RotationSolver.Basic/Configuration/Configs.cs
@@ -86,9 +86,6 @@ internal partial class Configs : IPluginConfiguration
     [UI("", Action = ActionID.PassageOfArmsPvE, Parent = nameof(PoslockCasting))]
     public bool PosPassageOfArms { get; set; } = false;
 
-    [UI("", Action = ActionID.TenChiJinPvE, Parent = nameof(PoslockCasting))]
-    public bool PosTenChiJin { get; set; } = true;
-
     [UI("", Action = ActionID.FlamethrowerPvE, Parent = nameof(PoslockCasting))]
     public bool PosFlameThrower { get; set; } = false;
 

--- a/RotationSolver.Basic/Rotations/Basic/NinjaRotation.cs
+++ b/RotationSolver.Basic/Rotations/Basic/NinjaRotation.cs
@@ -338,7 +338,7 @@ partial class NinjaRotation
 
     static partial void ModifySuitonPvE(ref ActionSetting setting)
     {
-        setting.StatusProvide = [StatusID.ShadowWalker];
+        //setting.StatusProvide = [StatusID.ShadowWalker];
     }
 
     static partial void ModifyGokaMekkyakuPvE(ref ActionSetting setting)

--- a/RotationSolver/Updaters/MovingUpdater.cs
+++ b/RotationSolver/Updaters/MovingUpdater.cs
@@ -31,11 +31,6 @@ internal static class MovingUpdater
                 statusList.Add(StatusID.Flamethrower);
                 actionList.Add(ActionID.FlameThrowerPvE);
             }
-            if (Service.Config.PosTenChiJin)
-            {
-                statusList.Add(StatusID.TenChiJin);
-                actionList.Add(ActionID.TenChiJinPvE);
-            }
             if (Service.Config.PosPassageOfArms)
             {
                 statusList.Add(StatusID.PassageOfArms);


### PR DESCRIPTION
This pull request includes several changes to the `BasicRotations/Melee/NIN_Default.cs` file and related files to update the Ninja rotation logic and configuration options. The most significant changes involve mudra, Ninki spending, and updating TenChiJin behaviour now that it no longer requires players stand still.

Updates to Ninja rotation logic and configuration:

* [`BasicRotations/Melee/NIN_Default.cs`](diffhunk://#diff-40e0f154b39c23ffccde39af86843b1915010db8c01b77c83f1395ec31890f08L3-R20): Updated the game version from `7.05` to `7.15` and added a new configuration option `MudraProtection` to prevent ghosting during mudra.
* [`BasicRotations/Melee/NIN_Default.cs`](diffhunk://#diff-40e0f154b39c23ffccde39af86843b1915010db8c01b77c83f1395ec31890f08L221-R226): Modified `DoNinjutsu` to include `skipStatusProvideCheck` when using `SuitonPvE_18881`.
* [`BasicRotations/Melee/NIN_Default.cs`](diffhunk://#diff-40e0f154b39c23ffccde39af86843b1915010db8c01b77c83f1395ec31890f08L343-R350): Adjusted `AttackAbility` to remove the movement check for `Ten Chi Jin` and added a condition to use `HellfrogMediumPvE` and `BhavacakraPvE` when `Ninki` is at 100, as well as an AOE skip check to account for the few levels between HellFrog and Bhavacakra. [[1]](diffhunk://#diff-40e0f154b39c23ffccde39af86843b1915010db8c01b77c83f1395ec31890f08L343-R350) [[2]](diffhunk://#diff-40e0f154b39c23ffccde39af86843b1915010db8c01b77c83f1395ec31890f08L371-R397)
* [`BasicRotations/Melee/NIN_Default.cs`](diffhunk://#diff-40e0f154b39c23ffccde39af86843b1915010db8c01b77c83f1395ec31890f08R414-R418): Added a condition to `GeneralGCD` to check for `MudraProtection` and call the base method if the last ability used was `TenPvE`, `ChiPvE`, or `JinPvE`.

Other changes:

* [`ECommons`](diffhunk://#diff-e347001520b30beb27d6d2af61f0ac96655dea8d449d396616012d03575182d9L1-R1): Updated the subproject commit reference.
* [`RotationSolver.Basic/Configuration/Configs.cs`](diffhunk://#diff-8146c07f057c08a985ecf11930f19a1ce5444efc69fcc45f0edd4e6c341dbe16L89-L91): Removed the configuration option `PosTenChiJin`.
* [`RotationSolver.Basic/Rotations/Basic/NinjaRotation.cs`](diffhunk://#diff-9879ef16fb849b32e8a2dd6f4b80a06b817f68cd349ed75c176709098ac89547L341-R341): Commented out the `StatusProvide` setting for `ModifySuitonPvE`.
* [`RotationSolver/Updaters/MovingUpdater.cs`](diffhunk://#diff-126568b3148aacab80d89190dfc92b2be2df2155a8bfa7286eea33ad92ab66e6L34-L38): Removed the handling of `TenChiJin` status and action in `UpdateCanMove`.