### PR TITLE
Adjust cooldowns and streamline Monk action checks

### DIFF
--- a/BasicRotations/Healer/AST_Default.cs
+++ b/BasicRotations/Healer/AST_Default.cs
@@ -183,8 +183,8 @@ public sealed class AST_Default : AstrologianRotation
 
         if (AstralDrawPvE.CanUse(out act)) return true;
         if (UmbralDrawPvE.CanUse(out act)) return true;
-        if ((Player.HasStatus(true, StatusID.Divination) || !DivinationPvE.Cooldown.WillHaveOneCharge(45) || !DivinationPvE.EnoughLevel || UmbralDrawPvE.Cooldown.WillHaveOneCharge(3)) && InCombat && TheBalancePvE.CanUse(out act)) return true;
-        if ((Player.HasStatus(true, StatusID.Divination) || !DivinationPvE.Cooldown.WillHaveOneCharge(45) || !DivinationPvE.EnoughLevel || AstralDrawPvE.Cooldown.WillHaveOneCharge(3)) && InCombat && TheSpearPvE.CanUse(out act)) return true;
+        if ((Player.HasStatus(true, StatusID.Divination) || !DivinationPvE.Cooldown.WillHaveOneCharge(66) || !DivinationPvE.EnoughLevel) && InCombat && TheBalancePvE.CanUse(out act)) return true;
+        if ((Player.HasStatus(true, StatusID.Divination) || !DivinationPvE.Cooldown.WillHaveOneCharge(66) || !DivinationPvE.EnoughLevel) && InCombat && TheSpearPvE.CanUse(out act)) return true;
         return base.GeneralAbility(nextGCD, out act);
     }
 

--- a/BasicRotations/Melee/MNK_Default.cs
+++ b/BasicRotations/Melee/MNK_Default.cs
@@ -88,22 +88,20 @@ public sealed class MNK_Default : MonkRotation
 
         if (InBrotherhood)
         {
-            // 'If you are in brotherhood, and you have 10 chakra, and forbidden chakra is available, use it.'
-            if (Chakra == 10 && TheForbiddenChakraPvE.CanUse(out act)) return true;
-            // 'If you are in brotherhood, and forbidden chakra is available, use it regardless of stacks.'
-            if (Player.WillStatusEndGCD(1, 0, true, StatusID.Brotherhood) && TheForbiddenChakraPvE.CanUse(out act)) return true;
+            // 'If you are in brotherhood and forbidden chakra is available, use it.'
+            if (TheForbiddenChakraPvE.CanUse(out act)) return true;
         }
         if (!InBrotherhood)
         {
-            // 'If you are not in brotherhood, have 5 chakra, and brotherhood is about to be available, hold.'
-            if (Chakra == 5 && BrotherhoodPvE.Cooldown.WillHaveOneChargeGCD(1) && TheForbiddenChakraPvE.CanUse(out act)) return false;
-            // 'If you are not in brotherhood, have 5 chakra, and brotherhood is in cooldown, use it.'
-            if (Chakra == 5 && BrotherhoodPvE.Cooldown.IsCoolingDown && TheForbiddenChakraPvE.CanUse(out act)) return true;
+            // 'If you are not in brotherhood and brotherhood is about to be available, hold for burst.'
+            if (BrotherhoodPvE.Cooldown.WillHaveOneChargeGCD(1) && TheForbiddenChakraPvE.CanUse(out act)) return false;
+            // 'If you are not in brotherhood use it.'
+            if (TheForbiddenChakraPvE.CanUse(out act)) return true;
         }
         if (!TheForbiddenChakraPvE.EnoughLevel)
         {
             // 'If you are not high enough level for TheForbiddenChakra, use immediately at 5 chakra.'
-            if (Chakra == 5 && SteelPeakPvE.CanUse(out act)) return true;
+            if (SteelPeakPvE.CanUse(out act)) return true;
         }
 
         return base.EmergencyAbility(nextGCD, out act);

--- a/RotationSolver.Basic/Rotations/Basic/MonkRotation.cs
+++ b/RotationSolver.Basic/Rotations/Basic/MonkRotation.cs
@@ -83,12 +83,12 @@ partial class MonkRotation
 
     static partial void ModifySteeledMeditationPvE(ref ActionSetting setting)
     {
-        setting.ActionCheck = () => Chakra < 5;
+        setting.ActionCheck = () => (!InBrotherhood && Chakra < 5 || InBrotherhood && Chakra < 10);
     }
 
     static partial void ModifySteelPeakPvE(ref ActionSetting setting)
     {
-        setting.ActionCheck = () => InCombat && Chakra == 5;
+        setting.ActionCheck = () => InCombat && (!InBrotherhood && Chakra == 5 || InBrotherhood && Chakra >= 5);
         setting.UnlockedByQuestID = 66094;
     }
 
@@ -134,12 +134,12 @@ partial class MonkRotation
 
     static partial void ModifyInspiritedMeditationPvE(ref ActionSetting setting)
     {
-        setting.ActionCheck = () => Chakra < 5;
+        setting.ActionCheck = () => (!InBrotherhood && Chakra < 5 || InBrotherhood && Chakra < 10);
     }
 
     static partial void ModifyHowlingFistPvE(ref ActionSetting setting)
     {
-        setting.ActionCheck = () => InCombat && Chakra == 5;
+        setting.ActionCheck = () => InCombat && (!InBrotherhood && Chakra == 5 || InBrotherhood && Chakra >= 5);
         setting.UnlockedByQuestID = 66599;
         setting.CreateConfig = () => new ActionConfig()
         {
@@ -189,12 +189,12 @@ partial class MonkRotation
 
     static partial void ModifyForbiddenMeditationPvE(ref ActionSetting setting)
     {
-        setting.ActionCheck = () => Chakra < 5;
+        setting.ActionCheck = () => (!InBrotherhood && Chakra < 5 || InBrotherhood && Chakra < 10);
     }
 
     static partial void ModifyTheForbiddenChakraPvE(ref ActionSetting setting)
     {
-        setting.ActionCheck = () => InCombat;
+        setting.ActionCheck = () => InCombat && (!InBrotherhood && Chakra == 5 || InBrotherhood && Chakra >= 5);
         setting.UnlockedByQuestID = 67564;
     }
 
@@ -294,12 +294,12 @@ partial class MonkRotation
 
     static partial void ModifyEnlightenedMeditationPvE(ref ActionSetting setting)
     {
-        setting.ActionCheck = () => Chakra < 5;
+        setting.ActionCheck = () => (!InBrotherhood && Chakra < 5 || InBrotherhood && Chakra < 10);
     }
 
     static partial void ModifyEnlightenmentPvE(ref ActionSetting setting)
     {
-        setting.ActionCheck = () => InCombat && Chakra == 5;
+        setting.ActionCheck = () => InCombat && (!InBrotherhood && Chakra == 5 || InBrotherhood && Chakra >= 5);
         setting.CreateConfig = () => new ActionConfig()
         {
             AoeCount = 3,


### PR DESCRIPTION
This pull request includes several changes to the `BasicRotations` and `RotationSolver.Basic` files to improve the handling of abilities in different combat states, particularly focusing on the `Brotherhood` status and `Chakra` levels for the Monk class. The most important changes include adjustments to the general and emergency abilities, as well as modifications to action settings for various Monk abilities.

### Adjustments to Abilities:

* [`BasicRotations/Healer/AST_Default.cs`](diffhunk://#diff-330bfb6ae846185576f35b43bc761c7df2df5783898500d8d4500a10b8523918L186-R187): Updated the cooldown check for `DivinationPvE` from 45 to 66 seconds in the `GeneralAbility` method.
* [`BasicRotations/Melee/MNK_Default.cs`](diffhunk://#diff-c8f54622438b0935ab3c9c0d37c4ef394d8a28f6a371bdf821005760f98f7ca3L91-R104): Simplified the logic in the `EmergencyAbility` method for handling `TheForbiddenChakraPvE` usage based on `Brotherhood` status.

### Modifications to Monk Abilities:

* [`RotationSolver.Basic/Rotations/Basic/MonkRotation.cs`](diffhunk://#diff-4329964d5c7e9b451e6bcf0dac0480f29a253fccfcc762827ac14436ccc709aaL86-R91): Updated the `ActionCheck` logic for `SteeledMeditationPvE`, `SteelPeakPvE`, `InspiritedMeditationPvE`, `HowlingFistPvE`, `ForbiddenMeditationPvE`, `TheForbiddenChakraPvE`, `EnlightenedMeditationPvE`, and `EnlightenmentPvE` to account for `Brotherhood` status and different `Chakra` levels. [[1]](diffhunk://#diff-4329964d5c7e9b451e6bcf0dac0480f29a253fccfcc762827ac14436ccc709aaL86-R91) [[2]](diffhunk://#diff-4329964d5c7e9b451e6bcf0dac0480f29a253fccfcc762827ac14436ccc709aaL137-R142) [[3]](diffhunk://#diff-4329964d5c7e9b451e6bcf0dac0480f29a253fccfcc762827ac14436ccc709aaL192-R197) [[4]](diffhunk://#diff-4329964d5c7e9b451e6bcf0dac0480f29a253fccfcc762827ac14436ccc709aaL297-R302)