### PR TITLE
delirium core fixes, verified rotation no longer hangs

### DIFF
--- a/BasicRotations/Tank/DRK_Default.cs
+++ b/BasicRotations/Tank/DRK_Default.cs
@@ -136,13 +136,16 @@ public sealed class DRK_Default : DarkKnightRotation
     #region GCD Logic
     protected override bool GeneralGCD(out IAction? act)
     {
-
-        //AOE
-        if (ImpalementPvE.CanUse(out act, skipComboCheck: true)) return true;
-        if (QuietusPvE.CanUse(out act, skipComboCheck: true)) return true;
-
-        if (TorcleaverPvE.CanUse(out act)) return true;
         if (DisesteemPvE.CanUse(out act)) return true;
+
+        //AOE Delirium
+        if (ImpalementPvE.CanUse(out act)) return true;
+        if (QuietusPvE.CanUse(out act)) return true;
+
+        // Single Target Delirium
+        if (TorcleaverPvE.CanUse(out act, skipComboCheck: true)) return true;
+        if (ComeuppancePvE.CanUse(out act, skipComboCheck: true)) return true;
+        if (ScarletDeliriumPvE.CanUse(out act, skipComboCheck: true)) return true;
 
         if (BloodspillerPvE.CanUse(out act, skipComboCheck: true)) return true;
 
@@ -151,9 +154,9 @@ public sealed class DRK_Default : DarkKnightRotation
         if (UnleashPvE.CanUse(out act)) return true;
 
         //Single Target
-        if (DeliriumStacks == 0 && LowDeliriumStacks == 0 && SouleaterPvE.CanUse(out act)) return true;
-        if (DeliriumStacks == 0 && LowDeliriumStacks == 0 && SyphonStrikePvE.CanUse(out act)) return true;
-        if (DeliriumStacks == 0 && LowDeliriumStacks == 0 && HardSlashPvE.CanUse(out act)) return true;
+        if (!HasDelirium && SouleaterPvE.CanUse(out act)) return true;
+        if (!HasDelirium && SyphonStrikePvE.CanUse(out act)) return true;
+        if (!HasDelirium && HardSlashPvE.CanUse(out act)) return true;
 
         if (UnmendPvE.CanUse(out act)) return true;
 

--- a/RotationSolver.Basic/Rotations/Basic/DarkKnightRotation.cs
+++ b/RotationSolver.Basic/Rotations/Basic/DarkKnightRotation.cs
@@ -17,6 +17,31 @@ partial class DarkKnightRotation
     /// 
     /// </summary>
     public static bool HasDarkArts => JobGauge.HasDarkArts;
+    
+    /// <summary>
+    /// 
+    /// </summary>
+    public static bool HasDelirium => !Player.WillStatusEnd(0, true, StatusID.Delirium_3836);
+
+    /// <summary>
+    /// 
+    /// </summary>
+    public static bool ScarletDeliriumReady => Service.GetAdjustedActionId(ActionID.BloodspillerPvE) == ActionID.ScarletDeliriumPvE;
+
+    /// <summary>
+    /// 
+    /// </summary>
+    public static bool ComeuppanceReady => Service.GetAdjustedActionId(ActionID.BloodspillerPvE) == ActionID.ComeuppancePvE;
+
+    /// <summary>
+    /// 
+    /// </summary>
+    public static bool TorcleaverReady => Service.GetAdjustedActionId(ActionID.BloodspillerPvE) == ActionID.TorcleaverPvE;
+
+    /// <summary>
+    /// 
+    /// </summary>
+    public static bool ImpalementReady => Service.GetAdjustedActionId(ActionID.QuietusPvE) == ActionID.ImpalementPvE;
 
     static float DarkSideTimeRemainingRaw => JobGauge.DarksideTimeRemaining / 1000f;
 
@@ -110,6 +135,11 @@ partial class DarkKnightRotation
         ImGui.Text("DarkSideTime: " + DarkSideTime.ToString());
         ImGui.Text("HasDarkArts: " + HasDarkArts.ToString());
         ImGui.Text("Blood: " + Blood.ToString());
+        ImGui.Text("HasDelirium: " + HasDelirium.ToString());
+        ImGui.Text("ScarletDeliriumReady: " + ScarletDeliriumReady.ToString());
+        ImGui.Text("ComeuppanceReady: " + ComeuppanceReady.ToString());
+        ImGui.Text("TorcleaverReady: " + TorcleaverReady.ToString());
+        ImGui.Text("ImpalementReady: " + ImpalementReady.ToString());
     }
     #endregion
 
@@ -333,22 +363,27 @@ partial class DarkKnightRotation
 
     static partial void ModifyScarletDeliriumPvE(ref ActionSetting setting)
     {
-        
+        setting.ActionCheck = () => ScarletDeliriumReady;
+        setting.MPOverride = () => 0;
     }
 
     static partial void ModifyComeuppancePvE(ref ActionSetting setting)
     {
-        
+        setting.ActionCheck = () => ComeuppanceReady;
+        setting.MPOverride = () => 0;
+        setting.ComboIds = [ActionID.ScarletDeliriumPvE];
     }
 
     static partial void ModifyTorcleaverPvE(ref ActionSetting setting)
     {
-        
+        setting.ActionCheck = () => TorcleaverReady;
+        setting.MPOverride = () => 0;
+        setting.ComboIds = [ActionID.ComeuppancePvE];
     }
 
     static partial void ModifyImpalementPvE(ref ActionSetting setting)
     {
-        setting.ActionCheck = () => !Player.WillStatusEnd(0, true, StatusID.Delirium_3836);
+        setting.ActionCheck = () => ImpalementReady;
         setting.CreateConfig = () => new ActionConfig()
         {
             AoeCount = 2,
@@ -358,6 +393,7 @@ partial class DarkKnightRotation
     static partial void ModifyDisesteemPvE(ref ActionSetting setting)
     {
         setting.StatusNeed = [StatusID.Scorn];
+        setting.MPOverride = () => 0;
         setting.CreateConfig = () => new ActionConfig()
         {
             AoeCount = 1,


### PR DESCRIPTION
This pull request includes enhancements to the Dark Knight rotation logic in `DRK_Default.cs` and `DarkKnightRotation.cs`. The changes focus on improving the handling of Delirium status and adjusting action checks for various abilities.

Enhancements to Delirium handling and action checks:

* [`BasicRotations/Tank/DRK_Default.cs`](diffhunk://#diff-064f781a95040a36748b8a0301ee33562f73a3452a30b87d0bd8b5500ab32d96R139-R148): Reorganized the GCD logic to better handle Delirium status and added new action checks for `DisesteemPvE`, `ComeuppancePvE`, and `ScarletDeliriumPvE`. [[1]](diffhunk://#diff-064f781a95040a36748b8a0301ee33562f73a3452a30b87d0bd8b5500ab32d96R139-R148) [[2]](diffhunk://#diff-064f781a95040a36748b8a0301ee33562f73a3452a30b87d0bd8b5500ab32d96L154-R159)

* [`RotationSolver.Basic/Rotations/Basic/DarkKnightRotation.cs`](diffhunk://#diff-ecd9f64077bcd927c9d821bbd2c8afae56fc79b5f881f3089103393ddd8b5af5R21-R45): Introduced new properties such as `HasDelirium`, `ScarletDeliriumReady`, `ComeuppanceReady`, `TorcleaverReady`, and `ImpalementReady` to streamline action checks.

* [`RotationSolver.Basic/Rotations/Basic/DarkKnightRotation.cs`](diffhunk://#diff-ecd9f64077bcd927c9d821bbd2c8afae56fc79b5f881f3089103393ddd8b5af5R138-R142): Updated the `DisplayStatus` method to include the new properties for better debugging and status display.

* [`RotationSolver.Basic/Rotations/Basic/DarkKnightRotation.cs`](diffhunk://#diff-ecd9f64077bcd927c9d821bbd2c8afae56fc79b5f881f3089103393ddd8b5af5L336-R386): Modified action settings for `ScarletDeliriumPvE`, `ComeuppancePvE`, `TorcleaverPvE`, and `ImpalementPvE` to use the new properties and ensure proper action execution. [[1]](diffhunk://#diff-ecd9f64077bcd927c9d821bbd2c8afae56fc79b5f881f3089103393ddd8b5af5L336-R386) [[2]](diffhunk://#diff-ecd9f64077bcd927c9d821bbd2c8afae56fc79b5f881f3089103393ddd8b5af5R396)