### PR TITLE
Fix oversight on SAM due to ability names being stupid

### DIFF
--- a/BasicRotations/Melee/SAM_Default.cs
+++ b/BasicRotations/Melee/SAM_Default.cs
@@ -144,6 +144,9 @@ public sealed class SAM_Default : SamuraiRotation
     protected override bool GeneralGCD(out IAction? act)
     {
         act = null;
+        var isTargetBoss = HostileTarget?.IsBossFromTTK() ?? false;
+        var isTargetDying = HostileTarget?.IsDying() ?? false;
+
         if (EnableTEAChecker && Target.Name.ToString() == "Jagd Doll" && Target.GetHealthRatio() < 0.25)
         {
             return false;
@@ -151,23 +154,28 @@ public sealed class SAM_Default : SamuraiRotation
 
         if ((!HiganbanaTargets || (HiganbanaTargets && NumberOfAllHostilesInRange < 2)) && (HostileTarget?.WillStatusEnd(18, true, StatusID.Higanbana) ?? false) && HiganbanaPvE.CanUse(out act, skipStatusProvideCheck: true)) return true;
 
+        if (TendoKaeshiGokenPvE.CanUse(out act)) return true;
+        if (TendoGokenPvE.CanUse(out act)) return true;
+        if (KaeshiGokenPvE.CanUse(out act)) return true;
+        if (TenkaGokenPvE.CanUse(out act)) return true;
+
+        // aoe 12 combo's 2
+        if ((!HasMoon || IsMoonTimeLessThanFlower || !OkaPvE.EnoughLevel) && MangetsuPvE.CanUse(out act, skipComboCheck: HaveMeikyoShisui && !HasGetsu)) return true;
+        if ((!HasFlower || !IsMoonTimeLessThanFlower) && OkaPvE.CanUse(out act, skipComboCheck: HaveMeikyoShisui && !HasKa)) return true;
+
+        // initiate aoe
+        if (FukoPvE.CanUse(out act, skipComboCheck: true)) return true;
+        if (!FukoPvE.EnoughLevel && FugaPvE.CanUse(out act, skipComboCheck: true)) return true;
+
         if (MidareSetsugekkaPvE.CanUse(out act)) return true;
 
-        if (TenkaGokenPvE.CanUse(out act)) return true;
-        if (TendoGokenPvE.CanUse(out act)) return true;
         if (TendoSetsugekkaPvE.CanUse(out act)) return true;
-        if (TendoKaeshiGokenPvE.CanUse(out act)) return true;
         if (TendoKaeshiSetsugekkaPvE.CanUse(out act)) return true;
         // use 2nd finisher combo spell first
         if (KaeshiNamikiriPvE.CanUse(out act, usedUp: true)) return true;
 
-        var isTargetBoss = HostileTarget?.IsBossFromTTK() ?? false;
-        var isTargetDying = HostileTarget?.IsDying() ?? false;
-
         // use 2nd finisher combo spell first
-        if (KaeshiGokenPvE.CanUse(out act, usedUp: true)) return true;
         if (KaeshiSetsugekkaPvE.CanUse(out act, usedUp: true)) return true;
-        if (TendoKaeshiGokenPvE.CanUse(out act, usedUp: true)) return true;
         if (TendoKaeshiSetsugekkaPvE.CanUse(out act, usedUp: true)) return true;
 
         // burst finisher
@@ -176,10 +184,6 @@ public sealed class SAM_Default : SamuraiRotation
 
         if (TendoSetsugekkaPvE.CanUse(out act)) return true;
         if (MidareSetsugekkaPvE.CanUse(out act)) return true;
-
-        // aoe 12 combo's 2
-        if ((!HasMoon || IsMoonTimeLessThanFlower || !OkaPvE.EnoughLevel) && MangetsuPvE.CanUse(out act, skipComboCheck: HaveMeikyoShisui && !HasGetsu)) return true;
-        if ((!HasFlower || !IsMoonTimeLessThanFlower) && OkaPvE.CanUse(out act, skipComboCheck: HaveMeikyoShisui && !HasKa)) return true;
 
         if (!HasSetsu && SamBuffs.All(buff => Player.HasStatus(true, buff)) &&
             YukikazePvE.CanUse(out act, skipComboCheck: HaveMeikyoShisui && HasGetsu && HasKa)) return true;
@@ -197,10 +201,6 @@ public sealed class SAM_Default : SamuraiRotation
 
         if ((!HasMoon || IsMoonTimeLessThanFlower || !ShifuPvE.EnoughLevel) && JinpuPvE.CanUse(out act)) return true;
         if ((!HasFlower || !IsMoonTimeLessThanFlower) && ShifuPvE.CanUse(out act)) return true;
-
-        // initiate aoe
-        if (FukoPvE.CanUse(out act, skipComboCheck: true)) return true; // fuga doesn't becomes fuko automatically
-        if (!FukoPvE.EnoughLevel && FugaPvE.CanUse(out act, skipComboCheck: true)) return true;
 
         // MeikyoShisui buff is not active - not bursting - single target 123 combo's 1
         if (!HaveMeikyoShisui)

--- a/RotationSolver.Basic/Rotations/Basic/SamuraiRotation.cs
+++ b/RotationSolver.Basic/Rotations/Basic/SamuraiRotation.cs
@@ -375,6 +375,7 @@ partial class SamuraiRotation
     static partial void ModifyKaeshiGokenPvE(ref ActionSetting setting)
     {
         setting.ActionCheck = () => KaeshiGokenReady;
+        setting.IsFriendly = false;
         setting.CreateConfig = () => new ActionConfig()
         {
             AoeCount = 3,
@@ -399,8 +400,6 @@ partial class SamuraiRotation
     static partial void ModifyTendoGokenPvE(ref ActionSetting setting)
     {
         setting.ActionCheck = () => TendoGokenReady;
-        setting.StatusProvide = [StatusID.Tsubamegaeshi];
-        setting.StatusNeed = [StatusID.Tendo];
         setting.IsFriendly = false;
         setting.CreateConfig = () => new ActionConfig()
         {
@@ -419,7 +418,6 @@ partial class SamuraiRotation
     {
         setting.ActionCheck = () => TendoKaeshiGokenReady;
         setting.IsFriendly = false;
-        setting.StatusNeed = [StatusID.Tendo];
         setting.CreateConfig = () => new ActionConfig()
         {
             AoeCount = 3,


### PR DESCRIPTION
This pull request includes several changes to the Samurai rotation logic in the `BasicRotations/Melee/SAM_Default.cs` and `RotationSolver.Basic/Rotations/Basic/SamuraiRotation.cs` files. The main focus is on refining the attack abilities and their conditions, as well as modifying the action settings for specific abilities.

### Changes to attack abilities:

* Added new checks and conditions for various abilities in the `GeneralGCD` method to improve the rotation logic. (`BasicRotations/Melee/SAM_Default.cs`, [[1]](diffhunk://#diff-e913e7d87d2c2dc2110b83a10d2cfdcca6566f88f9ec2b3b11feaf645fb7bda6R147-L170) [[2]](diffhunk://#diff-e913e7d87d2c2dc2110b83a10d2cfdcca6566f88f9ec2b3b11feaf645fb7bda6L180-L183) [[3]](diffhunk://#diff-e913e7d87d2c2dc2110b83a10d2cfdcca6566f88f9ec2b3b11feaf645fb7bda6L201-L204)

### Modifications to action settings:

* Updated the `ModifyKaeshiGokenPvE` method to set `IsFriendly` to false. (`RotationSolver.Basic/Rotations/Basic/SamuraiRotation.cs`, [RotationSolver.Basic/Rotations/Basic/SamuraiRotation.csR378](diffhunk://#diff-a8cbe45fd4e84ec8d8298cdbebb2e56186da00d9e74c49fdccea108acdac1305R378))
* Removed `StatusProvide` and `StatusNeed` from the `ModifyTendoGokenPvE` method. (`RotationSolver.Basic/Rotations/Basic/SamuraiRotation.cs`, [RotationSolver.Basic/Rotations/Basic/SamuraiRotation.csL402-L403](diffhunk://#diff-a8cbe45fd4e84ec8d8298cdbebb2e56186da00d9e74c49fdccea108acdac1305L402-L403))
* Removed `StatusNeed` from the `ModifyTendoKaeshiGokenPvE` method. (`RotationSolver.Basic/Rotations/Basic/SamuraiRotation.cs`, [RotationSolver.Basic/Rotations/Basic/SamuraiRotation.csL422](diffhunk://#diff-a8cbe45fd4e84ec8d8298cdbebb2e56186da00d9e74c49fdccea108acdac1305L422))