### PR TITLE
Fixes to MNK chakra usage, fixes to DRK delirium combo

### DIFF
--- a/BasicRotations/Melee/MNK_Default.cs
+++ b/BasicRotations/Melee/MNK_Default.cs
@@ -165,6 +165,8 @@ public sealed class MNK_Default : MonkRotation
             if (PerfectBalancePvE.CanUse(out act, usedUp: true)) return true;
         }
 
+        if (EnlightenmentPvE.CanUse(out act)) return true; // Enlightment
+        if (HowlingFistPvE.CanUse(out act)) return true; // Howling Fist
         if (TheForbiddenChakraPvE.CanUse(out act)) return true;
         if (SteelPeakPvE.CanUse(out act)) return true;
 
@@ -178,8 +180,8 @@ public sealed class MNK_Default : MonkRotation
         // 'Use on cooldown, unless you know your killtime. You should aim to get as many casts of RoW as you can, and then shift those usages to align with burst as much as possible without losing a use.'
         if (!CombatElapsedLessGCD(3) && RiddleOfWindPvE.CanUse(out act)) return true; // Riddle Of Wind
 
-        if (EnlightenmentPvE.CanUse(out act, skipAoeCheck: HowlingSingle)) return true; // Enlightment
-        if (HowlingFistPvE.CanUse(out act, skipAoeCheck: HowlingSingle)) return true; // Howling Fist
+        if (HowlingSingle && EnlightenmentPvE.CanUse(out act, skipAoeCheck: true)) return true; // Enlightment
+        if (HowlingSingle && HowlingFistPvE.CanUse(out act, skipAoeCheck: true)) return true; // Howling Fist
 
         return base.AttackAbility(nextGCD, out act);
     }

--- a/BasicRotations/Tank/DRK_Default.cs
+++ b/BasicRotations/Tank/DRK_Default.cs
@@ -1,7 +1,7 @@
 namespace DefaultRotations.Tank;
 
-[Rotation("Default", CombatType.PvE, GameVersion = "7.05")]
-[SourceCode(Path = "main/BasicRotations/Tank/DRK_Balance.cs")]
+[Rotation("Default", CombatType.PvE, GameVersion = "7.15")]
+[SourceCode(Path = "main/BasicRotations/Tank/DRK_Default.cs")]
 [Api(4)]
 public sealed class DRK_Default : DarkKnightRotation
 {
@@ -136,27 +136,24 @@ public sealed class DRK_Default : DarkKnightRotation
     #region GCD Logic
     protected override bool GeneralGCD(out IAction? act)
     {
+
+        //AOE
         if (ImpalementPvE.CanUse(out act, skipComboCheck: true)) return true;
         if (QuietusPvE.CanUse(out act, skipComboCheck: true)) return true;
 
-        if (IsLastGCD(true, ComeuppancePvE) && TorcleaverPvE.CanUse(out act, skipComboCheck: true)) return true;
-        if (IsLastGCD(true, ScarletDeliriumPvE) && ComeuppancePvE.CanUse(out act, skipComboCheck: true)) return true;
-        if (ScarletDeliriumPvE.CanUse(out act, skipComboCheck: true)) return true;
-
+        if (TorcleaverPvE.CanUse(out act)) return true;
         if (DisesteemPvE.CanUse(out act)) return true;
 
         if (BloodspillerPvE.CanUse(out act, skipComboCheck: true)) return true;
-
-
 
         //AOE
         if (StalwartSoulPvE.CanUse(out act)) return true;
         if (UnleashPvE.CanUse(out act)) return true;
 
         //Single Target
-        if (SouleaterPvE.CanUse(out act)) return true;
-        if (SyphonStrikePvE.CanUse(out act)) return true;
-        if (HardSlashPvE.CanUse(out act)) return true;
+        if (DeliriumStacks == 0 && LowDeliriumStacks == 0 && SouleaterPvE.CanUse(out act)) return true;
+        if (DeliriumStacks == 0 && LowDeliriumStacks == 0 && SyphonStrikePvE.CanUse(out act)) return true;
+        if (DeliriumStacks == 0 && LowDeliriumStacks == 0 && HardSlashPvE.CanUse(out act)) return true;
 
         if (UnmendPvE.CanUse(out act)) return true;
 

--- a/RotationSolver.Basic/Rotations/Basic/DarkKnightRotation.cs
+++ b/RotationSolver.Basic/Rotations/Basic/DarkKnightRotation.cs
@@ -333,17 +333,17 @@ partial class DarkKnightRotation
 
     static partial void ModifyScarletDeliriumPvE(ref ActionSetting setting)
     {
-        setting.ActionCheck = () => !Player.WillStatusEnd(0, true, StatusID.Delirium_3836);
+        
     }
 
     static partial void ModifyComeuppancePvE(ref ActionSetting setting)
     {
-        setting.ActionCheck = () => !Player.WillStatusEnd(0, true, StatusID.Delirium_3836);
+        
     }
 
     static partial void ModifyTorcleaverPvE(ref ActionSetting setting)
     {
-        setting.ActionCheck = () => !Player.WillStatusEnd(0, true, StatusID.Delirium_3836);
+        
     }
 
     static partial void ModifyImpalementPvE(ref ActionSetting setting)


### PR DESCRIPTION
This pull request includes several changes to the `BasicRotations` module, focusing on the `Melee` and `Tank` classes, as well as an update to a subproject commit. The most important changes include adding new abilities to the `MNK_Default` rotation, updating the `DRK_Default` rotation logic, and modifying the game version and source code path for the `DRK_Default` class.

### Changes to `MNK_Default` rotation:

* Added `EnlightenmentPvE` and `HowlingFistPvE` abilities to the `AttackAbility` method.
* Adjusted the conditions for using `EnlightenmentPvE` and `HowlingFistPvE` abilities when `HowlingSingle` is true.

### Changes to `DRK_Default` rotation:

* Updated the game version to "7.15" and corrected the source code path in the `DRK_Default` class definition.
* Refined the `GeneralGCD` method to include new AOE logic and adjusted conditions for using `SouleaterPvE`, `SyphonStrikePvE`, and `HardSlashPvE` abilities based on `DeliriumStacks` and `LowDeliriumStacks`.

### Other changes:

* Updated the subproject commit for `ECommons`.
* Removed action checks for `ScarletDeliriumPvE`, `ComeuppancePvE`, and `TorcleaverPvE` in `DarkKnightRotation`.