### PR TITLE
Update SGE and PLD classes; remove ConfiteorPvEActionId

### DIFF
--- a/BasicRotations/Healer/SGE_Default.cs
+++ b/BasicRotations/Healer/SGE_Default.cs
@@ -339,6 +339,21 @@ public sealed class SGE_Default : SageRotation
 
         if (HasSwift && SwiftLogic && EgeiroPvE.CanUse(out _)) return false;
 
+        if (EukrasianDiagnosisPvE.CanUse(out act) && MergedStatus.HasFlag(AutoStatus.DefenseSingle))
+        {
+            if (EukrasianDiagnosisPvE.Target.Target?.HasStatus(true,
+                StatusID.EukrasianDiagnosis,
+                StatusID.DifferentialDiagnosis,
+                StatusID.EukrasianPrognosis,
+                StatusID.Galvanize
+            ) ?? false) return false;
+
+            if (EukrasiaPvE.CanUse(out act)) return true;
+
+            act = EukrasianDiagnosisPvE;
+            return true;
+        }
+
         if (!InCombat && !Player.HasStatus(true, StatusID.Eukrasia) && EukrasiaPvE.CanUse(out act)) return true;
 
         if (HostileTarget?.IsBossFromTTK() ?? false)
@@ -390,7 +405,7 @@ public sealed class SGE_Default : SageRotation
 
         if (DyskrasiaPvE.CanUse(out _))
         {
-            if (EukrasianDyskrasiaPvE.EnoughLevel && (EukrasianDyskrasiaPvE.Target.Target?.WillStatusEnd(3, true, EukrasianDyskrasiaPvE.Setting.TargetStatusProvide ?? []) ?? false) && InCombat)
+            if (EukrasianDyskrasiaPvE.EnoughLevel && (EukrasianDyskrasiaPvE.Target.Target?.WillStatusEnd(3, true, EukrasianDyskrasiaPvE.Setting.TargetStatusProvide ?? []) ?? false) && InCombat && (!MergedStatus.HasFlag(AutoStatus.DefenseArea) || !MergedStatus.HasFlag(AutoStatus.DefenseSingle)))
             {
                 StatusHelper.StatusOff(StatusID.Eukrasia);
             }
@@ -412,7 +427,7 @@ public sealed class SGE_Default : SageRotation
 
         if (DosisPvE.CanUse(out _))
         {
-            if ((EukrasianDosisPvE.Target.Target?.WillStatusEnd(3, true, EukrasianDosisPvE.Setting.TargetStatusProvide ?? []) ?? false) && InCombat)
+            if ((EukrasianDosisPvE.Target.Target?.WillStatusEnd(3, true, EukrasianDosisPvE.Setting.TargetStatusProvide ?? []) ?? false) && InCombat && (!MergedStatus.HasFlag(AutoStatus.DefenseArea) || !MergedStatus.HasFlag(AutoStatus.DefenseSingle)))
             {
                 StatusHelper.StatusOff(StatusID.Eukrasia);
             }

--- a/BasicRotations/Tank/PLD_Beta.cs
+++ b/BasicRotations/Tank/PLD_Beta.cs
@@ -36,6 +36,9 @@ public sealed class PLD_Beta : PaladinRotation
     private const ActionID ConfiteorPvEActionId = (ActionID)16459;
     private new readonly IBaseAction ConfiteorPvE = new BaseAction(ConfiteorPvEActionId);
 
+    private const ActionID ImperatorPvEActionId = (ActionID)36921;
+    private new readonly IBaseAction ImperatorPvE = new BaseAction(ImperatorPvEActionId);
+
     #region Countdown Logic
     protected override IAction? CountDownAction(float remainTime)
     {
@@ -147,8 +150,8 @@ public sealed class PLD_Beta : PaladinRotation
         if (!SwordOathTrait.EnoughLevel && nextGCD.IsTheSameTo(true, RoyalAuthorityPvE) && FightOrFlightPvE.CanUse(out act)) return true;
         if (SwordOathTrait.EnoughLevel && Player.HasStatus(true, StatusID.AtonementReady) && FightOrFlightPvE.CanUse(out act)) return true;
 
-        if (IsLastAbility(true, FightOrFlightPvE) && ImperatorPvE.CanUse(out act, skipAoeCheck: true)) return true;
-        if (IsLastAbility(true, FightOrFlightPvE) && RequiescatPvE.CanUse(out act)) return true;
+        if (IsLastAbility(true, FightOrFlightPvE) && ImperatorPvE.CanUse(out act, skipAoeCheck: true, usedUp: true)) return true;
+        if (IsLastAbility(true, FightOrFlightPvE) && RequiescatPvE.CanUse(out act, skipAoeCheck: true, usedUp: true)) return true;
          
         if (FightOrFlightPvE.Cooldown.IsCoolingDown && CircleOfScornPvE.CanUse(out act, skipAoeCheck: true)) return true;
         if (FightOrFlightPvE.Cooldown.IsCoolingDown && ExpiacionPvE.CanUse(out act, skipAoeCheck: true)) return true;

--- a/RotationSolver.Basic/Rotations/Basic/PaladinRotation.cs
+++ b/RotationSolver.Basic/Rotations/Basic/PaladinRotation.cs
@@ -5,8 +5,6 @@ partial class PaladinRotation
     /// <inheritdoc/>
     public override MedicineType MedicineType => MedicineType.Strength;
 
-    private const ActionID ConfiteorPvEActionId = (ActionID)16459;
-
     /// <summary>
     /// 
     /// </summary>


### PR DESCRIPTION
This pull request includes several updates to the healer and tank rotations, as well as a submodule update. The most important changes include adding new actions to the Paladin rotation, updating the logic for the healer's general GCD, and modifying the conditions for certain actions.

### Healer Rotation Updates:
* Added logic to use `EukrasianDiagnosisPvE` based on specific statuses in `GeneralGCD` method in `SGE_Default.cs`.
* Updated conditions for `EukrasianDyskrasiaPvE` and `EukrasianDosisPvE` to check for additional status flags in `GeneralGCD` method in `SGE_Default.cs`. [[1]](diffhunk://#diff-048922cde007c3a11c8a1edea2742248b0c16ceb8806c7c8f14c6e2fbd612898L393-R408) [[2]](diffhunk://#diff-048922cde007c3a11c8a1edea2742248b0c16ceb8806c7c8f14c6e2fbd612898L415-R430)

### Tank Rotation Updates:
* Added `ImperatorPvE` action to `PLD_Beta` class in `PLD_Beta.cs`.
* Updated `AttackAbility` method to include `skipAoeCheck` and `usedUp` parameters for `ImperatorPvE` and `RequiescatPvE` actions in `PLD_Beta.cs`.

### Submodule Update:
* Updated the `ECommons` submodule to a new commit.