### PR TITLE
Adjustments to abilites that use or provide ShadowWalker

### DIFF
--- a/BasicRotations/Melee/NIN_Default.cs
+++ b/BasicRotations/Melee/NIN_Default.cs
@@ -126,7 +126,7 @@ public sealed class NIN_Default : NinjaRotation
         {
             // If Suiton is active but no specific Ninjutsu is currently aimed, it clears the Ninjutsu aim.
             // This check is relevant for managing Suiton's effect, particularly for enabling Trick Attack.
-            if (Player.HasStatus(true, StatusID.Suiton)
+            if (Player.HasStatus(true, StatusID.ShadowWalker)
                 && _ninActionAim == SuitonPvE && NoNinjutsu)
             {
                 ClearNinjutsu();
@@ -145,15 +145,8 @@ public sealed class NIN_Default : NinjaRotation
                 return false;
             }
 
-            //Vulnerable
-            if (IsBurst && TrickAttackPvE.Cooldown.WillHaveOneCharge(18) && SuitonPvE.CanUse(out _) && !Player.HasStatus(true, StatusID.Suiton) && TenPvE.CanUse(out _) && ChiPvE.CanUse(out _) && JinPvE.CanUse(out _))
-            {
-                SetNinjutsu(SuitonPvE);
-                return false;
-            }
-
             //Single
-            if (TenPvE.CanUse(out _, usedUp: InTrickAttack && !Player.HasStatus(false, StatusID.RaijuReady)))
+            if (!ShadowWalkerNeeded && TenPvE.CanUse(out _, usedUp: InTrickAttack && !Player.HasStatus(false, StatusID.RaijuReady)))
             {
                 if (RaitonPvE.CanUse(out _) && TenPvE.CanUse(out _) && ChiPvE.CanUse(out _))
                 {
@@ -166,6 +159,13 @@ public sealed class NIN_Default : NinjaRotation
                     SetNinjutsu(FumaShurikenPvE);
                     return false;
                 }
+            }
+
+            //Vulnerable
+            if (ShadowWalkerNeeded && !Player.HasStatus(true, StatusID.TenChiJin) && SuitonPvE.CanUse(out _, skipStatusProvideCheck: false) && TenPvE.CanUse(out _) && ChiPvE.CanUse(out _) && JinPvE.CanUse(out _))
+            {
+                SetNinjutsu(SuitonPvE);
+                return false;
             }
         }
 
@@ -316,7 +316,7 @@ public sealed class NIN_Default : NinjaRotation
         if (!NoNinjutsu || !InCombat) return base.EmergencyAbility(nextGCD, out act);
 
         // First priority is given to Kassatsu if it's available, allowing for an immediate powerful Ninjutsu.
-        if (KassatsuPvE.CanUse(out act)) return true;
+        if (NoNinjutsu && KassatsuPvE.CanUse(out act)) return true;
 
         if (TenriJindoPvE.CanUse(out act)) return true;
 

--- a/RotationSolver.Basic/Rotations/Basic/NinjaRotation.cs
+++ b/RotationSolver.Basic/Rotations/Basic/NinjaRotation.cs
@@ -22,6 +22,11 @@ partial class NinjaRotation
     public static bool HasJin => IncreaseAttackSpeedTrait.EnoughLevel;
 
     /// <summary>
+    /// Do you need to prep or currently use shadowwalker
+    /// </summary>
+    public bool ShadowWalkerNeeded => TrickAttackPvE.Cooldown.WillHaveOneCharge(18) || KunaisBanePvE.Cooldown.WillHaveOneCharge(18) || MeisuiPvE.Cooldown.WillHaveOneCharge(18);
+
+    /// <summary>
     /// Determines if Trick Attack is in its effective period.
     /// </summary>
     public bool InTrickAttack => (KunaisBanePvE.Cooldown.IsCoolingDown || TrickAttackPvE.Cooldown.IsCoolingDown) && (!KunaisBanePvE.Cooldown.ElapsedAfter(17) || !TrickAttackPvE.Cooldown.ElapsedAfter(17));
@@ -36,6 +41,18 @@ partial class NinjaRotation
     /// </summary>
     public static bool NoNinjutsu => AdjustId(ActionID.NinjutsuPvE) is ActionID.NinjutsuPvE or ActionID.RabbitMediumPvE;
 
+    /// <summary>
+    /// Holds the remaining amount of Delirium stacks
+    /// </summary>
+    public static byte RaijuStacks
+    {
+        get
+        {
+            byte stacks = Player.StatusStack(true, StatusID.RaijuReady);
+            return stacks == byte.MaxValue ? (byte)3 : stacks;
+        }
+    }
+
     /// <inheritdoc/>
     public override void DisplayStatus()
     {
@@ -45,6 +62,8 @@ partial class NinjaRotation
         ImGui.Text($"InTrickAttack: {InTrickAttack}");
         ImGui.Text($"InMug: {InMug}");
         ImGui.Text($"NoNinjutsu: {NoNinjutsu}");
+        ImGui.Text($"RaijuStacks: {RaijuStacks}");
+        ImGui.Text($"ShadowWalkerNeeded: {ShadowWalkerNeeded}");
     }
     #endregion
 
@@ -310,7 +329,7 @@ partial class NinjaRotation
 
     static partial void ModifyRaitonPvE(ref ActionSetting setting)
     {
-        setting.StatusProvide = [StatusID.RaijuReady];
+        //setting.StatusProvide = [StatusID.RaijuReady];
     }
 
     static partial void ModifyHyotonPvE(ref ActionSetting setting)
@@ -338,7 +357,7 @@ partial class NinjaRotation
 
     static partial void ModifySuitonPvE(ref ActionSetting setting)
     {
-        //setting.StatusProvide = [StatusID.ShadowWalker];
+        setting.StatusProvide = [StatusID.ShadowWalker];
     }
 
     static partial void ModifyGokaMekkyakuPvE(ref ActionSetting setting)


### PR DESCRIPTION
This pull request includes several changes to improve the Ninja class's rotation logic in the `BasicRotations` module. The most important changes involve updating the handling of the `ShadowWalker` status, adding new properties, and modifying the behavior of certain abilities.

### Updates to handling of `ShadowWalker` status:

* [`BasicRotations/Melee/NIN_Default.cs`](diffhunk://#diff-40e0f154b39c23ffccde39af86843b1915010db8c01b77c83f1395ec31890f08L129-R129): Updated the `ChoiceNinjutsu` method to check for `ShadowWalker` status instead of `Suiton` and added logic to handle `ShadowWalkerNeeded`. [[1]](diffhunk://#diff-40e0f154b39c23ffccde39af86843b1915010db8c01b77c83f1395ec31890f08L129-R129) [[2]](diffhunk://#diff-40e0f154b39c23ffccde39af86843b1915010db8c01b77c83f1395ec31890f08L148-R149) [[3]](diffhunk://#diff-40e0f154b39c23ffccde39af86843b1915010db8c01b77c83f1395ec31890f08R163-R169)
* [`BasicRotations/Melee/NIN_Default.cs`](diffhunk://#diff-40e0f154b39c23ffccde39af86843b1915010db8c01b77c83f1395ec31890f08L319-R319): Modified the `EmergencyAbility` method to include a check for `NoNinjutsu` before using `KassatsuPvE`.

### New properties and status display:

* [`RotationSolver.Basic/Rotations/Basic/NinjaRotation.cs`](diffhunk://#diff-9879ef16fb849b32e8a2dd6f4b80a06b817f68cd349ed75c176709098ac89547R24-R28): Added `ShadowWalkerNeeded` property to determine if `ShadowWalker` needs to be prepped or used.
* [`RotationSolver.Basic/Rotations/Basic/NinjaRotation.cs`](diffhunk://#diff-9879ef16fb849b32e8a2dd6f4b80a06b817f68cd349ed75c176709098ac89547R44-R55): Added `RaijuStacks` property to hold the remaining amount of `Delirium` stacks.
* [`RotationSolver.Basic/Rotations/Basic/NinjaRotation.cs`](diffhunk://#diff-9879ef16fb849b32e8a2dd6f4b80a06b817f68cd349ed75c176709098ac89547R65-R66): Updated `DisplayStatus` method to include `RaijuStacks` and `ShadowWalkerNeeded`.

### Modifications to ability settings:

* [`RotationSolver.Basic/Rotations/Basic/NinjaRotation.cs`](diffhunk://#diff-9879ef16fb849b32e8a2dd6f4b80a06b817f68cd349ed75c176709098ac89547L341-R360): Updated `ModifySuitonPvE` to provide the `ShadowWalker` status.
* [`RotationSolver.Basic/Rotations/Basic/NinjaRotation.cs`](diffhunk://#diff-9879ef16fb849b32e8a2dd6f4b80a06b817f68cd349ed75c176709098ac89547L313-R332): Commented out the status provision for `RaijuReady` in `ModifyRaitonPvE`.