### PR TITLE
Refactor and clean up code for better readability

### DIFF
--- a/BasicRotations/Ranged/MCH_Default.cs
+++ b/BasicRotations/Ranged/MCH_Default.cs
@@ -1,6 +1,6 @@
 namespace DefaultRotations.Ranged;
 
-[Rotation("Default", CombatType.PvE, GameVersion = "7.11")]
+[Rotation("Default", CombatType.PvE, GameVersion = "7.15")]
 [SourceCode(Path = "main/BasicRotations/Ranged/MCH_Default.cs")]
 [Api(4)]
 public sealed class MCH_Default : MachinistRotation
@@ -64,8 +64,8 @@ public sealed class MCH_Default : MachinistRotation
     [RotationDesc(ActionID.TacticianPvE, ActionID.DismantlePvE)]
     protected override bool DefenseAreaAbility(IAction nextGCD, out IAction? act)
     {
-        if ((!BurstDefense || (BurstDefense && !IsOverheated)) && TacticianPvE.CanUse(out act, skipAoeCheck: true)) return true;
-        if ((!BurstDefense || (BurstDefense && !IsOverheated)) && DismantlePvE.CanUse(out act, skipAoeCheck: true)) return true;
+        if ((!BurstDefense || (BurstDefense && !IsOverheated)) && TacticianPvE.CanUse(out act)) return true;
+        if ((!BurstDefense || (BurstDefense && !IsOverheated)) && DismantlePvE.CanUse(out act)) return true;
 
         return base.DefenseAreaAbility(nextGCD, out act);
     }
@@ -80,8 +80,8 @@ public sealed class MCH_Default : MachinistRotation
         if (Player.HasStatus(true, StatusID.Wildfire_1946) && HyperchargePvE.CanUse(out act)) return true;
 
         // Start Ricochet/Gauss cooldowns rolling
-        if (!RicochetPvE.Cooldown.IsCoolingDown && RicochetPvE.CanUse(out act, skipAoeCheck: true)) return true;
-        if (!GaussRoundPvE.Cooldown.IsCoolingDown && GaussRoundPvE.CanUse(out act, skipAoeCheck: true)) return true;
+        if (!RicochetPvE.Cooldown.IsCoolingDown && RicochetPvE.CanUse(out act)) return true;
+        if (!GaussRoundPvE.Cooldown.IsCoolingDown && GaussRoundPvE.CanUse(out act)) return true;
 
         // Check for not burning Hypercharge below level 52 on AOE
         bool LowLevelHyperCheck = !AutoCrossbowPvE.EnoughLevel && SpreadShotPvE.CanUse(out _);
@@ -109,8 +109,8 @@ public sealed class MCH_Default : MachinistRotation
         if (CanUseQueenMeow(out act, nextGCD)) return true;
 
         // Use Ricochet and Gauss
-        if (isRicochetMore && RicochetPvE.CanUse(out act, skipAoeCheck: true, usedUp: true)) return true;
-        if (GaussRoundPvE.CanUse(out act, usedUp: true, skipAoeCheck: true)) return true;
+        if (isRicochetMore && RicochetPvE.CanUse(out act, usedUp: true)) return true;
+        if (GaussRoundPvE.CanUse(out act, usedUp: true)) return true;
 
         if (IsBurst && BarrelStabilizerPvE.CanUse(out act)) return true;
 
@@ -143,9 +143,9 @@ public sealed class MCH_Default : MachinistRotation
         }
 
         // ChainSaw is always used after Drill
-        if (ChainSawPvE.CanUse(out act, skipAoeCheck: true)) return true;
+        if (ChainSawPvE.CanUse(out act)) return true;
         // use combo finisher asap
-        if (ExcavatorPvE.CanUse(out act, skipAoeCheck: true)) return true;
+        if (ExcavatorPvE.CanUse(out act)) return true;
         // use FMF after ChainSaw combo in 'alternative opener'
         if (FullMetalFieldPvE.CanUse(out act)) return true;
 

--- a/BasicRotations/Ranged/MCH_HighEnd.cs
+++ b/BasicRotations/Ranged/MCH_HighEnd.cs
@@ -1,18 +1,18 @@
 namespace DefaultRotations.Ranged;
 
-[Rotation("High End", CombatType.PvE, GameVersion = "7.11")]
+[Rotation("High End", CombatType.PvE, GameVersion = "7.15")]
 [SourceCode(Path = "main/BasicRotations/Ranged/MCH_HighEnd.cs")]
 [Api(4)]
 public sealed class MCH_HighEnd : MachinistRotation
 {
     #region Config Options
     [RotationConfig(CombatType.PvE, Name = "Use hardcoded Queen timings\nSlight DPS gain if uninterrupted but possibly loses more from drift or death.")]
-    private bool UseBalanceQueenTimings { get; set; }
+    private bool UseBalanceQueenTimings { get; set; } = false;
 
-    [RotationConfig(CombatType.PvE, Name = "Use burst medicine in countdown")]
+    [RotationConfig(CombatType.PvE, Name = "Use burst medicine at the 2 second mark in countdown")]
     private bool OpenerBurstMeds { get; set; } = false;
 
-    [RotationConfig(CombatType.PvE, Name = "Use burst medicine when available for midfight burst phase")]
+    [RotationConfig(CombatType.PvE, Name = "Use burst medicine midfight when Air Anchor, Barrel Stabilizer, and Wildfire are about to come off cooldown")]
     private bool MidfightBurstMeds { get; set; } = false;
     #endregion
 
@@ -74,8 +74,8 @@ public sealed class MCH_HighEnd : MachinistRotation
     [RotationDesc(ActionID.TacticianPvE, ActionID.DismantlePvE)]
     protected override bool DefenseAreaAbility(IAction nextGCD, out IAction act)
     {
-        if (TacticianPvE.CanUse(out act, skipAoeCheck: true)) return true;
-        if (DismantlePvE.CanUse(out act, skipAoeCheck: true)) return true;
+        if (TacticianPvE.CanUse(out act)) return true;
+        if (DismantlePvE.CanUse(out act)) return true;
         return false;
     }
 
@@ -93,8 +93,8 @@ public sealed class MCH_HighEnd : MachinistRotation
         }
 
         // Start Ricochet/Gauss cooldowns rolling
-        if (!RicochetPvE.Cooldown.IsCoolingDown && RicochetPvE.CanUse(out act, skipAoeCheck: true)) return true;
-        if (!GaussRoundPvE.Cooldown.IsCoolingDown && GaussRoundPvE.CanUse(out act, skipAoeCheck: true)) return true;
+        if (!RicochetPvE.Cooldown.IsCoolingDown && RicochetPvE.CanUse(out act)) return true;
+        if (!GaussRoundPvE.Cooldown.IsCoolingDown && GaussRoundPvE.CanUse(out act)) return true;
 
         if (IsBurst && IsLastGCD(true, DrillPvE) && BarrelStabilizerPvE.CanUse(out act)) return true;
 
@@ -114,14 +114,14 @@ public sealed class MCH_HighEnd : MachinistRotation
             if ((IsLastGCD(true, BlazingShotPvE, HeatBlastPvE)
                 || RicochetPvE.Cooldown.RecastTimeElapsed >= 45
                 || !BarrelStabilizerPvE.Cooldown.ElapsedAfter(20))
-                && RicochetPvE.CanUse(out act, skipAoeCheck: true, usedUp: true))
+                && RicochetPvE.CanUse(out act, usedUp: true))
                 return true;
         }
 
         if ((IsLastGCD(true, BlazingShotPvE, HeatBlastPvE)
             || GaussRoundPvE.Cooldown.RecastTimeElapsed >= 45
             || !BarrelStabilizerPvE.Cooldown.ElapsedAfter(20))
-            && GaussRoundPvE.CanUse(out act, usedUp: true, skipAoeCheck: true))
+            && GaussRoundPvE.CanUse(out act, usedUp: true))
             return true;
 
 
@@ -138,7 +138,7 @@ public sealed class MCH_HighEnd : MachinistRotation
     protected override bool GeneralGCD(out IAction? act)
     {
         // use procs asap
-        if (ExcavatorPvE.CanUse(out act, skipAoeCheck: true)) return true;
+        if (ExcavatorPvE.CanUse(out act)) return true;
         if (!ChainSawPvE.Cooldown.WillHaveOneChargeGCD(2) && FullMetalFieldPvE.CanUse(out act)) return true;
 
         // overheated aoe
@@ -163,7 +163,7 @@ public sealed class MCH_HighEnd : MachinistRotation
         }
 
         // ChainSaw is always used after Drill
-        if (ChainSawPvE.CanUse(out act, skipAoeCheck: true)) return true;
+        if (ChainSawPvE.CanUse(out act)) return true;
 
         // save Drill for burst
         if (EnhancedMultiweaponTrait.EnoughLevel

--- a/RotationSolver.Basic/Rotations/Basic/MachinistRotation.cs
+++ b/RotationSolver.Basic/Rotations/Basic/MachinistRotation.cs
@@ -112,7 +112,10 @@ partial class MachinistRotation
 
     static partial void ModifyGaussRoundPvE(ref ActionSetting setting)
     {
-
+        setting.CreateConfig = () => new ActionConfig()
+        {
+            AoeCount = 1,
+        };
     }
 
     static partial void ModifySpreadShotPvE(ref ActionSetting setting)

--- a/RotationSolver.Basic/Rotations/Basic/SamuraiRotation.cs
+++ b/RotationSolver.Basic/Rotations/Basic/SamuraiRotation.cs
@@ -36,7 +36,17 @@ partial class SamuraiRotation
     /// <summary>
     /// 
     /// </summary>
-    public static byte SenCount => (byte)((HasGetsu ? 1 : 0) + (HasSetsu ? 1 : 0) + (HasKa ? 1 : 0));
+    public static byte SenCount
+    {
+        get
+        {
+            byte count = 0;
+            if (HasGetsu) count++;
+            if (HasSetsu) count++;
+            if (HasKa) count++;
+            return count;
+        }
+    }
     #endregion
 
     #region Status Tracking
@@ -58,7 +68,12 @@ partial class SamuraiRotation
     /// 
     /// </summary>
     public static bool IsMoonTimeLessThanFlower
-        => Player.StatusTime(true, StatusID.Fugetsu) < Player.StatusTime(true, StatusID.Fuka);
+    {
+        get
+        {
+            return Player.StatusTime(true, StatusID.Fugetsu) < Player.StatusTime(true, StatusID.Fuka);
+        }
+    }
 
     /// <summary>
     /// 
@@ -155,7 +170,7 @@ partial class SamuraiRotation
     static partial void ModifyJinpuPvE(ref ActionSetting setting)
     {
         setting.ActionCheck = () => Kenki <= 95;
-        setting.ComboIds = [ActionID.HakazePvE, ActionID.GyofuPvE];
+        setting.ComboIds = new[] { ActionID.HakazePvE, ActionID.GyofuPvE };
     }
 
     static partial void ModifyEnpiPvE(ref ActionSetting setting)
@@ -165,13 +180,13 @@ partial class SamuraiRotation
 
     static partial void ModifyThirdEyePvE(ref ActionSetting setting)
     {
-        setting.StatusProvide = [StatusID.ThirdEye];
+        setting.StatusProvide = new[] { StatusID.ThirdEye };
     }
 
     static partial void ModifyShifuPvE(ref ActionSetting setting)
     {
         setting.ActionCheck = () => Kenki <= 95;
-        setting.ComboIds = [ActionID.HakazePvE, ActionID.GyofuPvE];
+        setting.ComboIds = new[] { ActionID.HakazePvE, ActionID.GyofuPvE };
     }
 
     static partial void ModifyFugaPvE(ref ActionSetting setting)
@@ -185,7 +200,7 @@ partial class SamuraiRotation
 
     static partial void ModifyGekkoPvE(ref ActionSetting setting)
     {
-        setting.ComboIds = [ActionID.JinpuPvE];
+        setting.ComboIds = new[] { ActionID.JinpuPvE };
         setting.ActionCheck = () => Kenki <= 90;
     }
 
@@ -196,7 +211,7 @@ partial class SamuraiRotation
 
     static partial void ModifyMangetsuPvE(ref ActionSetting setting)
     {
-        setting.ComboIds = [ActionID.FukoPvE];
+        setting.ComboIds = new[] { ActionID.FukoPvE };
         setting.ActionCheck = () => Kenki <= 90;
         setting.CreateConfig = () => new ActionConfig()
         {
@@ -207,12 +222,12 @@ partial class SamuraiRotation
     static partial void ModifyKashaPvE(ref ActionSetting setting)
     {
         setting.ActionCheck = () => Kenki <= 90;
-        setting.ComboIds = [ActionID.ShifuPvE];
+        setting.ComboIds = new[] { ActionID.ShifuPvE };
     }
 
     static partial void ModifyOkaPvE(ref ActionSetting setting)
     {
-        setting.ComboIds = [ActionID.FukoPvE];
+        setting.ComboIds = new[] { ActionID.FukoPvE };
         setting.ActionCheck = () => Kenki <= 90;
         setting.CreateConfig = () => new ActionConfig()
         {
@@ -222,13 +237,13 @@ partial class SamuraiRotation
 
     static partial void ModifyYukikazePvE(ref ActionSetting setting)
     {
-        setting.ComboIds = [ActionID.HakazePvE, ActionID.GyofuPvE];
+        setting.ComboIds = new[] { ActionID.HakazePvE, ActionID.GyofuPvE };
         setting.ActionCheck = () => Kenki <= 85;
     }
 
     static partial void ModifyMeikyoShisuiPvE(ref ActionSetting setting)
     {
-        setting.StatusProvide = [StatusID.MeikyoShisui, StatusID.Tendo];
+        setting.StatusProvide = new[] { StatusID.MeikyoShisui, StatusID.Tendo };
         setting.CreateConfig = () => new ActionConfig()
         {
             TimeToKill = 0,
@@ -273,7 +288,7 @@ partial class SamuraiRotation
 
     static partial void ModifyIkishotenPvE(ref ActionSetting setting)
     {
-        setting.StatusProvide = [StatusID.OgiNamikiriReady, StatusID.ZanshinReady];
+        setting.StatusProvide = new[] { StatusID.OgiNamikiriReady, StatusID.ZanshinReady };
         setting.ActionCheck = () => InCombat && Kenki <= 50;
     }
 
@@ -308,7 +323,7 @@ partial class SamuraiRotation
 
     static partial void ModifyTengentsuPvE(ref ActionSetting setting)
     {
-        setting.StatusProvide = [StatusID.Tengentsu];
+        setting.StatusProvide = new[] { StatusID.Tengentsu };
     }
 
     static partial void ModifyFukoPvE(ref ActionSetting setting)
@@ -322,7 +337,7 @@ partial class SamuraiRotation
 
     static partial void ModifyOgiNamikiriPvE(ref ActionSetting setting)
     {
-        setting.StatusNeed = [StatusID.OgiNamikiriReady];
+        setting.StatusNeed = new[] { StatusID.OgiNamikiriReady };
         setting.ActionCheck = () => MeditationStacks <= 2;
         setting.CreateConfig = () => new ActionConfig()
         {
@@ -337,7 +352,7 @@ partial class SamuraiRotation
 
     static partial void ModifyZanshinPvE(ref ActionSetting setting)
     {
-        setting.StatusNeed = [StatusID.ZanshinReady_3855];
+        setting.StatusNeed = new[] { StatusID.ZanshinReady_3855 };
         setting.ActionCheck = () => Kenki >= 50;
         setting.CreateConfig = () => new ActionConfig()
         {
@@ -350,7 +365,7 @@ partial class SamuraiRotation
     static partial void ModifyHiganbanaPvE(ref ActionSetting setting)
     {
         setting.ActionCheck = () => HiganbanaReady;
-        setting.TargetStatusProvide = [StatusID.Higanbana];
+        setting.TargetStatusProvide = new[] { StatusID.Higanbana };
         setting.CreateConfig = () => new ActionConfig()
         {
             TimeToKill = 48,
@@ -385,7 +400,7 @@ partial class SamuraiRotation
     static partial void ModifyKaeshiSetsugekkaPvE(ref ActionSetting setting)
     {
         setting.ActionCheck = () => KaeshiSetsugekkaReady;
-        setting.StatusNeed = [StatusID.Tsubamegaeshi];
+        setting.StatusNeed = new[] { StatusID.Tsubamegaeshi };
     }
 
     static partial void ModifyKaeshiNamikiriPvE(ref ActionSetting setting)
@@ -410,8 +425,8 @@ partial class SamuraiRotation
     static partial void ModifyTendoSetsugekkaPvE(ref ActionSetting setting)
     {
         setting.ActionCheck = () => TendoSetsugekkaReady;
-        setting.StatusProvide = [StatusID.Tsubamegaeshi];
-        setting.StatusNeed = [StatusID.Tendo];
+        setting.StatusProvide = new[] { StatusID.Tsubamegaeshi };
+        setting.StatusNeed = new[] { StatusID.Tendo };
     }
 
     static partial void ModifyTendoKaeshiGokenPvE(ref ActionSetting setting)
@@ -427,7 +442,7 @@ partial class SamuraiRotation
     static partial void ModifyTendoKaeshiSetsugekkaPvE(ref ActionSetting setting)
     {
         setting.ActionCheck = () => TendoKaeshiSetsugekkaReady;
-        setting.StatusNeed = [StatusID.Tsubamegaeshi_4218];
+        setting.StatusNeed = new[] { StatusID.Tsubamegaeshi_4218 };
     }
 
     #endregion

--- a/RotationSolver.Basic/Rotations/Basic/ViperRotation.cs
+++ b/RotationSolver.Basic/Rotations/Basic/ViperRotation.cs
@@ -210,12 +210,24 @@ public partial class ViperRotation
     /// <summary>
     /// Indicates that Hunters Instinct is ending before Swiftscaled.
     /// </summary>
-    public static bool HunterLessThanSwift => Player.StatusTime(true, StatusID.HuntersInstinct) < Player.StatusTime(true, StatusID.Swiftscaled);
+    public static bool HunterLessThanSwift
+    {
+        get
+        {
+            return Player.StatusTime(true, StatusID.HuntersInstinct) < Player.StatusTime(true, StatusID.Swiftscaled);
+        }
+    }
 
     /// <summary>
     /// Indicates that Swiftscaled is ending before Hunters Instinct.
     /// </summary>
-    public static bool SwiftLessThanHunter => Player.StatusTime(true, StatusID.Swiftscaled) < Player.StatusTime(true, StatusID.HuntersInstinct);
+    public static bool SwiftLessThanHunter
+    {
+        get
+        {
+            return Player.StatusTime(true, StatusID.Swiftscaled) < Player.StatusTime(true, StatusID.HuntersInstinct);
+        }
+    }
     #endregion
 
     #region Actions


### PR DESCRIPTION
This pull request includes multiple changes across different files to update game versions, remove unnecessary parameters, and improve code readability. The most important changes include updating game versions, simplifying method calls by removing unused parameters, and enhancing code readability in the `SamuraiRotation` class.

### Game Version Updates:
* Updated game version from "7.11" to "7.15" in `BasicRotations/Ranged/MCH_Default.cs` and `BasicRotations/Ranged/MCH_HighEnd.cs`. [[1]](diffhunk://#diff-18a4bcb56b9f9757c8f7433cbf7c0bdf8595591724f92e6e0376e81115ace381L3-R3) [[2]](diffhunk://#diff-09ace0e58dc4b356a6f82de953c04dbb6517b79b3a6c15f5311e1bfcb6289e35L3-R15)

### Simplification of Method Calls:
* Removed `skipAoeCheck` parameter from various method calls in `BasicRotations/Ranged/MCH_Default.cs` to simplify the code. [[1]](diffhunk://#diff-18a4bcb56b9f9757c8f7433cbf7c0bdf8595591724f92e6e0376e81115ace381L67-R68) [[2]](diffhunk://#diff-18a4bcb56b9f9757c8f7433cbf7c0bdf8595591724f92e6e0376e81115ace381L83-R84) [[3]](diffhunk://#diff-18a4bcb56b9f9757c8f7433cbf7c0bdf8595591724f92e6e0376e81115ace381L112-R113) [[4]](diffhunk://#diff-18a4bcb56b9f9757c8f7433cbf7c0bdf8595591724f92e6e0376e81115ace381L146-R148)
* Removed `skipAoeCheck` parameter from various method calls in `BasicRotations/Ranged/MCH_HighEnd.cs` to simplify the code. [[1]](diffhunk://#diff-09ace0e58dc4b356a6f82de953c04dbb6517b79b3a6c15f5311e1bfcb6289e35L77-R78) [[2]](diffhunk://#diff-09ace0e58dc4b356a6f82de953c04dbb6517b79b3a6c15f5311e1bfcb6289e35L96-R97) [[3]](diffhunk://#diff-09ace0e58dc4b356a6f82de953c04dbb6517b79b3a6c15f5311e1bfcb6289e35L117-R124) [[4]](diffhunk://#diff-09ace0e58dc4b356a6f82de953c04dbb6517b79b3a6c15f5311e1bfcb6289e35L141-R141) [[5]](diffhunk://#diff-09ace0e58dc4b356a6f82de953c04dbb6517b79b3a6c15f5311e1bfcb6289e35L166-R166)

### Code Readability Improvements:
* Refactored `SenCount` and `IsMoonTimeLessThanFlower` properties in `RotationSolver.Basic/Rotations/Basic/SamuraiRotation.cs` to use `get` blocks for better readability. [[1]](diffhunk://#diff-a8cbe45fd4e84ec8d8298cdbebb2e56186da00d9e74c49fdccea108acdac1305L39-R49) [[2]](diffhunk://#diff-a8cbe45fd4e84ec8d8298cdbebb2e56186da00d9e74c49fdccea108acdac1305L61-R76)
* Replaced array initialization syntax with `new[]` for better readability in multiple `Modify*PvE` methods in `RotationSolver.Basic/Rotations/Basic/SamuraiRotation.cs`. [[1]](diffhunk://#diff-a8cbe45fd4e84ec8d8298cdbebb2e56186da00d9e74c49fdccea108acdac1305L158-R173) [[2]](diffhunk://#diff-a8cbe45fd4e84ec8d8298cdbebb2e56186da00d9e74c49fdccea108acdac1305L168-R189) [[3]](diffhunk://#diff-a8cbe45fd4e84ec8d8298cdbebb2e56186da00d9e74c49fdccea108acdac1305L188-R203) [[4]](diffhunk://#diff-a8cbe45fd4e84ec8d8298cdbebb2e56186da00d9e74c49fdccea108acdac1305L199-R214) [[5]](diffhunk://#diff-a8cbe45fd4e84ec8d8298cdbebb2e56186da00d9e74c49fdccea108acdac1305L210-R230) [[6]](diffhunk://#diff-a8cbe45fd4e84ec8d8298cdbebb2e56186da00d9e74c49fdccea108acdac1305L225-R246) [[7]](diffhunk://#diff-a8cbe45fd4e84ec8d8298cdbebb2e56186da00d9e74c49fdccea108acdac1305L276-R291) [[8]](diffhunk://#diff-a8cbe45fd4e84ec8d8298cdbebb2e56186da00d9e74c49fdccea108acdac1305L311-R326) [[9]](diffhunk://#diff-a8cbe45fd4e84ec8d8298cdbebb2e56186da00d9e74c49fdccea108acdac1305L325-R340) [[10]](diffhunk://#diff-a8cbe45fd4e84ec8d8298cdbebb2e56186da00d9e74c49fdccea108acdac1305L340-R355) [[11]](diffhunk://#diff-a8cbe45fd4e84ec8d8298cdbebb2e56186da00d9e74c49fdccea108acdac1305L353-R368) [[12]](diffhunk://#diff-a8cbe45fd4e84ec8d8298cdbebb2e56186da00d9e74c49fdccea108acdac1305L388-R403) [[13]](diffhunk://#diff-a8cbe45fd4e84ec8d8298cdbebb2e56186da00d9e74c49fdccea108acdac1305L413-R429) [[14]](diffhunk://#diff-a8cbe45fd4e84ec8d8298cdbebb2e56186da00d9e74c49fdccea108acdac1305L430-R445)

### Configuration Changes:
* Added a configuration for `GaussRoundPvE` to set `AoeCount` to 1 in `RotationSolver.Basic/Rotations/Basic/MachinistRotation.cs`.

These changes collectively aim to improve the maintainability and readability of the codebase.