### PR TITLE
PLD Beta update and AOE Heal correction

### DIFF
--- a/BasicRotations/Tank/PLD_Beta.cs
+++ b/BasicRotations/Tank/PLD_Beta.cs
@@ -28,6 +28,9 @@ public sealed class PLD_Beta : PaladinRotation
     [Range(0, 1, ConfigUnitType.Percent)]
     [RotationConfig(CombatType.PvE, Name = "Health threshold for Cover (Set to 0 to disable)")]
     private float CoverRatio { get; set; } = 0.3f;
+
+    [RotationConfig(CombatType.PvE, Name = "Use Holy Spirit when out of melee range")]
+    private bool UseHolyWhenAway { get; set; } = false;
     #endregion
 
     private const ActionID ConfiteorPvEActionId = (ActionID)16459;
@@ -137,7 +140,7 @@ public sealed class PLD_Beta : PaladinRotation
         act = null;
         if (PassageProtec && Player.HasStatus(true, StatusID.PassageOfArms)) return false;
 
-        if (BladeOfHonorPvE.CanUse(out act)) return true;
+        if (BladeOfHonorPvE.CanUse(out act, skipAoeCheck: true)) return true;
 
         if (!RiotBladePvE.EnoughLevel && FightOrFlightPvE.CanUse(out act)) return true;
         if (!RageOfHalonePvE.EnoughLevel && nextGCD.IsTheSameTo(true, RiotBladePvE) && FightOrFlightPvE.CanUse(out act)) return true;
@@ -207,7 +210,7 @@ public sealed class PLD_Beta : PaladinRotation
         if (FastBladePvE.CanUse(out act)) return true;
 
         //Ranged
-        if (StopMovingTime > 1 && HolySpiritPvE.CanUse(out act)) return true;
+        if (UseHolyWhenAway && StopMovingTime > 1 && HolySpiritPvE.CanUse(out act)) return true;
         if (ShieldLobPvE.CanUse(out act)) return true;
         return base.GeneralGCD(out act);
     }

--- a/RotationSolver.Basic/Data/AutoStatus.cs
+++ b/RotationSolver.Basic/Data/AutoStatus.cs
@@ -42,24 +42,24 @@ public enum AutoStatus : uint
     DefenseArea = 1 << 5,
 
     /// <summary>
-    /// We should heal single by ability.
-    /// </summary>
-    HealSingleAbility = 1 << 6,
-
-    /// <summary>
-    /// We should heal single by spell.
-    /// </summary>
-    HealSingleSpell = 1 << 7,
-
-    /// <summary>
     /// We should heal area by ability.
     /// </summary>
-    HealAreaAbility = 1 << 8,
+    HealAreaAbility = 1 << 6,
 
     /// <summary>
     /// We should heal area by spell.
     /// </summary>
-    HealAreaSpell = 1 << 9,
+    HealAreaSpell = 1 << 7,
+
+    /// <summary>
+    /// We should heal single by ability.
+    /// </summary>
+    HealSingleAbility = 1 << 8,
+
+    /// <summary>
+    /// We should heal single by spell.
+    /// </summary>
+    HealSingleSpell = 1 << 9,
 
     /// <summary>
     /// We should raise.

--- a/RotationSolver.Basic/Rotations/Basic/PaladinRotation.cs
+++ b/RotationSolver.Basic/Rotations/Basic/PaladinRotation.cs
@@ -198,6 +198,7 @@ partial class PaladinRotation
         setting.CreateConfig = () => new ActionConfig()
         {
             AoeCount = 3,
+            TimeToKill = 0,
         };
     }
 


### PR DESCRIPTION
This pull request includes several updates to the `PLD_Beta` class in `BasicRotations/Tank/PLD_Beta.cs`, changes to the `AutoStatus` enum in `RotationSolver.Basic/Data/AutoStatus.cs`, and a modification to the `ModifyCircleOfScornPvE` method in `RotationSolver.Basic/Rotations/Basic/PaladinRotation.cs`. The most important changes are summarized below:

### Updates to `PLD_Beta` class:

* Added a new configuration option `UseHolyWhenAway` to allow the use of Holy Spirit when out of melee range.
* Modified the `AttackAbility` method to skip the AoE check when using `BladeOfHonorPvE`.
* Updated the `GeneralGCD` method to respect the new `UseHolyWhenAway` configuration option when deciding to use Holy Spirit.

### Changes to `AutoStatus` enum:

* Corrected the descriptions and values for healing abilities and spells, swapping single and area healing statuses.

### Modification to `ModifyCircleOfScornPvE` method:

* Added a `TimeToKill` property with a default value of 0 in the `ActionConfig` for `CircleOfScornPvE`.