### PR TITLE
Complete rework of BLM PVP

### DIFF
--- a/BasicRotations/PVPRotations/Magical/BLM_Default.PVP.cs
+++ b/BasicRotations/PVPRotations/Magical/BLM_Default.PVP.cs
@@ -1,6 +1,6 @@
 ﻿namespace DefaultRotations.Magical;
 
-[Rotation("Default PVP", CombatType.PvP, GameVersion = "7.00", Description = "Beta Rotation")]
+[Rotation("Default PVP", CombatType.PvP, GameVersion = "7.15", Description = "Beta Rotation")]
 [SourceCode(Path = "main/BasicRotations/PVPRotations/Magical/BLM_Default.PVP.cs")]
 [Api(4)]
 public class BLM_DefaultPVP : BlackMageRotation
@@ -42,6 +42,8 @@ public class BLM_DefaultPVP : BlackMageRotation
     [RotationConfig(CombatType.PvP, Name = "Stop attacking while in Guard.")]
     public bool GuardCancel { get; set; } = false;
 
+    protected static bool HalfHeathXeno => Player.CurrentHp >= 27000;
+
     private bool TryPurify(out IAction? action)
     {
         action = null;
@@ -79,10 +81,25 @@ public class BLM_DefaultPVP : BlackMageRotation
         return base.EmergencyAbility(nextGCD, out act);
     }
 
+    protected override bool MoveForwardAbility(IAction nextGCD, out IAction? act)
+    {
+        act = null;
+        if (GuardCancel && Player.HasStatus(true, StatusID.Guard)) return false;
+
+        if (AetherialManipulationPvP.CanUse(out act)) return true;
+
+        return base.MoveForwardAbility(nextGCD, out act);
+    }
+
     protected override bool AttackAbility(IAction nextGCD, out IAction? act)
     {
         act = null;
         if (GuardCancel && Player.HasStatus(true, StatusID.Guard)) return false;
+
+        if (XenoglossyPvP.CanUse(out act)) return true;
+        if (LethargyPvP.CanUse(out act)) return true;
+        if (WreathOfFirePvP.CanUse(out act)) return true;
+        if (WreathOfIcePvP.CanUse(out act)) return true;
 
         return base.AttackAbility(nextGCD, out act);
     }
@@ -91,8 +108,6 @@ public class BLM_DefaultPVP : BlackMageRotation
     {
         act = null;
         if (GuardCancel && Player.HasStatus(true, StatusID.Guard)) return false;
-
-        if (AetherialManipulationPvP.CanUse(out act)) return true;
 
         return base.GeneralAbility(nextGCD, out act);
     }
@@ -104,11 +119,24 @@ public class BLM_DefaultPVP : BlackMageRotation
         if (GuardCancel && Player.HasStatus(true, StatusID.Guard)) return false;
         if (!Player.HasStatus(true, StatusID.Guard) && UseSprintPvP && !Player.HasStatus(true, StatusID.Sprint) && !InCombat && SprintPvP.CanUse(out act)) return true;
 
-        if (BurstPvP.CanUse(out act)) return true;
+        if (XenoglossyPvP.CanUse(out act, usedUp: !HalfHeathXeno)) return true;
 
         if (ParadoxPvP.CanUse(out act)) return true;
 
+        if (BurstPvP.CanUse(out act)) return true;
+
+        if (FlareStarPvP.CanUse(out act)) return true;
+        if (FlarePvP.CanUse(out act)) return true;
+        if (HighFireIiPvP.CanUse(out act)) return true;
+        if (FireIvPvP.CanUse(out act)) return true;
+        if (FireIiiPvP.CanUse(out act)) return true;
         if (FirePvP.CanUse(out act)) return true;
+
+        if (FrostStarPvP.CanUse(out act)) return true;
+        if (FreezePvP.CanUse(out act)) return true;
+        if (HighBlizzardIiPvP.CanUse(out act)) return true;
+        if (BlizzardIvPvP.CanUse(out act)) return true;
+        if (BlizzardIiiPvP.CanUse(out act)) return true;
         if (BlizzardPvP.CanUse(out act)) return true;
 
         return base.GeneralGCD(out act);

--- a/RotationSolver.Basic/Rotations/Basic/BlackMageRotation.cs
+++ b/RotationSolver.Basic/Rotations/Basic/BlackMageRotation.cs
@@ -101,19 +101,23 @@ partial class BlackMageRotation
     /// <returns></returns>
     protected static bool ElementTimeEndAfterGCD(uint gctCount = 0, float offset = 0)
         => ElementTimeEndAfter(GCDTime(gctCount, offset));
-    #endregion
-
 
     /// <summary>
     /// 
     /// </summary>
-    protected static bool HasFire => Player.HasStatus(true, StatusID.Firestarter);
+    protected static float Fire4Time { get; private set; }
 
     /// <summary>
     /// 
     /// </summary>
-    protected static bool HasThunder => Player.HasStatus(true, StatusID.Thunderhead);
-
+    protected override void UpdateInfo()
+    {
+        if (Player.CastActionId == (uint)ActionID.FireIvPvE && Player.CurrentCastTime < 0.2)
+        {
+            Fire4Time = Player.TotalCastTime;
+        }
+        base.UpdateInfo();
+    }
 
     /// <summary>
     /// A check with variable max stacks of Polyglot based on the trait level.
@@ -136,7 +140,31 @@ partial class BlackMageRotation
             }
         }
     }
+    #endregion
 
+    #region Status Tracking
+    /// <summary>
+    /// 
+    /// </summary>
+    protected static bool HasPvPAstralFire => Player.HasStatus(true, StatusID.AstralFire_3212, StatusID.AstralFireIi_3213, StatusID.AstralFireIii_3381);
+
+    /// <summary>
+    /// 
+    /// </summary>
+    protected static bool HasPvPUmbralIce => Player.HasStatus(true, StatusID.UmbralIce_3214, StatusID.UmbralIceIi_3215, StatusID.UmbralIceIii_3382);
+
+    /// <summary>
+    /// 
+    /// </summary>
+    protected static bool HasFire => Player.HasStatus(true, StatusID.Firestarter);
+
+    /// <summary>
+    /// 
+    /// </summary>
+    protected static bool HasThunder => Player.HasStatus(true, StatusID.Thunderhead);
+    #endregion
+
+    #region Debug
     /// <inheritdoc/>
     public override void DisplayStatus()
     {
@@ -155,7 +183,12 @@ partial class BlackMageRotation
         ImGui.Text("IsEnochianActive: " + IsEnochianActive.ToString());
         ImGui.Text("EnochianTimeRaw: " + EnochianTimeRaw.ToString());
         ImGui.Text("EnochianTime: " + EnochianTime.ToString());
+        ImGui.Text("HasPvPAstralFire: " + HasPvPAstralFire.ToString());
+        ImGui.Text("HasPvPUmbralIce: " + HasPvPUmbralIce.ToString());
     }
+    #endregion
+
+    #region PvE Actions
 
     static partial void ModifyBlizzardPvE(ref ActionSetting setting)
     {
@@ -399,27 +432,158 @@ partial class BlackMageRotation
             AoeCount = 1,
         };
     }
+    #endregion
+
+    #region PvP Actions Unassignable
+    /// <summary>
+    /// 
+    /// </summary>
+    public static bool WreathOfFireReady => Service.GetAdjustedActionId(ActionID.ElementalWeavePvP) == ActionID.WreathOfFirePvP;
 
     /// <summary>
     /// 
     /// </summary>
-    protected static float Fire4Time { get; private set; }
+    public static bool WreathOfIceReady => Service.GetAdjustedActionId(ActionID.ElementalWeavePvP) == ActionID.WreathOfIcePvP;
+    #endregion
 
-    /// <summary>
-    /// 
-    /// </summary>
-    protected override void UpdateInfo()
+    #region PvP Actions
+    static partial void ModifyFirePvP(ref ActionSetting setting)
     {
-        if (Player.CastActionId == (uint)ActionID.FireIvPvE && Player.CurrentCastTime < 0.2)
-        {
-            Fire4Time = Player.TotalCastTime;
-        }
-        base.UpdateInfo();
+        setting.StatusProvide = [StatusID.Paradox, StatusID.AstralFire_3212];
     }
 
-    // PvP
+    static partial void ModifyBlizzardPvP(ref ActionSetting setting)
+    {
+        setting.StatusProvide = [StatusID.Paradox, StatusID.UmbralIce_3214];
+    }
+
+    static partial void ModifyBurstPvP(ref ActionSetting setting)
+    {
+        setting.CreateConfig = () => new ActionConfig()
+        {
+            AoeCount = 1,
+        };
+    }
+
+    static partial void ModifyParadoxPvP(ref ActionSetting setting)
+    {
+        setting.StatusNeed = [StatusID.Paradox];
+    }
+
+    static partial void ModifyXenoglossyPvP(ref ActionSetting setting)
+    {
+
+    }
+
+    static partial void ModifyLethargyPvP(ref ActionSetting setting)
+    {
+        setting.TargetStatusProvide = [StatusID.Lethargy_4333, StatusID.Heavy_1344];
+    }
+
     static partial void ModifyAetherialManipulationPvP(ref ActionSetting setting)
     {
         setting.SpecialType = SpecialActionType.MovingForward;
     }
+
+    static partial void ModifyElementalWeavePvP(ref ActionSetting setting)
+    {
+        setting.CreateConfig = () => new ActionConfig()
+        {
+            AoeCount = 1,
+        };
+    }
+
+    static partial void ModifyFireIiiPvP(ref ActionSetting setting)
+    {
+        setting.StatusNeed = [StatusID.AstralFire_3212];
+        setting.StatusProvide = [StatusID.AstralFireIi_3213];
+    }
+
+    static partial void ModifyFireIvPvP(ref ActionSetting setting)
+    {
+        setting.StatusNeed = [StatusID.AstralFireIi_3213];
+        setting.StatusProvide = [StatusID.AstralFireIii_3381];
+    }
+
+    static partial void ModifyHighFireIiPvP(ref ActionSetting setting)
+    {
+        setting.StatusNeed = [StatusID.AstralFireIii_3381];
+        setting.StatusProvide = [StatusID.AstralFire_3212];
+        setting.CreateConfig = () => new ActionConfig()
+        {
+            AoeCount = 1,
+        };
+    }
+
+    static partial void ModifyFlarePvP(ref ActionSetting setting)
+    {
+        setting.StatusNeed = [StatusID.SoulResonance];
+        setting.CreateConfig = () => new ActionConfig()
+        {
+            AoeCount = 1,
+        };
+    }
+
+    static partial void ModifyBlizzardIiiPvP(ref ActionSetting setting)
+    {
+        setting.StatusNeed = [StatusID.UmbralIce_3214];
+        setting.StatusProvide = [StatusID.UmbralIceIi_3215];
+    }
+
+    static partial void ModifyBlizzardIvPvP(ref ActionSetting setting)
+    {
+        setting.StatusNeed = [StatusID.UmbralIceIi_3215];
+        setting.StatusProvide = [StatusID.UmbralIceIii_3382];
+    }
+
+    static partial void ModifyHighBlizzardIiPvP(ref ActionSetting setting)
+    {
+        setting.StatusNeed = [StatusID.UmbralIceIii_3382];
+        setting.StatusProvide = [StatusID.UmbralIce_3214];
+        setting.CreateConfig = () => new ActionConfig()
+        {
+            AoeCount = 1,
+        };
+    }
+
+    static partial void ModifyFreezePvP(ref ActionSetting setting)
+    {
+        setting.StatusNeed = [StatusID.SoulResonance];
+        setting.CreateConfig = () => new ActionConfig()
+        {
+            AoeCount = 1,
+        };
+    }
+
+    static partial void ModifyWreathOfFirePvP(ref ActionSetting setting)
+    {
+        setting.ActionCheck = () => WreathOfFireReady;
+    }
+
+    static partial void ModifyWreathOfIcePvP(ref ActionSetting setting)
+    {
+        setting.ActionCheck = () => WreathOfIceReady;
+    }
+
+    static partial void ModifyFlareStarPvP(ref ActionSetting setting)
+    {
+        setting.StatusNeed = [StatusID.ElementalStar];
+        setting.ActionCheck = () => HasPvPAstralFire;
+        setting.CreateConfig = () => new ActionConfig()
+        {
+            AoeCount = 1,
+        };
+    }
+    
+    static partial void ModifyFrostStarPvP(ref ActionSetting setting)
+    {
+        setting.StatusNeed = [StatusID.ElementalStar];
+        setting.ActionCheck = () => HasPvPUmbralIce;
+        setting.CreateConfig = () => new ActionConfig()
+        {
+            AoeCount = 1,
+        };
+    }
+
+    #endregion
 }


### PR DESCRIPTION
This pull request includes several updates and enhancements to the Black Mage rotation logic in both PvP and PvE contexts. The most important changes include updating the game version, adding new abilities, and enhancing status tracking and action modification methods.

### PvP Rotation Updates:
* Updated the `GameVersion` from "7.00" to "7.15" in the `BLM_DefaultPVP` class.
* Added the `HalfHeathXeno` property to check if the player's HP is at least 27000.
* Introduced the `MoveForwardAbility` method to handle movement abilities and conditions.
* Enhanced the `AttackAbility` method to include checks for various PvP-specific abilities such as `XenoglossyPvP`, `LethargyPvP`, `WreathOfFirePvP`, and `WreathOfIcePvP`.

### General Rotation Enhancements:
* Modified the `GeneralGCD` method to prioritize `XenoglossyPvP` based on the `HalfHeathXeno` condition and added checks for additional abilities like `FlareStarPvP`, `FlarePvP`, `HighFireIiPvP`, and others.
* Added new status tracking properties for PvP-specific statuses such as `HasPvPAstralFire` and `HasPvPUmbralIce`.

### Codebase Simplification:
* Moved and reorganized the `HasFire` and `HasThunder` properties, and added the `Fire4Time` property with a corresponding update in the `UpdateInfo` method.
* Added new partial methods to modify various PvP actions, including `ModifyFirePvP`, `ModifyBlizzardPvP`, `ModifyBurstPvP`, and others, to handle specific status needs and configurations.