### PR TITLE
Forbidden chakra fix and Doton Mudra fix

### DIFF
--- a/BasicRotations/Melee/MNK_Default.cs
+++ b/BasicRotations/Melee/MNK_Default.cs
@@ -133,10 +133,8 @@ public sealed class MNK_Default : MonkRotation
             if (PerfectBalancePvE.CanUse(out act, usedUp: true)) return true;
         }
 
-        if (EnlightenmentPvE.CanUse(out act)) return true; // Enlightment
-        if (HowlingFistPvE.CanUse(out act)) return true; // Howling Fist
-        if (SteelPeakPvE.CanUse(out act)) return true;
         if (TheForbiddenChakraPvE.CanUse(out act)) return true;
+        if (SteelPeakPvE.CanUse(out act)) return true;
 
         // use bh when bh and rof are ready (opener) or ask bh to wait for rof's cd to be close and then use bh
         if (!CombatElapsedLessGCD(2)

--- a/BasicRotations/Melee/NIN_Default.cs
+++ b/BasicRotations/Melee/NIN_Default.cs
@@ -139,7 +139,7 @@ public sealed class NIN_Default : NinjaRotation
             //Aoe
             if (KatonPvE.CanUse(out _) && ChiPvE.CanUse(out _) && TenPvE.CanUse(out _))
             {
-                if (!Player.HasStatus(true, StatusID.Doton) && !IsMoving && !IsLastGCD(false, DotonPvE) && (!TenChiJinPvE.Cooldown.WillHaveOneCharge(6)) || !TenChiJinPvE.Cooldown.IsCoolingDown && TenPvE.CanUse(out _) && ChiPvE.CanUse(out _) && JinPvE.CanUse(out _))
+                if (!Player.HasStatus(true, StatusID.Doton) && !IsMoving && !IsLastGCD(false, DotonPvE) && (!TenChiJinPvE.Cooldown.WillHaveOneCharge(6)) || !Player.HasStatus(true, StatusID.Doton) && !TenChiJinPvE.Cooldown.IsCoolingDown && TenPvE.CanUse(out _) && ChiPvE.CanUse(out _) && JinPvE.CanUse(out _))
                     SetNinjutsu(DotonPvE);
                 else SetNinjutsu(KatonPvE);
                 return false;


### PR DESCRIPTION
This pull request includes changes to the `BasicRotations` module, specifically for the `MNK_Default` and `NIN_Default` classes. The changes involve reordering ability checks and refining conditions for using abilities.

Changes to ability checks:

* [`BasicRotations/Melee/MNK_Default.cs`](diffhunk://#diff-c8f54622438b0935ab3c9c0d37c4ef394d8a28f6a371bdf821005760f98f7ca3L136-R137): Reordered the check for `SteelPeakPvE` to be after `TheForbiddenChakraPvE` and removed the checks for `EnlightenmentPvE` and `HowlingFistPvE`.

Refinement of conditions:

* [`BasicRotations/Melee/NIN_Default.cs`](diffhunk://#diff-40e0f154b39c23ffccde39af86843b1915010db8c01b77c83f1395ec31890f08L142-R142): Refined the condition for setting `DotonPvE` by adding an additional check for `Player.HasStatus(true, StatusID.Doton)` before checking if `TenChiJinPvE.Cooldown` is cooling down.