### PR TITLE
Change card check from TheArrowPvE to TheEwerPvE

### DIFF
--- a/BasicRotations/Healer/AST_Default.cs
+++ b/BasicRotations/Healer/AST_Default.cs
@@ -176,7 +176,7 @@ public sealed class AST_Default : AstrologianRotation
         if (AstralDrawPvE.Cooldown.WillHaveOneCharge(3) && LadyOfCrownsPvE.CanUse(out act)) return true;
 
         // Use cards if you are about to use Umbral or Astral Draw (to prevent overwriting)
-        if (AstralDrawPvE.Cooldown.WillHaveOneCharge(3) && InCombat && TheArrowPvE.CanUse(out act)) return true;
+        if (AstralDrawPvE.Cooldown.WillHaveOneCharge(3) && InCombat && TheEwerPvE.CanUse(out act)) return true;
         if (AstralDrawPvE.Cooldown.WillHaveOneCharge(3) && InCombat && TheBolePvE.CanUse(out act)) return true;
         if (UmbralDrawPvE.Cooldown.WillHaveOneCharge(3) && InCombat && TheArrowPvE.CanUse(out act)) return true;
         if (UmbralDrawPvE.Cooldown.WillHaveOneCharge(3) && InCombat && TheSpirePvE.CanUse(out act)) return true;


### PR DESCRIPTION
Modified the condition for using a card when the AstralDrawPvE cooldown will have one charge in 3 seconds and the player is in combat. Specifically, replaced the check for using TheArrowPvE card with a check for using TheEwerPvE card. The rest of the conditions and logic remain unchanged.