### PR TITLE
Fixed tincture bug from lumina update

### DIFF
--- a/RotationSolver.Basic/Actions/MedicineItem.cs
+++ b/RotationSolver.Basic/Actions/MedicineItem.cs
@@ -44,7 +44,7 @@ internal class MedicineItem : BaseItem
 
     public MedicineItem(Item item) : base(item)
     {
-        Type = _item.Icon switch // used to be Unknown19, not entirely sure if Icon is the correct property to use
+        Type = _item.Unknown4 switch // Unknown4 is column for the medicine type
         {
             10120 => MedicineType.Strength,
             10140 => MedicineType.Dexterity,
@@ -55,5 +55,5 @@ internal class MedicineItem : BaseItem
         };
     }
 
-    protected override bool CanUseThis => DataCenter.RightNowTinctureUseType == TinctureUseType.Anywhere || DataCenter.RightNowTinctureUseType == TinctureUseType.InHighEndDuty;
+    protected override bool CanUseThis => DataCenter.RightNowTinctureUseType == TinctureUseType.Anywhere || (DataCenter.RightNowTinctureUseType == TinctureUseType.InHighEndDuty && DataCenter.IsInHighEndDuty);
 }


### PR DESCRIPTION
This pull request includes changes to the `MedicineItem` class in the `RotationSolver.Basic/Actions/MedicineItem.cs` file to improve the accuracy of determining medicine types and conditions for usage.

Improvements to medicine type determination:

* Changed the property used to determine the medicine type from `_item.Icon` to `_item.Unknown4`, which is the correct column for this information.

Enhancements to usage conditions:

* Updated the `CanUseThis` property to include an additional condition that checks if the user is in a high-end duty when the `RightNowTinctureUseType` is set to `InHighEndDuty`.