### PR TITLE
Bunchafixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ obj/
 lib/
 .idea/
 RotationSolver/Localization/Localization.json
+/Resources/AutoStatusOrder.json

--- a/RotationSolver.Basic/Configuration/Configs.cs
+++ b/RotationSolver.Basic/Configuration/Configs.cs
@@ -25,11 +25,6 @@ internal partial class Configs : IPluginConfiguration
         List2 = "List2",
         Debug = "Debug";
 
-    public List<AutoStatus> AutoStatusOrder { get; set; } = Enum.GetValues(typeof(AutoStatus))
-        .Cast<AutoStatus>()
-        .Where(status => status != AutoStatus.None)
-        .ToList();
-
     public const int CurrentVersion = 12;
     public int Version { get; set; } = CurrentVersion;
 
@@ -64,6 +59,10 @@ internal partial class Configs : IPluginConfiguration
         Filter = BasicAutoSwitch)]
     private static readonly bool _autoOffWhenDead = true;
 
+    [ConditionBool, UI("Auto turn off when dead in PvP.",
+        Filter = BasicAutoSwitch)]
+    private static readonly bool _autoOffWhenDeadPvP = true;
+
     [ConditionBool, UI("Auto turn off when duty completed.",
         Filter = BasicAutoSwitch)]
     private static readonly bool _autoOffWhenDutyCompleted = true;
@@ -76,6 +75,10 @@ internal partial class Configs : IPluginConfiguration
     [ConditionBool, UI("Audio notification for when the status changes",
         Filter = UiInformation)]
     private static readonly bool _sayOutStateChanged = false;
+
+    [ConditionBool, UI("Enable changelog window popup on update",
+        Filter = UiInformation)]
+    private static readonly bool _changelogPopup = true;
 
     [ConditionBool, UI("Show plugin status in server info bar.",
         Filter = UiInformation)]

--- a/RotationSolver.Basic/Configuration/OtherConfiguration.cs
+++ b/RotationSolver.Basic/Configuration/OtherConfiguration.cs
@@ -19,6 +19,7 @@ internal class OtherConfiguration
     public static HashSet<uint> InvincibleStatus = [];
     public static HashSet<uint> NoCastingStatus = [];
     public static HashSet<uint> PrioTargetId = [];
+    public static HashSet<uint> AutoStatusOrder = [];
 
     public static RotationSolverRecord RotationSolverRecord = new();
 
@@ -33,6 +34,7 @@ internal class OtherConfiguration
         Task.Run(() => InitOne(ref PriorityStatus, nameof(PriorityStatus)));
         Task.Run(() => InitOne(ref InvincibleStatus, nameof(InvincibleStatus)));
         Task.Run(() => InitOne(ref PrioTargetId, nameof(PrioTargetId)));
+        Task.Run(() => InitOne(ref AutoStatusOrder, nameof(AutoStatusOrder)));
         Task.Run(() => InitOne(ref NoHostileNames, nameof(NoHostileNames)));
         Task.Run(() => InitOne(ref NoProvokeNames, nameof(NoProvokeNames)));
         Task.Run(() => InitOne(ref AnimationLockTime, nameof(AnimationLockTime)));
@@ -52,6 +54,7 @@ internal class OtherConfiguration
             await SaveDangerousStatus();
             await SaveInvincibleStatus();
             await SavePrioTargetId();
+            await SaveAutoStatusOrder();
             await SaveNoHostileNames();
             await SaveAnimationLockTime();
             await SaveHostileCastingArea();
@@ -162,12 +165,23 @@ internal class OtherConfiguration
     public static void ResetPrioTargetId()
     {
         InitOne(ref PrioTargetId, nameof(PrioTargetId), true, true);
-        SaveHostileCastingKnockback().Wait();
+        SavePrioTargetId().Wait();
     }
 
     public static Task SavePrioTargetId()
     {
         return Task.Run(() => Save(PrioTargetId, nameof(PrioTargetId)));
+    }
+
+    public static void ResetAutoStatusOrder()
+    {
+        InitOne(ref AutoStatusOrder, nameof(AutoStatusOrder), true, true);
+        SaveAutoStatusOrder().Wait();
+    }
+
+    public static Task SaveAutoStatusOrder()
+    {
+        return Task.Run(() => Save(AutoStatusOrder, nameof(AutoStatusOrder)));
     }
 
     public static Task SaveNoHostileNames()

--- a/RotationSolver.Basic/Rotations/CustomRotation_Actions.cs
+++ b/RotationSolver.Basic/Rotations/CustomRotation_Actions.cs
@@ -30,6 +30,11 @@ partial class CustomRotation
         setting.ActionCheck = () => !IsLastAction(ActionID.TrueNorthPvE);
     }
 
+    static partial void ModifyShirkPvE(ref ActionSetting setting)
+    {
+        setting.TargetType = TargetType.Tank;
+    }
+
     static partial void ModifyAddlePvE(ref ActionSetting setting)
     {
         setting.TargetStatusProvide = new[] { StatusID.Addle };

--- a/RotationSolver/Commands/RSCommands_Actions.cs
+++ b/RotationSolver/Commands/RSCommands_Actions.cs
@@ -187,6 +187,12 @@ namespace RotationSolver.Commands
             {
                 CancelState();
             }
+            else if (Service.Config.AutoOffWhenDeadPvP && DataCenter.Territory?.IsPvP == true
+                && Player.Available
+                && Player.Object.CurrentHp == 0)
+            {
+                CancelState();
+            }
             else if (Service.Config.AutoOffCutScene
                 && Svc.Condition[ConditionFlag.OccupiedInCutSceneEvent])
             {

--- a/RotationSolver/UI/RotationConfigWindow.cs
+++ b/RotationSolver/UI/RotationConfigWindow.cs
@@ -40,7 +40,7 @@ public partial class RotationConfigWindow : Window
     private const float JOB_ICON_WIDTH = 50;
 
     public RotationConfigWindow()
-        : base("", ImGuiWindowFlags.NoScrollbar, false)
+    : base("", ImGuiWindowFlags.NoScrollbar, false)
     {
         SizeCondition = ImGuiCond.FirstUseEver;
         Size = new Vector2(740f, 490f);
@@ -765,15 +765,11 @@ public partial class RotationConfigWindow : Window
 
         if (ImGui.Button("Reset to Default"))
         {
-            Service.Config.AutoStatusOrder = Enum.GetValues(typeof(AutoStatus))
-                .Cast<AutoStatus>()
-                .Where(status => status != AutoStatus.None)
-                .ToList();
-            Service.Config.Save();
+            OtherConfiguration.ResetAutoStatusOrder();
         }
         ImGui.Spacing();
 
-        var autoStatusOrder = Service.Config.AutoStatusOrder;
+        var autoStatusOrder = OtherConfiguration.AutoStatusOrder.ToList(); // Convert HashSet to List
         bool orderChanged = false;
 
         // Begin a child window to contain the list
@@ -784,6 +780,7 @@ public partial class RotationConfigWindow : Window
         for (int i = 0; i < itemCount; i++)
         {
             var item = autoStatusOrder[i];
+            var itemName = Enum.GetName(typeof(AutoStatus), item) ?? item.ToString(); // Retrieve the status name by its enum value
 
             // Draw up button
             if (ImGuiEx.IconButton(FontAwesomeIcon.ArrowUp, $"##Up{i}") && i > 0)
@@ -810,7 +807,7 @@ public partial class RotationConfigWindow : Window
             ImGui.SameLine();
 
             // Draw the item
-            ImGui.Text(item.ToString());
+            ImGui.Text(itemName);
 
             // Optionally, add tooltips or additional information
             if (ImGui.IsItemHovered())
@@ -825,7 +822,8 @@ public partial class RotationConfigWindow : Window
 
         if (orderChanged)
         {
-            Service.Config.Save();
+            OtherConfiguration.AutoStatusOrder = new HashSet<uint>(autoStatusOrder); // Convert List back to HashSet
+            OtherConfiguration.SaveAutoStatusOrder();
         }
     }
 

--- a/RotationSolver/UI/WelcomeWindow.cs
+++ b/RotationSolver/UI/WelcomeWindow.cs
@@ -13,7 +13,7 @@ namespace RotationSolver.UI
         {
             Size = new Vector2(650, 500);
             SizeCondition = ImGuiCond.FirstUseEver;
-            if (_lastSeenChangelog != _assemblyVersion || !Service.Config.FirstTimeSetupDone)
+            if ((_lastSeenChangelog != _assemblyVersion && Service.Config.ChangelogPopup || !Service.Config.FirstTimeSetupDone) && Service.Config.ChangelogPopup)
             {
                 PopulateChangelogs();
                 IsOpen = true;
@@ -25,7 +25,7 @@ namespace RotationSolver.UI
 #if DEBUG
         private string _assemblyVersion = "6.9.6.9"; //kekw
 #else
-        private string _assemblyVersion = typeof(RotationConfigWindow).Assembly.GetName().Version?.ToString() ?? "4.0.5.4";
+        private string _assemblyVersion = typeof(RotationConfigWindow).Assembly.GetName().Version?.ToString() ?? "7.1.5.24";
 #endif
 
         private string _lastSeenChangelog = Service.Config.LastSeenChangelog;

--- a/RotationSolver/Updaters/StateUpdater.cs
+++ b/RotationSolver/Updaters/StateUpdater.cs
@@ -1,4 +1,5 @@
 ﻿using ECommons.GameHelpers;
+using RotationSolver.Basic.Configuration;
 using RotationSolver.Basic.Configuration.Conditions;
 
 namespace RotationSolver.Updaters;
@@ -24,78 +25,78 @@ internal static class StateUpdater
         AutoStatus status = AutoStatus.None;
 
         // Get the user-defined order of AutoStatus flags
-        var autoStatusOrder = Service.Config.AutoStatusOrder;
+        var autoStatusOrder = OtherConfiguration.AutoStatusOrder;
 
         foreach (var autoStatus in autoStatusOrder)
         {
             switch (autoStatus)
             {
-                case AutoStatus.Dispel:
+                case (uint)AutoStatus.Dispel:
                     if (ShouldAddDispel())
                         status |= AutoStatus.Dispel;
                     break;
 
-                case AutoStatus.Interrupt:
+                case (uint)AutoStatus.Interrupt:
                     if (ShouldAddInterrupt())
                         status |= AutoStatus.Interrupt;
                     break;
 
-                case AutoStatus.AntiKnockback:
+                case (uint)AutoStatus.AntiKnockback:
                     if (ShouldAddAntiKnockback())
                         status |= AutoStatus.AntiKnockback;
                     break;
 
-                case AutoStatus.Positional:
+                case (uint)AutoStatus.Positional:
                     if (ShouldAddPositional())
                         status |= AutoStatus.Positional;
                     break;
 
-                case AutoStatus.HealAreaAbility:
+                case (uint)AutoStatus.HealAreaAbility:
                     if (ShouldAddHealAreaAbility())
                         status |= AutoStatus.HealAreaAbility;
                     break;
 
-                case AutoStatus.HealAreaSpell:
+                case (uint)AutoStatus.HealAreaSpell:
                     if (ShouldAddHealAreaSpell())
                         status |= AutoStatus.HealAreaSpell;
                     break;
 
-                case AutoStatus.HealSingleAbility:
+                case (uint)AutoStatus.HealSingleAbility:
                     if (ShouldAddHealSingleAbility())
                         status |= AutoStatus.HealSingleAbility;
                     break;
 
-                case AutoStatus.HealSingleSpell:
+                case (uint)AutoStatus.HealSingleSpell:
                     if (ShouldAddHealSingleSpell())
                         status |= AutoStatus.HealSingleSpell;
                     break;
 
-                case AutoStatus.DefenseArea:
+                case (uint)AutoStatus.DefenseArea:
                     if (ShouldAddDefenseArea())
                         status |= AutoStatus.DefenseArea;
                     break;
 
-                case AutoStatus.DefenseSingle:
+                case (uint)AutoStatus.DefenseSingle:
                     if (ShouldAddDefenseSingle())
                         status |= AutoStatus.DefenseSingle;
                     break;
 
-                case AutoStatus.Raise:
+                case (uint)AutoStatus.Raise:
                     if (ShouldAddRaise())
                         status |= AutoStatus.Raise;
                     break;
 
-                case AutoStatus.Provoke:
+                case (uint)AutoStatus.Provoke:
                     if (ShouldAddProvoke())
                         status |= AutoStatus.Provoke;
                     break;
 
-                case AutoStatus.TankStance:
+                case (uint)AutoStatus.TankStance:
                     if (ShouldAddTankStance())
                         status |= AutoStatus.TankStance;
                     break;
 
-                case AutoStatus.Speed:
+                case (uint)AutoStatus.Speed:
                     if (ShouldAddSpeed())
                         status |= AutoStatus.Speed;
                     break;


### PR DESCRIPTION
This pull request introduces several changes to the `RotationSolver` project, focusing on configuration updates, new feature additions, and code improvements. The most important changes include the addition of a new configuration option, the refactoring of `AutoStatusOrder` handling, and updates to the UI and rotation logic.

Configuration updates:

* Added new configuration option `_autoOffWhenDeadPvP` to handle automatic turn-off during PvP when the player is dead. (`RotationSolver.Basic/Configuration/Configs.cs`, [RotationSolver.Basic/Configuration/Configs.csR62-R65](diffhunk://#diff-8146c07f057c08a985ecf11930f19a1ce5444efc69fcc45f0edd4e6c341dbe16R62-R65))
* Introduced new configuration option `_changelogPopup` to enable a changelog window popup on updates. (`RotationSolver.Basic/Configuration/Configs.cs`, [RotationSolver.Basic/Configuration/Configs.csR79-R82](diffhunk://#diff-8146c07f057c08a985ecf11930f19a1ce5444efc69fcc45f0edd4e6c341dbe16R79-R82))

Refactoring `AutoStatusOrder` handling:

* Removed `AutoStatusOrder` from `Configs.cs` and added it to `OtherConfiguration.cs` as a `HashSet<uint>`. (`RotationSolver.Basic/Configuration/Configs.cs`, [[1]](diffhunk://#diff-8146c07f057c08a985ecf11930f19a1ce5444efc69fcc45f0edd4e6c341dbe16L28-L32); `RotationSolver.Basic/Configuration/OtherConfiguration.cs`, [[2]](diffhunk://#diff-2a54fb6375225cb426ae0d1fd54b026ac63ca9fe324513272d1ac0b0d28678f6R22)
* Updated methods to initialize, save, and reset `AutoStatusOrder` in `OtherConfiguration.cs`. (`RotationSolver.Basic/Configuration/OtherConfiguration.cs`, [[1]](diffhunk://#diff-2a54fb6375225cb426ae0d1fd54b026ac63ca9fe324513272d1ac0b0d28678f6R37) [[2]](diffhunk://#diff-2a54fb6375225cb426ae0d1fd54b026ac63ca9fe324513272d1ac0b0d28678f6R57) [[3]](diffhunk://#diff-2a54fb6375225cb426ae0d1fd54b026ac63ca9fe324513272d1ac0b0d28678f6L165-R186)

UI updates:

* Modified `DrawAutoStatusOrderConfig` to use the new `AutoStatusOrder` from `OtherConfiguration` and updated the reset functionality. (`RotationSolver/UI/RotationConfigWindow.cs`, [[1]](diffhunk://#diff-44969e3ee4b8d522e4eb8b1ff7712a14af282526ae777e1bbe2ec561a1e9ef0eL768-R772) [[2]](diffhunk://#diff-44969e3ee4b8d522e4eb8b1ff7712a14af282526ae777e1bbe2ec561a1e9ef0eR783) [[3]](diffhunk://#diff-44969e3ee4b8d522e4eb8b1ff7712a14af282526ae777e1bbe2ec561a1e9ef0eL813-R810) [[4]](diffhunk://#diff-44969e3ee4b8d522e4eb8b1ff7712a14af282526ae777e1bbe2ec561a1e9ef0eL828-R826)
* Updated `WelcomeWindow` to check the new `ChangelogPopup` configuration before displaying the changelog. (`RotationSolver/UI/WelcomeWindow.cs`, [[1]](diffhunk://#diff-486fac93191220ee2256f85f40cae119e549bdba0e3cfac850cf3a3b2070b9a5L16-R16) [[2]](diffhunk://#diff-486fac93191220ee2256f85f40cae119e549bdba0e3cfac850cf3a3b2070b9a5L28-R28)

Rotation logic updates:

* Added a new method `ModifyShirkPvE` to set the target type for the `Shirk` action. (`RotationSolver.Basic/Rotations/CustomRotation_Actions.cs`, [RotationSolver.Basic/Rotations/CustomRotation_Actions.csR33-R37](diffhunk://#diff-ae39f8aef64d2e7369998732072f276dae2e30db05638f92f9c7466671fefb5cR33-R37))
* Updated `UpdateRotationState` to handle the new `_autoOffWhenDeadPvP` configuration. (`RotationSolver/Commands/RSCommands_Actions.cs`, [RotationSolver/Commands/RSCommands_Actions.csR190-R195](diffhunk://#diff-00dd18d622b13551bf1910159e3babc95bb17e7bcb06a0c14365be251d24a59bR190-R195))