### PR TITLE
JeunoBoss prio fix

### DIFF
--- a/BasicRotations/Healer/AST_Default.cs
+++ b/BasicRotations/Healer/AST_Default.cs
@@ -1,6 +1,6 @@
 namespace DefaultRotations.Healer;
 
-[Rotation("Default", CombatType.PvE, GameVersion = "7.05")]
+[Rotation("Default", CombatType.PvE, GameVersion = "7.15")]
 [SourceCode(Path = "main/BasicRotations/Healer/AST_Default.cs")]
 [Api(4)]
 public sealed class AST_Default : AstrologianRotation

--- a/BasicRotations/Healer/SCH_Default.cs
+++ b/BasicRotations/Healer/SCH_Default.cs
@@ -1,6 +1,6 @@
 namespace DefaultRotations.Healer;
 
-[Rotation("Default", CombatType.PvE, GameVersion = "7.05")]
+[Rotation("Default", CombatType.PvE, GameVersion = "7.15")]
 [SourceCode(Path = "main/BasicRotations/Healer/SCH_Default.cs")]
 [Api(4)]
 public sealed class SCH_Default : ScholarRotation

--- a/BasicRotations/Healer/SGE_Default.cs
+++ b/BasicRotations/Healer/SGE_Default.cs
@@ -1,6 +1,6 @@
 namespace DefaultRotations.Healer;
 
-[Rotation("Default", CombatType.PvE, GameVersion = "7.05")]
+[Rotation("Default", CombatType.PvE, GameVersion = "7.15")]
 [SourceCode(Path = "main/BasicRotations/Healer/SGE_Default.cs")]
 [Api(4)]
 public sealed class SGE_Default : SageRotation

--- a/BasicRotations/Healer/WHM_Default.cs
+++ b/BasicRotations/Healer/WHM_Default.cs
@@ -2,7 +2,7 @@ using System.ComponentModel;
 
 namespace DefaultRotations.Healer;
 
-[Rotation("Default", CombatType.PvE, GameVersion = "7.05")]
+[Rotation("Default", CombatType.PvE, GameVersion = "7.15")]
 [SourceCode(Path = "main/BasicRotations/Healer/WHM_Default.cs")]
 [Api(4)]
 public sealed class WHM_Default : WhiteMageRotation

--- a/BasicRotations/Limited Jobs/BLU_Basic.cs
+++ b/BasicRotations/Limited Jobs/BLU_Basic.cs
@@ -1,6 +1,6 @@
 namespace DefaultRotations.Magical;
 
-[Rotation("Basic BLU", CombatType.PvE, GameVersion = "7.11")]
+[Rotation("Basic BLU", CombatType.PvE, GameVersion = "7.15")]
 [SourceCode(Path = "main/BasicRotations/Limited Jobs/BLU_Basic.cs")]
 [Api(4)]
 public sealed class Blue_Basic : BlueMageRotation

--- a/BasicRotations/Limited Jobs/BLU_Default.cs
+++ b/BasicRotations/Limited Jobs/BLU_Default.cs
@@ -1,6 +1,6 @@
 namespace DefaultRotations.Magical;
 
-[Rotation("DOES NOT WORK", CombatType.PvE, GameVersion = "7.11")]
+[Rotation("DOES NOT WORK", CombatType.PvE, GameVersion = "7.15")]
 [SourceCode(Path = "main/BasicRotations/Limited Jobs/BLU_Default.cs")]
 [Api(4)]
 public sealed class Blue_Default : BlueMageRotation

--- a/BasicRotations/Limited Jobs/BSM_Default.cs
+++ b/BasicRotations/Limited Jobs/BSM_Default.cs
@@ -1,6 +1,6 @@
 //namespace DefaultRotations.Ranged;
 
-//[Rotation("Default", CombatType.PvE, GameVersion = "7.0")]
+//[Rotation("Default", CombatType.PvE, GameVersion = "7.2")]
 //[SourceCode(Path = "main/BasicRotations/Limited Jobs/BSM_Default.cs")]
 //[Api(1)]
 //public sealed class BSM_Default : BeastmasterRotation

--- a/BasicRotations/Magical/ICWA_PCT_BETA.cs
+++ b/BasicRotations/Magical/ICWA_PCT_BETA.cs
@@ -2,7 +2,7 @@
 
 namespace DefaultRotations.Magical;
 
-[Rotation("IcWa PCT BETA", CombatType.PvE, GameVersion = "7.05", Description = "Kindly created and donated by Rabbs and further update made by IcWa")]
+[Rotation("IcWa PCT BETA", CombatType.PvE, GameVersion = "7.15", Description = "Kindly created and donated by Rabbs and further update made by IcWa")]
 [SourceCode(Path = "main/BasicRotations/Magical/ICWA_PCT_BETA.cs")]
 [Api(4)]
 public sealed class IcWaPctBeta : PictomancerRotation

--- a/BasicRotations/Magical/PCT_Default.cs
+++ b/BasicRotations/Magical/PCT_Default.cs
@@ -1,6 +1,6 @@
 ﻿namespace DefaultRotations.Magical;
 
-[Rotation("Default", CombatType.PvE, GameVersion = "7.05")]
+[Rotation("Default", CombatType.PvE, GameVersion = "7.15")]
 [SourceCode(Path = "main/BasicRotations/Magical/PCT_Default.cs")]
 [Api(4)]
 public sealed class PCT_Default : PictomancerRotation

--- a/BasicRotations/Magical/RDM_Default.cs
+++ b/BasicRotations/Magical/RDM_Default.cs
@@ -1,6 +1,6 @@
 namespace DefaultRotations.Magical;
 
-[Rotation("Default", CombatType.PvE, GameVersion = "7.05")]
+[Rotation("Default", CombatType.PvE, GameVersion = "7.15")]
 [SourceCode(Path = "main/BasicRotations/Magical/RDM_Default.cs")]
 [Api(4)]
 public sealed class RDM_Default : RedMageRotation

--- a/BasicRotations/Magical/SMN_Default.cs
+++ b/BasicRotations/Magical/SMN_Default.cs
@@ -2,7 +2,7 @@
 
 namespace DefaultRotations.Magical;
 
-[Rotation("Default", CombatType.PvE, GameVersion = "7.05")]
+[Rotation("Default", CombatType.PvE, GameVersion = "7.15")]
 [SourceCode(Path = "main/BasicRotations/Magical/SMN_Default.cs")]
 [Api(4)]
 public sealed class SMN_Default : SummonerRotation

--- a/BasicRotations/Melee/DRG_Default.cs
+++ b/BasicRotations/Melee/DRG_Default.cs
@@ -1,6 +1,8 @@
+using System.Drawing.Text;
+
 namespace DefaultRotations.Melee;
 
-[Rotation("Default", CombatType.PvE, GameVersion = "7.05")]
+[Rotation("Default", CombatType.PvE, GameVersion = "7.15")]
 [SourceCode(Path = "main/BasicRotations/Melee/DRG_Default.cs")]
 [Api(4)]
 
@@ -47,6 +49,11 @@ public sealed class DRG_Default : DragoonRotation
     {
         if (IsBurst && InCombat)
         {
+            bool lifeSurgeReady = (Player.HasStatus(true, StatusID.BattleLitany) || Player.HasStatus(true, StatusID.LanceCharge) 
+            || LOTDEndAfter(1000)) && nextGCD.IsTheSameTo(true, HeavensThrustPvE, DrakesbanePvE)
+            || (Player.HasStatus(true, StatusID.BattleLitany) && Player.HasStatus(true, StatusID.LanceCharge) && LOTDEndAfter(1000) && nextGCD.IsTheSameTo(true, ChaoticSpringPvE, LanceBarragePvE, WheelingThrustPvE, FangAndClawPvE))
+            || (nextGCD.IsTheSameTo(true, HeavensThrustPvE, DrakesbanePvE) && (LanceChargePvE.IsInCooldown || BattleLitanyPvE.IsInCooldown));
+
             if ((!BattleLitanyPvE.Cooldown.ElapsedAfter(60) || !BattleLitanyPvE.EnoughLevel) && LanceChargePvE.CanUse(out act)) return true;
 
             if (Player.HasStatus(true, StatusID.LanceCharge) && BattleLitanyPvE.CanUse(out act)) return true;
@@ -54,6 +61,15 @@ public sealed class DRG_Default : DragoonRotation
             if ((Player.HasStatus(true, StatusID.BattleLitany) || Player.HasStatus(true, StatusID.LanceCharge) || LOTDEndAfter(1000)) && nextGCD.IsTheSameTo(true, HeavensThrustPvE, DrakesbanePvE)
             || (Player.HasStatus(true, StatusID.BattleLitany) && Player.HasStatus(true, StatusID.LanceCharge) && LOTDEndAfter(1000) && nextGCD.IsTheSameTo(true, ChaoticSpringPvE, LanceBarragePvE, WheelingThrustPvE, FangAndClawPvE))
             || (nextGCD.IsTheSameTo(true, HeavensThrustPvE, DrakesbanePvE) && (LanceChargePvE.IsInCooldown || BattleLitanyPvE.IsInCooldown)))
+            {
+                if (LifeSurgePvE.CanUse(out act, usedUp: true)) return true;
+            }
+
+            if (lifeSurgeReady 
+                || !DisembowelPvE.EnoughLevel && nextGCD.IsTheSameTo(true, VorpalThrustPvE) 
+                || !FullThrustPvE.EnoughLevel && nextGCD.IsTheSameTo(true, VorpalThrustPvE, DisembowelPvE) 
+                || !LanceChargePvE.EnoughLevel && nextGCD.IsTheSameTo(true, DisembowelPvE, FullThrustPvE)
+                || !BattleLitanyPvE.EnoughLevel && nextGCD.IsTheSameTo(true, ChaosThrustPvE, FullThrustPvE))
             {
                 if (LifeSurgePvE.CanUse(out act, usedUp: true)) return true;
             }

--- a/BasicRotations/Melee/RPR_Default.cs
+++ b/BasicRotations/Melee/RPR_Default.cs
@@ -1,6 +1,6 @@
 ﻿namespace DefaultRotations.Melee;
 
-[Rotation("Default", CombatType.PvE, GameVersion = "7.01", Description = "")]
+[Rotation("Default", CombatType.PvE, GameVersion = "7.15", Description = "")]
 [SourceCode(Path = "main/BasicRotations/Melee/RPR_Default.cs")]
 [Api(4)]
 public sealed class RPR_Default : ReaperRotation

--- a/BasicRotations/Melee/VPR_Default.cs
+++ b/BasicRotations/Melee/VPR_Default.cs
@@ -1,6 +1,6 @@
 ﻿namespace DefaultRotations.Melee;
 
-[Rotation("Default", CombatType.PvE, GameVersion = "7.05")]
+[Rotation("Default", CombatType.PvE, GameVersion = "7.15")]
 [SourceCode(Path = "main/BasicRotations/Melee/VPR_Default.cs")]
 [Api(4)]
 public sealed class VPR_Default : ViperRotation

--- a/BasicRotations/Ranged/DNC_Default.cs
+++ b/BasicRotations/Ranged/DNC_Default.cs
@@ -1,6 +1,6 @@
 namespace DefaultRotations.Ranged;
 
-[Rotation("Default", CombatType.PvE, GameVersion = "7.05", Description = "")]
+[Rotation("Default", CombatType.PvE, GameVersion = "7.15", Description = "")]
 [SourceCode(Path = "main/BasicRotations/Ranged/DNC_Default.cs")]
 [Api(4)]
 public sealed class DNC_Default : DancerRotation

--- a/BasicRotations/Tank/GNB_Default.cs
+++ b/BasicRotations/Tank/GNB_Default.cs
@@ -1,6 +1,6 @@
 namespace DefaultRotations.Tank;
 
-[Rotation("Default", CombatType.PvE, GameVersion = "7.11")]
+[Rotation("Default", CombatType.PvE, GameVersion = "7.15")]
 [SourceCode(Path = "main/BasicRotations/Tank/GNB_Default.cs")]
 [Api(4)]
 public sealed class GNB_Default : GunbreakerRotation

--- a/BasicRotations/Tank/PLD_Beta.cs
+++ b/BasicRotations/Tank/PLD_Beta.cs
@@ -14,6 +14,9 @@ public sealed class PLD_Beta : PaladinRotation
     [RotationConfig(CombatType.PvE, Name = "Use Hallowed Ground with Cover")]
     private bool HallowedWithCover { get; set; } = true;
 
+    [RotationConfig(CombatType.PvE, Name = "Use up both stacks of Intervene during burst window")]
+    private bool UseInterveneFight { get; set; } = true;
+
     [Range(0, 100, ConfigUnitType.Pixels)]
     [RotationConfig(CombatType.PvE, Name = "Use Sheltron at minimum X Oath to prevent over cap (Set to 0 to disable)")]
     private int WhenToSheltron { get; set; } = 100;
@@ -125,11 +128,7 @@ public sealed class PLD_Beta : PaladinRotation
         act = null;
         if (PassageProtec && Player.HasStatus(true, StatusID.PassageOfArms)) return false;
 
-        if (OathGauge >= WhenToSheltron && WhenToSheltron > 0 && UseOath(out act)) return true;
-
-        if (!RiotBladePvE.EnoughLevel && FightOrFlightPvE.CanUse(out act)) return true;
-        if (!RageOfHalonePvE.EnoughLevel && nextGCD.IsTheSameTo(true, RiotBladePvE) && FightOrFlightPvE.CanUse(out act)) return true;
-        if (!ProminencePvE.EnoughLevel && nextGCD.IsTheSameTo(true, RageOfHalonePvE) && FightOrFlightPvE.CanUse(out act)) return true;
+        if (InCombat && OathGauge >= WhenToSheltron && WhenToSheltron > 0 && UseOath(out act)) return true;
         return base.GeneralAbility(nextGCD, out act);
     }
     [RotationDesc(ActionID.SpiritsWithinPvE)]
@@ -151,7 +150,7 @@ public sealed class PLD_Beta : PaladinRotation
         if (FightOrFlightPvE.Cooldown.IsCoolingDown && CircleOfScornPvE.CanUse(out act)) return true;
         if (FightOrFlightPvE.Cooldown.IsCoolingDown && ExpiacionPvE.CanUse(out act)) return true;
         if (FightOrFlightPvE.Cooldown.IsCoolingDown && SpiritsWithinPvE.CanUse(out act)) return true;
-        if (!IsMoving && IntervenePvE.CanUse(out act, usedUp: HasFightOrFlight)) return true;
+        if (!IsMoving && IntervenePvE.CanUse(out act, usedUp: UseInterveneFight && HasFightOrFlight)) return true;
         return base.AttackAbility(nextGCD, out act);
     }
     #endregion

--- a/BasicRotations/Tank/WAR_Default.cs
+++ b/BasicRotations/Tank/WAR_Default.cs
@@ -1,6 +1,6 @@
 namespace DefaultRotations.Tank;
 
-[Rotation("Default", CombatType.PvE, GameVersion = "7.05")]
+[Rotation("Default", CombatType.PvE, GameVersion = "7.15")]
 [SourceCode(Path = "main/BasicRotations/Tank/WAR_Default.cs")]
 [Api(4)]
 public sealed class WAR_Default : WarriorRotation


### PR DESCRIPTION
This pull request includes a series of updates to various rotation files to reflect changes in game version and some additional functionality improvements. The most significant changes involve updating the game version for various rotations, adding new configuration options, and enhancing existing methods.

### Game Version Updates:
* Updated game version to "7.15" in `BasicRotations/Healer/AST_Default.cs`, `BasicRotations/Healer/SCH_Default.cs`, `BasicRotations/Healer/SGE_Default.cs`, `BasicRotations/Healer/WHM_Default.cs`, `BasicRotations/Limited Jobs/BLU_Basic.cs`, `BasicRotations/Limited Jobs/BLU_Default.cs`, `BasicRotations/Magical/ICWA_PCT_BETA.cs`, `BasicRotations/Magical/PCT_Default.cs`, `BasicRotations/Magical/RDM_Default.cs`, `BasicRotations/Magical/SMN_Default.cs`, `BasicRotations/Melee/DRG_Default.cs`, `BasicRotations/Melee/RPR_Default.cs`, `BasicRotations/Melee/VPR_Default.cs`, `BasicRotations/Ranged/DNC_Default.cs`, `BasicRotations/Tank/GNB_Default.cs`, `BasicRotations/Tank/WAR_Default.cs` [[1]](diffhunk://#diff-330bfb6ae846185576f35b43bc761c7df2df5783898500d8d4500a10b8523918L3-R3) [[2]](diffhunk://#diff-47b613c092bac6c0fca7f78e0876e61724dc22b2706305872f6854f87940aea8L3-R3) [[3]](diffhunk://#diff-048922cde007c3a11c8a1edea2742248b0c16ceb8806c7c8f14c6e2fbd612898L3-R3) [[4]](diffhunk://#diff-fbffa564df294aeb6931debccf5f27492b868d6d4314d7d96f31689233ec0936L5-R5) [[5]](diffhunk://#diff-3e56e9f9ab22f53d36d367513c7042b42af1482f3836b95d20eadc7e1f4c50a1L3-R3) [[6]](diffhunk://#diff-fa0f690f671b57eb26ec5c64e29551eac26a6601e23cf37cdc0f3da2bd9224e3L3-R3) [[7]](diffhunk://#diff-d88c245dcedaea407c12d82ae54b72dc27b4b9147819aae2fa1ad25ac22f4b04L5-R5) [[8]](diffhunk://#diff-1dba57f32afcb34c62ded341d867ea72affff6da11d4fb6a9ad4f1c74625467eL3-R3) [[9]](diffhunk://#diff-124b9f747e1a79431fec6fd7539133f4f99db00bcb2e9e7d59ce59009fe9da88L3-R3) [[10]](diffhunk://#diff-83d53925ae6d8c58ca3a83c9acc9c24e4b19aee37422b55b17623abbe6cc2eecL5-R5) [[11]](diffhunk://#diff-408e51743495f585bdfcad7e9eaab67629eb3c88c8726ed094b6cf54ee32cc6cR1-R5) [[12]](diffhunk://#diff-41766f5a9e8781501954ec98e728f10db303d9af6d66cda08bc4b5d2fbe35259L3-R3) [[13]](diffhunk://#diff-7427c87a4c87139d96976bd9e060154f4dca608d51a6e2484ceeaef68dcdcc76L3-R3) [[14]](diffhunk://#diff-f3d2d26c8e682a2ef686dac15ef52289c13d134f88807b48ccb342f7fd9f35daL3-R3) [[15]](diffhunk://#diff-2f876854b9479311f1c5a602aed03a90f3540f769265b55c38422a2505a77d07L3-R3) [[16]](diffhunk://#diff-eae4d6a3e2a4e0e4e9f8e21321a88c6d03946aa3c7a270769b20d2651417e98aL3-R3).

### Functional Enhancements:
* Added new configuration option `UseInterveneFight` to `PLD_Beta` rotation to use both stacks of Intervene during burst window (`BasicRotations/Tank/PLD_Beta.cs`).
* Improved `EmergencyAbility` method in `DRG_Default` rotation to include additional conditions for `lifeSurgeReady` (`BasicRotations/Melee/DRG_Default.cs`) [[1]](diffhunk://#diff-408e51743495f585bdfcad7e9eaab67629eb3c88c8726ed094b6cf54ee32cc6cR52-R56) [[2]](diffhunk://#diff-408e51743495f585bdfcad7e9eaab67629eb3c88c8726ed094b6cf54ee32cc6cR67-R75).
* Enhanced `GeneralAbility` and `AttackAbility` methods in `PLD_Beta` rotation to better handle Oath Gauge and Intervene usage (`BasicRotations/Tank/PLD_Beta.cs`) [[1]](diffhunk://#diff-a3a9a9026a4a0c8a1f5225bc7e0ec105c6cb90febbc87cf76f83f31db5fea6b0L128-R131) [[2]](diffhunk://#diff-a3a9a9026a4a0c8a1f5225bc7e0ec105c6cb90febbc87cf76f83f31db5fea6b0L154-R153).

### Codebase Improvements:
* Added `System.Drawing.Text` namespace to `DRG_Default` rotation (`BasicRotations/Melee/DRG_Default.cs`).
* Modified `ObjectHelper` methods to improve status checks and logging (`RotationSolver.Basic/Helpers/ObjectHelper.cs`) [[1]](diffhunk://#diff-44cc6e98dcd8c3d2aa47210ec76d800058560df9bbff9ce225b3116c47ddc1fcR9) [[2]](diffhunk://#diff-44cc6e98dcd8c3d2aa47210ec76d800058560df9bbff9ce225b3116c47ddc1fcL68-R69) [[3]](diffhunk://#diff-44cc6e98dcd8c3d2aa47210ec76d800058560df9bbff9ce225b3116c47ddc1fcL398-R430) [[4]](diffhunk://#diff-44cc6e98dcd8c3d2aa47210ec76d800058560df9bbff9ce225b3116c47ddc1fcL497-R531) [[5]](diffhunk://#diff-44cc6e98dcd8c3d2aa47210ec76d800058560df9bbff9ce225b3116c47ddc1fcL512-R542).