### PR TITLE
Add checks to PvE methods and update online status handling

### DIFF
--- a/RotationSolver.Basic/Rotations/Basic/AstrologianRotation.cs
+++ b/RotationSolver.Basic/Rotations/Basic/AstrologianRotation.cs
@@ -104,6 +104,7 @@ partial class AstrologianRotation
     static partial void ModifyLightspeedPvE(ref ActionSetting setting)
     {
         setting.StatusProvide = [StatusID.Lightspeed];
+        setting.ActionCheck = () => !IsLastAbility(ActionID.LightspeedPvE);
         setting.CreateConfig = () => new ActionConfig()
         {
             TimeToKill = 10,

--- a/RotationSolver.Basic/Rotations/CustomRotation_Actions.cs
+++ b/RotationSolver.Basic/Rotations/CustomRotation_Actions.cs
@@ -27,6 +27,7 @@ partial class CustomRotation
     static partial void ModifyTrueNorthPvE(ref ActionSetting setting)
     {
         setting.StatusProvide = new[] { StatusID.TrueNorth };
+        setting.ActionCheck = () => !IsLastAction(ActionID.TrueNorthPvE);
     }
 
     static partial void ModifyAddlePvE(ref ActionSetting setting)

--- a/RotationSolver/UI/RotationConfigWindow.cs
+++ b/RotationSolver/UI/RotationConfigWindow.cs
@@ -2644,6 +2644,7 @@ public partial class RotationConfigWindow : Window
             ImGui.Text($"Fate: {DataCenter.FateId}");
         }
         ImGui.Text($"Height: {Player.Character->ModelContainer.CalculateHeight()}");
+        ImGui.Text($"OnlineStatus: {Player.OnlineStatus}");
         ImGui.Text($"Moving: {DataCenter.IsMoving}");
         ImGui.Text($"Stop Moving: {DataCenter.StopMovingRaw}");
         ImGui.Text($"CountDownTime: {Service.CountDownTime}");

--- a/RotationSolver/Updaters/TargetUpdater.cs
+++ b/RotationSolver/Updaters/TargetUpdater.cs
@@ -38,7 +38,7 @@ internal static partial class TargetUpdater
         {
             return DataCenter.AllianceMembers?
                 .Where(ObjectHelper.IsParty)
-                .Where(b => b.Character() != null && b.Character()->CharacterData.OnlineStatus != 15 && b.IsTargetable)
+                .Where(b => b.Character() != null && b.Character()->CharacterData.OnlineStatus != 15 && b.Character()->CharacterData.OnlineStatus != 5 && b.IsTargetable)
                 .ToList() ?? new List<IBattleChara>();
         }
         catch (Exception ex)
@@ -55,7 +55,7 @@ internal static partial class TargetUpdater
         {
             return DataCenter.AllTargets?
                 .Where(ObjectHelper.IsAlliance)
-                .Where(b => b.Character() != null && b.Character()->CharacterData.OnlineStatus != 15 && b.IsTargetable)
+                .Where(b => b.Character() != null && b.Character()->CharacterData.OnlineStatus != 15 && b.Character()->CharacterData.OnlineStatus != 5 && b.IsTargetable)
                 .ToList() ?? new List<IBattleChara>();
         }
         catch (Exception ex)


### PR DESCRIPTION
This pull request includes several changes to the `RotationSolver` project, focusing on enhancing action settings and improving status checks. The most important changes include modifications to action settings in the `AstrologianRotation` and `CustomRotation_Actions` files, updates to the `DrawStatus` method in the `RotationConfigWindow` file, and refinements to the `GetPartyMembers` and `GetAllianceMembers` methods in the `TargetUpdater` file.

Enhancements to action settings:

* [`RotationSolver.Basic/Rotations/Basic/AstrologianRotation.cs`](diffhunk://#diff-fe436176cc02bf7604fe0f5ee83156907085138353d6bbfc978fab4c08e2e414R107): Modified `ModifyCombustPvE` to include an `ActionCheck` that ensures the action is not the last ability used.
* [`RotationSolver.Basic/Rotations/CustomRotation_Actions.cs`](diffhunk://#diff-ae39f8aef64d2e7369998732072f276dae2e30db05638f92f9c7466671fefb5cR30): Updated `ModifyTrueNorthPvE` to add an `ActionCheck` that verifies the action is not the last one performed.

Improvements to status checks:

* [`RotationSolver/UI/RotationConfigWindow.cs`](diffhunk://#diff-44969e3ee4b8d522e4eb8b1ff7712a14af282526ae777e1bbe2ec561a1e9ef0eR2647): Enhanced the `DrawStatus` method to display the player's online status.
* [`RotationSolver/Updaters/TargetUpdater.cs`](diffhunk://#diff-622e3c74c4a92d384d06fbf22795624a905d57cffab7cb988c7fe789a2d0cefcL41-R41): Refined the `GetPartyMembers` method to exclude characters with an online status of 5 from the list of targetable party members.
* [`RotationSolver/Updaters/TargetUpdater.cs`](diffhunk://#diff-622e3c74c4a92d384d06fbf22795624a905d57cffab7cb988c7fe789a2d0cefcL58-R58): Adjusted the `GetAllianceMembers` method to also exclude characters with an online status of 5 from the list of targetable alliance members.