### PR TITLE
Fix redundant checks on MNK causing delays for Masterful Blitz variant uses, added option to BRD to preserve the use of esuna for self

### DIFF
--- a/BasicRotations/Melee/MNK_Default.cs
+++ b/BasicRotations/Melee/MNK_Default.cs
@@ -1,5 +1,4 @@
 using System.ComponentModel;
-using static DefaultRotations.Magical.SMN_Default;
 
 namespace DefaultRotations.Melee;
 
@@ -92,7 +91,7 @@ public sealed class MNK_Default : MonkRotation
 
     protected override bool GeneralAbility(IAction nextGCD, out IAction? act)
     {
-        if (Player.WillStatusEnd(2.5f, true, StatusID.EarthsRumination) && EarthsReplyPvE.CanUse(out act)) return true;
+        if (Player.WillStatusEnd(5, true, StatusID.EarthsRumination) && EarthsReplyPvE.CanUse(out act)) return true;
         return base.GeneralAbility(nextGCD, out act);
     }
 
@@ -172,7 +171,7 @@ public sealed class MNK_Default : MonkRotation
         // use bh when bh and rof are ready (opener) or ask bh to wait for rof's cd to be close and then use bh
         if (!CombatElapsedLessGCD(2)
             && ((BrotherhoodPvE.IsInCooldown && RiddleOfFirePvE.IsInCooldown) || Math.Abs(BrotherhoodPvE.Cooldown.CoolDownGroup - RiddleOfFirePvE.Cooldown.CoolDownGroup) < 3)
-            && BrotherhoodPvE.CanUse(out act, skipAoeCheck: true)) return true;
+            && BrotherhoodPvE.CanUse(out act)) return true;
 
         // rof needs to be used on cd or after x gcd in opener
         if (!CombatElapsedLessGCD(3) && RiddleOfFirePvE.CanUse(out act)) return true; // Riddle Of Fire
@@ -227,18 +226,27 @@ public sealed class MNK_Default : MonkRotation
         // or if burst was missed, and next burst is not arriving in time, use it better than waste it, otherwise, hold it for next rof
         if (!BeastChakras.Contains(BeastChakra.NONE) && (Player.HasStatus(true, StatusID.RiddleOfFire) || RiddleOfFirePvE.Cooldown.JustUsedAfter(42)))
         {
-            // for some reason phantom doesn't count as a variation of masterful like the others
-            if (PhantomRushPvE.CanUse(out act, skipAoeCheck: true)) return true;
-            if (TornadoKickPvE.CanUse(out act, skipAoeCheck: true)) return true;
-            if (CelestialRevolutionPvE.CanUse(out act, skipAoeCheck: true)) return true; // shouldn't need this but who know what button the user may press
-            if (MasterfulBlitzPvE.CanUse(out act, skipAoeCheck: true)) return true;
+            // Both Nadi and 3 beasts
+            if (PhantomRushPvE.CanUse(out act)) return true;
+            if (TornadoKickPvE.CanUse(out act)) return true;
+
+            // Needing Solar Nadi and has 3 different beasts
+            if (RisingPhoenixPvE.CanUse(out act)) return true;
+            if (FlintStrikePvE.CanUse(out act)) return true;
+
+            // Needing Lunar Nadi and has 3 of the same beasts
+            if (ElixirBurstPvE.CanUse(out act)) return true;
+            if (ElixirFieldPvE.CanUse(out act)) return true;
+
+            // No Nadi and 3 beasts
+            if (CelestialRevolutionPvE.CanUse(out act)) return true;
         }
 
         // 'Because Fire¡¯s Reply grants formless, we have an imposed restriction that we prefer not to use it while under PB, or if we have a formless already.' + 'Cast Fire's Reply after an opo gcd'
         // need to test and see if IsLastGCD(false, ...) is better
-        if ((!Player.HasStatus(true, StatusID.PerfectBalance) && !Player.HasStatus(true, StatusID.FormlessFist) && IsLastGCD(true, DragonKickPvE, LeapingOpoPvE, BootshinePvE) || Player.WillStatusEnd(5, true, StatusID.FiresRumination)) && FiresReplyPvE.CanUse(out act, skipAoeCheck: true)) return true; // Fires Reply
+        if ((!Player.HasStatus(true, StatusID.PerfectBalance) && !Player.HasStatus(true, StatusID.FormlessFist) && IsLastGCD(true, DragonKickPvE, LeapingOpoPvE, BootshinePvE) || Player.WillStatusEnd(5, true, StatusID.FiresRumination)) && FiresReplyPvE.CanUse(out act)) return true; // Fires Reply
         // 'Cast Wind's Reply literally anywhere in the window'
-        if (!Player.HasStatus(true, StatusID.PerfectBalance) && WindsReplyPvE.CanUse(out act, skipAoeCheck: true)) return true; // Winds Reply
+        if ((!Player.HasStatus(true, StatusID.PerfectBalance) || Player.WillStatusEnd(5, true, StatusID.WindsRumination)) && WindsReplyPvE.CanUse(out act)) return true; // Winds Reply
 
         // Opo needs to follow each PB
         // 'This means ¡°bookending¡± any PB usage with opos and spending formless on opos.'

--- a/BasicRotations/Ranged/BRD_Default.cs
+++ b/BasicRotations/Ranged/BRD_Default.cs
@@ -30,6 +30,9 @@ public sealed class BRD_Default : BardRotation
     [RotationConfig(CombatType.PvE, Name = "First Song")]
     private Song FirstSong { get; set; } = Song.WANDERER;
 
+    [RotationConfig(CombatType.PvE, Name = "Use Warden's Paean on other players")]
+    public bool BRDEsuna { get; set; } = true;
+
     private float WANDRemainTime => 45 - WANDTime;
     private float MAGERemainTime => 45 - MAGETime;
     private float ARMYRemainTime => 45 - ARMYTime;
@@ -76,7 +79,7 @@ public sealed class BRD_Default : BardRotation
     [RotationDesc(ActionID.TheWardensPaeanPvE)]
     protected override bool DispelGCD(out IAction? act)
     {
-        if (TheWardensPaeanPvE.CanUse(out act)) return true;
+        if (BRDEsuna && TheWardensPaeanPvE.CanUse(out act)) return true;
         return base.DispelGCD(out act);
     }
 

--- a/RotationSolver.Basic/Rotations/Basic/MonkRotation.cs
+++ b/RotationSolver.Basic/Rotations/Basic/MonkRotation.cs
@@ -148,6 +148,7 @@ partial class MonkRotation
         setting.CreateConfig = () => new ActionConfig()
         {
             TimeToKill = 10,
+            AoeCount = 1,
         };
     }
 
@@ -240,11 +241,17 @@ partial class MonkRotation
     static partial void ModifyRiddleOfEarthPvE(ref ActionSetting setting)
     {
         setting.StatusProvide = [StatusID.RiddleOfEarth, StatusID.EarthsRumination];
+        setting.IsFriendly = true;
+        setting.CreateConfig = () => new ActionConfig()
+        {
+            AoeCount = 1,
+        };
     }
 
     static partial void ModifyEarthsReplyPvE(ref ActionSetting setting)
     {
         setting.StatusNeed = [StatusID.EarthsRumination];
+        setting.IsFriendly = true;
         setting.CreateConfig = () => new ActionConfig()
         {
             AoeCount = 1,
@@ -266,6 +273,7 @@ partial class MonkRotation
         setting.CreateConfig = () => new ActionConfig()
         {
             TimeToKill = 10,
+            AoeCount = 1,
         };
         setting.UnlockedByQuestID = 67966;
     }
@@ -289,7 +297,7 @@ partial class MonkRotation
         setting.ActionCheck = () => InCombat && Chakra == 5;
         setting.CreateConfig = () => new ActionConfig()
         {
-            AoeCount = 3,
+            AoeCount = 1,
         };
     }
 


### PR DESCRIPTION
This pull request includes several changes to the `BasicRotations` module, focusing on improving the Monk and Bard rotations. The most important changes include adjustments to ability conditions, the addition of new configuration options, and the removal of unnecessary parameters.

### Monk Rotation Adjustments:

* [`BasicRotations/Melee/MNK_Default.cs`](diffhunk://#diff-c8f54622438b0935ab3c9c0d37c4ef394d8a28f6a371bdf821005760f98f7ca3L95-R94): Modified the conditions for using `EarthsReplyPvE`, `BrotherhoodPvE`, and other abilities to ensure they are used more effectively. Removed `skipAoeCheck` parameter where it was unnecessary. [[1]](diffhunk://#diff-c8f54622438b0935ab3c9c0d37c4ef394d8a28f6a371bdf821005760f98f7ca3L95-R94) [[2]](diffhunk://#diff-c8f54622438b0935ab3c9c0d37c4ef394d8a28f6a371bdf821005760f98f7ca3L175-R174) [[3]](diffhunk://#diff-c8f54622438b0935ab3c9c0d37c4ef394d8a28f6a371bdf821005760f98f7ca3L230-R249)
* [`RotationSolver.Basic/Rotations/Basic/MonkRotation.cs`](diffhunk://#diff-4329964d5c7e9b451e6bcf0dac0480f29a253fccfcc762827ac14436ccc709aaR151): Added `AoeCount` to several action settings to better handle AoE scenarios. [[1]](diffhunk://#diff-4329964d5c7e9b451e6bcf0dac0480f29a253fccfcc762827ac14436ccc709aaR151) [[2]](diffhunk://#diff-4329964d5c7e9b451e6bcf0dac0480f29a253fccfcc762827ac14436ccc709aaR244-R254) [[3]](diffhunk://#diff-4329964d5c7e9b451e6bcf0dac0480f29a253fccfcc762827ac14436ccc709aaR276) [[4]](diffhunk://#diff-4329964d5c7e9b451e6bcf0dac0480f29a253fccfcc762827ac14436ccc709aaL292-R300)

### Bard Rotation Enhancements:

* [`BasicRotations/Ranged/BRD_Default.cs`](diffhunk://#diff-32d51b00c2413595ebf02ffcf158ea69662158220f85737637d079def6a74312R33-R35): Introduced a new configuration option `BRDEsuna` to allow `Warden's Paean` to be used on other players, improving the flexibility of the Bard's dispel ability. [[1]](diffhunk://#diff-32d51b00c2413595ebf02ffcf158ea69662158220f85737637d079def6a74312R33-R35) [[2]](diffhunk://#diff-32d51b00c2413595ebf02ffcf158ea69662158220f85737637d079def6a74312L79-R82)

### General Code Cleanup:

* [`BasicRotations/Melee/MNK_Default.cs`](diffhunk://#diff-c8f54622438b0935ab3c9c0d37c4ef394d8a28f6a371bdf821005760f98f7ca3L2): Removed unused `using` directive for `DefaultRotations.Magical.SMN_Default`.