### PR TITLE
Update BLM and SAM classes with new options and logic

### DIFF
--- a/BasicRotations/Magical/BLM_Default.cs
+++ b/BasicRotations/Magical/BLM_Default.cs
@@ -1,6 +1,6 @@
 ﻿namespace DefaultRotations.Magical;
 
-[Rotation("Default", CombatType.PvE, GameVersion = "7.01")]
+[Rotation("Default", CombatType.PvE, GameVersion = "7.15")]
 [SourceCode(Path = "main/BasicRotations/Magical/BLM_Default.cs")]
 [Api(4)]
 public class BLM_Default : BlackMageRotation
@@ -9,14 +9,20 @@ public class BLM_Default : BlackMageRotation
     [RotationConfig(CombatType.PvE, Name = "Use Transpose to Astral Fire before Paradox")]
     public bool UseTransposeForParadox { get; set; } = true;
 
-    [RotationConfig(CombatType.PvE, Name = "Use Retrace when out of Leylines and standing still (Dangerous and Experimental)")]
-    public bool UseRetrace { get; set; } = false;
-
     [RotationConfig(CombatType.PvE, Name = "Extend Astral Fire time more conservatively (3 GCDs) (Default is 2 GCDs)")]
     public bool ExtendTimeSafely { get; set; } = false;
 
     [RotationConfig(CombatType.PvE, Name = @"Use ""Double Paradox"" rotation [N15]")]
     public bool UseN15 { get; set; } = false;
+
+    [RotationConfig(CombatType.PvE, Name = "Use Leylines in combat when standing still")]
+    public bool LeylineMadness { get; set; } = false;
+
+    [RotationConfig(CombatType.PvE, Name = "Use both stacks of Leylines automatically")]
+    public bool Leyline2Madness { get; set; } = false;
+
+    [RotationConfig(CombatType.PvE, Name = "Use Retrace when out of Leylines in combat and standing still")]
+    public bool UseRetrace { get; set; } = false;
     #endregion
 
     #region Additional oGCD Logic
@@ -90,10 +96,12 @@ public class BLM_Default : BlackMageRotation
     #endregion
 
     #region oGCD Logic
-    [RotationDesc(ActionID.ManafontPvE, ActionID.TransposePvE)]
+    [RotationDesc(ActionID.TransposePvE, ActionID.LeyLinesPvE, ActionID.RetracePvE)]
     protected override bool GeneralAbility(IAction nextGCD, out IAction? act)
     {
         if (IsMoving && HasHostilesInRange && TriplecastPvE.CanUse(out act, usedUp: true)) return true;
+        if (LeylineMadness && InCombat && HasHostilesInRange && LeyLinesPvE.CanUse(out act, usedUp: Leyline2Madness)) return true;
+        if (!IsLastAbility(ActionID.LeyLinesPvE) && UseRetrace && InCombat && HasHostilesInRange && RetracePvE.CanUse(out act)) return true;
 
         return base.GeneralAbility(nextGCD, out act);
     }

--- a/BasicRotations/Melee/SAM_Default.cs
+++ b/BasicRotations/Melee/SAM_Default.cs
@@ -13,7 +13,7 @@ public sealed class SAM_Default : SamuraiRotation
     {
         [Description("Hagakure")] Hagakure,
 
-        [Description("Midare Setsugekka")] MidareSetsugekka,
+        [Description("Setsugekka")] Setsugekka,
     }
 
     [Range(0, 100, ConfigUnitType.None, 1)]
@@ -45,7 +45,7 @@ public sealed class SAM_Default : SamuraiRotation
     [RotationConfig(CombatType.PvE, Name = "Enable TEA Checker.")]
     public bool EnableTEAChecker { get; set; } = false;
 
-    [RotationConfig(CombatType.PvE, Name = "Use Hagakure or Midare Setsugekka when going from single target to AOE scenarios")]
+    [RotationConfig(CombatType.PvE, Name = "Use Hagakure or Midare/Tendo Setsugekka when going from single target to AOE scenarios")]
     public STtoAOEStrategy STtoAOE { get; set; } = STtoAOEStrategy.Hagakure;
     #endregion
 
@@ -175,7 +175,8 @@ public sealed class SAM_Default : SamuraiRotation
                     if (MidareSetsugekkaPvE.CanUse(out _) && HagakurePvE.CanUse(out act)) return true;
                     break;
 
-                case STtoAOEStrategy.MidareSetsugekka:
+                case STtoAOEStrategy.Setsugekka:
+                    if (TendoSetsugekkaPvE.CanUse(out act)) return true;
                     if (MidareSetsugekkaPvE.CanUse(out act)) return true;
                     break;
             }
@@ -196,23 +197,17 @@ public sealed class SAM_Default : SamuraiRotation
         if (FukoPvE.CanUse(out act, skipComboCheck: true)) return true;
         if (!FukoPvE.EnoughLevel && FugaPvE.CanUse(out act, skipComboCheck: true)) return true;
 
+        if (TendoSetsugekkaPvE.CanUse(out act)) return true;
         if (MidareSetsugekkaPvE.CanUse(out act)) return true;
 
-        if (TendoSetsugekkaPvE.CanUse(out act)) return true;
-        if (TendoKaeshiSetsugekkaPvE.CanUse(out act)) return true;
         // use 2nd finisher combo spell first
         if (KaeshiNamikiriPvE.CanUse(out act, usedUp: true)) return true;
-
-        // use 2nd finisher combo spell first
-        if (KaeshiSetsugekkaPvE.CanUse(out act, usedUp: true)) return true;
-        if (TendoKaeshiSetsugekkaPvE.CanUse(out act, usedUp: true)) return true;
+        if (!KaeshiNamikiriReady && KaeshiSetsugekkaPvE.CanUse(out act, usedUp: true)) return true;
+        if (!KaeshiNamikiriReady && TendoKaeshiSetsugekkaPvE.CanUse(out act, usedUp: true)) return true;
 
         // burst finisher
         if ((!isTargetBoss || (HostileTarget?.HasStatus(true, StatusID.Higanbana) ?? false)) && HasMoon && HasFlower
             && OgiNamikiriPvE.CanUse(out act)) return true;
-
-        if (TendoSetsugekkaPvE.CanUse(out act)) return true;
-        if (MidareSetsugekkaPvE.CanUse(out act)) return true;
 
         if (!HasSetsu && SamBuffs.All(buff => Player.HasStatus(true, buff)) &&
             YukikazePvE.CanUse(out act, skipComboCheck: HaveMeikyoShisui && HasGetsu && HasKa)) return true;

--- a/RotationSolver.Basic/Configuration/Configs.cs
+++ b/RotationSolver.Basic/Configuration/Configs.cs
@@ -283,7 +283,7 @@ internal partial class Configs : IPluginConfiguration
         Filter = UiInformation)]
     private static readonly bool _showToastsAboutDoAction = false;
 
-    [ConditionBool, UI("Automatically trigger dps burst phase.", Description = "If this is disabled, you will not use abilties that consume resources/gauge.", Filter = AutoActionUsage, Section = 4)]
+    [ConditionBool, UI("Allow rotations that use this config to use abilties definied in the rotation as burst", Filter = AutoActionUsage, Section = 4)]
     private static readonly bool _autoBurst = true;
 
     [ConditionBool, UI("Automatic Healing Thresholds", Filter = HealingActionCondition, Section = 1, Order = 1)]

--- a/RotationSolver.Basic/Rotations/Basic/BlackMageRotation.cs
+++ b/RotationSolver.Basic/Rotations/Basic/BlackMageRotation.cs
@@ -308,6 +308,7 @@ partial class BlackMageRotation
         setting.ActionCheck = () => !IsMoving;
         setting.StatusProvide = [StatusID.LeyLines];
         setting.UnlockedByQuestID = 67215;
+        setting.IsFriendly = true;
         setting.CreateConfig = () => new ActionConfig()
         {
             TimeToKill = 15,
@@ -418,6 +419,7 @@ partial class BlackMageRotation
     {
         setting.ActionCheck = () => !IsMoving && !Player.HasStatus(true, StatusID.CircleOfPower);
         setting.StatusNeed = [StatusID.LeyLines];
+        setting.IsFriendly = true;
         setting.CreateConfig = () => new ActionConfig()
         {
             AoeCount = 1,


### PR DESCRIPTION
This pull request includes several changes to the `BasicRotations` module, focusing on the `Magical` and `Melee` rotations. The key changes involve updating game versions, modifying rotation configurations, and adjusting ability checks and descriptions.

### Updates to `Magical` Rotations:

* **Game Version Update:**
  - Updated the `GameVersion` attribute in `BLM_Default` class from "7.01" to "7.15".

* **Configuration Changes:**
  - Added new configuration options `LeylineMadness` and `Leyline2Madness` for using Leylines in combat.
  - Re-added the `UseRetrace` configuration with a new description.

* **Ability Checks:**
  - Modified `GeneralAbility` method to include checks for `LeylineMadness` and `UseRetrace` abilities.

### Updates to `Melee` Rotations:

* **Enum and Configuration Updates:**
  - Renamed `MidareSetsugekka` to `Setsugekka` in the `STtoAOEStrategy` enum and updated related configurations and descriptions. [[1]](diffhunk://#diff-e913e7d87d2c2dc2110b83a10d2cfdcca6566f88f9ec2b3b11feaf645fb7bda6L16-R16) [[2]](diffhunk://#diff-e913e7d87d2c2dc2110b83a10d2cfdcca6566f88f9ec2b3b11feaf645fb7bda6L48-R48)

* **General Ability Logic:**
  - Adjusted the `GeneralGCD` method to prioritize `TendoSetsugekkaPvE` and `KaeshiSetsugekkaPvE` abilities more effectively. [[1]](diffhunk://#diff-e913e7d87d2c2dc2110b83a10d2cfdcca6566f88f9ec2b3b11feaf645fb7bda6L178-R179) [[2]](diffhunk://#diff-e913e7d87d2c2dc2110b83a10d2cfdcca6566f88f9ec2b3b11feaf645fb7bda6R200-L216)

### General Configuration:

* **Description Update:**
  - Updated the description for the `_autoBurst` configuration to clarify its purpose.

### Additional Changes:

* **Black Mage Rotation Settings:**
  - Set `IsFriendly` to `true` for `LeyLinesPvE` and `RetracePvE` actions. [[1]](diffhunk://#diff-2e9e89d2efe7313b0d50c2271fb708e47fd87a49dda8c0a558a27aedcca8e660R311) [[2]](diffhunk://#diff-2e9e89d2efe7313b0d50c2271fb708e47fd87a49dda8c0a558a27aedcca8e660R422)