### PR TITLE
Fix to esuna bug

### DIFF
--- a/RotationSolver/UI/RotationConfigWindow.cs
+++ b/RotationSolver/UI/RotationConfigWindow.cs
@@ -2721,6 +2721,18 @@ public partial class RotationConfigWindow : Window
             ImGui.Text("Friendly NPC Members: None");
         }
 
+        // Display dispel target
+        var dispelTarget = DataCenter.DispelTarget;
+        if (dispelTarget != null)
+        {
+            ImGui.Text("Dispel Target:");
+            ImGui.Text($"- {dispelTarget.Name}");
+        }
+        else
+        {
+            ImGui.Text("Dispel Target: None");
+        }
+
         ImGui.Text($"TerritoryType: {DataCenter.TerritoryContentType}");
         ImGui.Text($"DPSTaken: {DataCenter.DPSTaken}");
         ImGui.Text($"IsHostileCastingToTank: {DataCenter.IsHostileCastingToTank}");

--- a/RotationSolver/Updaters/TargetUpdater.cs
+++ b/RotationSolver/Updaters/TargetUpdater.cs
@@ -219,8 +219,8 @@ internal static partial class TargetUpdater
     private static IBattleChara? GetDispelTarget()
     {
         var rotation = DataCenter.RightNowRotation;
-        if ((Player.Job == Job.WHM || Player.Job == Job.SCH || Player.Job == Job.AST || Player.Job == Job.SGE ||
-            Player.Job == Job.BRD) && Service.Config.DispelAll)
+        if (Player.Job == Job.WHM || Player.Job == Job.SCH || Player.Job == Job.AST || Player.Job == Job.SGE ||
+            Player.Job == Job.BRD)
         {
             var weakenPeople = DataCenter.PartyMembers?
                 .Where(o => o is IBattleChara b && b.StatusList != null &&
@@ -236,8 +236,10 @@ internal static partial class TargetUpdater
                                       ?? weakenPeople.OrderBy(ObjectHelper.DistanceToPlayer).FirstOrDefault()
                                       ?? weakenNPC.OrderBy(ObjectHelper.DistanceToPlayer).FirstOrDefault();
         }
-
-        return null;
+        else
+        {
+            return null;
+        }
     }
 
     private static void UpdateTimeToKill()


### PR DESCRIPTION
This pull request includes changes to enhance the display of dispel targets and refine the logic for determining dispel targets in the `RotationSolver` module. The most important changes include adding a new display for the dispel target in the UI and modifying the conditions for identifying dispel targets.

Enhancements to display:

* [`RotationSolver/UI/RotationConfigWindow.cs`](diffhunk://#diff-44969e3ee4b8d522e4eb8b1ff7712a14af282526ae777e1bbe2ec561a1e9ef0eR2724-R2735): Added a new section in the `DrawStatus` method to display the current dispel target, including handling when there is no dispel target.

Refinements to dispel target logic:

* [`RotationSolver/Updaters/TargetUpdater.cs`](diffhunk://#diff-622e3c74c4a92d384d06fbf22795624a905d57cffab7cb988c7fe789a2d0cefcL222-R223): Removed the condition `Service.Config.DispelAll` from the `GetDispelTarget` method to always consider dispel targets for certain jobs.
* [`RotationSolver/Updaters/TargetUpdater.cs`](diffhunk://#diff-622e3c74c4a92d384d06fbf22795624a905d57cffab7cb988c7fe789a2d0cefcL239-R243): Added an `else` clause to return `null` if the player job is not one of the specified jobs for dispel targets.