### PR TITLE
Complete overhaul of Sage, updated Paladin buff logic for lower level support

### DIFF
--- a/BasicRotations/Healer/SGE_Default.cs
+++ b/BasicRotations/Healer/SGE_Default.cs
@@ -171,7 +171,6 @@ public sealed class SGE_Default : SageRotation
 
         if (SoteriaPvE.CanUse(out act) && PartyMembers.Any(b => b.HasStatus(true, StatusID.Kardion) && b.GetHealthRatio() < SoteriaHeal)) return true;
 
-
         var tank = PartyMembers.GetJobCategory(JobRole.Tank);
         if (Addersgall < 1 && (tank.Any(t => t.GetHealthRatio() < OGCDTankHeal) || PartyMembers.Any(b => b.GetHealthRatio() < OGCDHeal)))
         {
@@ -201,7 +200,6 @@ public sealed class SGE_Default : SageRotation
     }
 
     [RotationDesc(ActionID.EukrasianPrognosisPvE, ActionID.EukrasianPrognosisIiPvE)]
-
     protected override bool GeneralAbility(IAction nextGCD, out IAction? act)
     {
         // If not in combat and lacking the Kardia status, attempt to use KardiaPvE
@@ -219,69 +217,113 @@ public sealed class SGE_Default : SageRotation
     }
     #endregion
 
+    #region Eukrasia Logic
+    private IBaseAction? _EukrasiaActionAim = null;
+
+    // Sets the target Eukrasia action to be performed next.
+    // If the action is null, it exits early.
+    // If the current action aim is not null and the last action matches certain conditions, it exits early.
+    // Finally, updates the current Eukrasia action aim if it's different from the incoming action.
+    private void SetEukrasia(IBaseAction act)
+    {
+        if (act == null) return;
+
+        if (_EukrasiaActionAim != null && IsLastGCD(false, _EukrasiaActionAim)) return;
+
+        if (_EukrasiaActionAim != act)
+        {
+            _EukrasiaActionAim = act;
+        }
+    }
+
+    // Clears the Eukrasia action aim, effectively resetting any planned Eukrasia action.
+    private void ClearEukrasia()
+    {
+        if (_EukrasiaActionAim != null)
+        {
+            _EukrasiaActionAim = null;
+        }
+    }
+
+    private bool ChoiceEukrasia(out IAction? act)
+    {
+        act = null;
+
+        if (!EukrasiaPvE.CanUse(out _)) return false;
+        // Checks for Eukrasia status.
+        // Attempts to set correct Eurkrasia action based on availablity and MergedStatus.
+        if (EukrasianPrognosisIiPvE.CanUse(out _) && EukrasianPrognosisIiPvE.EnoughLevel && MergedStatus.HasFlag(AutoStatus.DefenseArea))
+        {
+            SetEukrasia(EukrasianPrognosisIiPvE);
+            return false;
+        }
+
+        if (EukrasianPrognosisPvE.CanUse(out _) && EukrasianPrognosisPvE.EnoughLevel && MergedStatus.HasFlag(AutoStatus.DefenseArea))
+        {
+            SetEukrasia(EukrasianPrognosisPvE);
+            return false;
+        }
+
+        if (EukrasianDiagnosisPvE.CanUse(out _) && EukrasianDiagnosisPvE.EnoughLevel && MergedStatus.HasFlag(AutoStatus.DefenseSingle))
+        {
+            SetEukrasia(EukrasianDiagnosisPvE);
+            return false;
+        }
+
+        if (EukrasianDyskrasiaPvE.CanUse(out _) && EukrasianDyskrasiaPvE.EnoughLevel && (!MergedStatus.HasFlag(AutoStatus.DefenseSingle) || !MergedStatus.HasFlag(AutoStatus.DefenseSingle)))
+        {
+            SetEukrasia(EukrasianDyskrasiaPvE);
+            return false;
+        }
+
+        if (EukrasianDosisIiiPvE.CanUse(out _) && EukrasianDosisIiiPvE.EnoughLevel && (!MergedStatus.HasFlag(AutoStatus.DefenseSingle) || !MergedStatus.HasFlag(AutoStatus.DefenseSingle)))
+        {
+            SetEukrasia(EukrasianDosisIiiPvE);
+            return false;
+        }
+
+        if (EukrasianDosisIiPvE.CanUse(out _) && EukrasianDosisIiPvE.EnoughLevel && (!MergedStatus.HasFlag(AutoStatus.DefenseSingle) || !MergedStatus.HasFlag(AutoStatus.DefenseSingle)))
+        {
+            SetEukrasia(EukrasianDosisIiPvE);
+            return false;
+        }
+
+        if (EukrasianDosisPvE.CanUse(out _) && EukrasianDosisPvE.EnoughLevel && (!MergedStatus.HasFlag(AutoStatus.DefenseSingle) || !MergedStatus.HasFlag(AutoStatus.DefenseSingle)))
+        {
+            SetEukrasia(EukrasianDosisPvE);
+            return false;
+        }
+
+        // If the last action performed matches any of a list of specific actions, it clears the Eukrasia aim.
+        // This serves as a reset/cleanup mechanism to ensure the decision logic starts fresh for the next cycle.
+        if (IsLastGCD(false, EukrasianPrognosisIiPvE, EukrasianPrognosisPvE,
+            EukrasianDiagnosisPvE, EukrasianDyskrasiaPvE, EukrasianDosisIiiPvE, EukrasianDosisIiPvE,
+            EukrasianDosisPvE) || !InCombat)
+        {
+            ClearEukrasia();
+        }
+        return false; // Indicates that no specific Eukrasia action was chosen in this cycle.
+    }
+    #endregion
+
+    #region Eukrasia Execution
+    // Attempts to perform a Eukrasia action, based on the current game state and conditions.
+    private bool DoEukrasia(out IAction? act)
+    {
+        act = null;
+
+        if (_EukrasiaActionAim != null && _EukrasiaActionAim.CanUse(out act))
+        {
+            if (EukrasiaPvE.CanUse(out act)) return true;
+
+            act = _EukrasiaActionAim;
+            return true;
+        }
+        return false;
+    }
+    #endregion
+
     #region GCD Logic 
-    protected override bool DefenseAreaGCD(out IAction? act)
-    {
-        act = null;
-
-        if (HasSwift && SwiftLogic && EgeiroPvE.CanUse(out _)) return false;
-
-        if (EukrasianPrognosisIiPvE.CanUse(out act))
-        {
-            if (EukrasianPrognosisIiPvE.Target.Target?.HasStatus(false,
-                StatusID.EukrasianDiagnosis,
-                StatusID.EukrasianPrognosis,
-                StatusID.Galvanize
-            ) ?? false) return false;
-
-            if (EukrasiaPvE.CanUse(out act)) return true;
-
-            act = EukrasianPrognosisIiPvE;
-            return true;
-        }
-
-        if (!EukrasianPrognosisIiPvE.EnoughLevel && EukrasianPrognosisPvE.CanUse(out act))
-        {
-            if (EukrasianPrognosisPvE.Target.Target?.HasStatus(false,
-                StatusID.EukrasianDiagnosis,
-                StatusID.EukrasianPrognosis,
-                StatusID.Galvanize
-            ) ?? false) return false;
-
-            if (EukrasiaPvE.CanUse(out act)) return true;
-
-            act = EukrasianPrognosisPvE;
-            return true;
-        }
-
-        return base.DefenseAreaGCD(out act);
-    }
-
-    [RotationDesc(ActionID.EukrasianDiagnosisPvE)]
-    protected override bool DefenseSingleGCD(out IAction? act)
-    {
-        act = null;
-
-        if (HasSwift && SwiftLogic && EgeiroPvE.CanUse(out _)) return false;
-
-        if (EukrasianDiagnosisPvE.CanUse(out act))
-        {
-            if (EukrasianDiagnosisPvE.Target.Target?.HasStatus(true,
-                StatusID.EukrasianDiagnosis,
-                StatusID.DifferentialDiagnosis,
-                StatusID.EukrasianPrognosis,
-                StatusID.Galvanize
-            ) ?? false) return false;
-
-            if (EukrasiaPvE.CanUse(out act)) return true;
-
-            act = EukrasianDiagnosisPvE;
-            return true;
-        }
-
-        return base.DefenseSingleGCD(out act);
-    }
-
     [RotationDesc(ActionID.PneumaPvE, ActionID.PrognosisPvE, ActionID.EukrasianPrognosisPvE, ActionID.EukrasianPrognosisIiPvE)]
     protected override bool HealAreaGCD(out IAction? act)
     {
@@ -339,48 +381,7 @@ public sealed class SGE_Default : SageRotation
 
         if (HasSwift && SwiftLogic && EgeiroPvE.CanUse(out _)) return false;
 
-        if (EukrasianDiagnosisPvE.CanUse(out act) && MergedStatus.HasFlag(AutoStatus.DefenseSingle))
-        {
-            if (EukrasianDiagnosisPvE.Target.Target?.HasStatus(true,
-                StatusID.EukrasianDiagnosis,
-                StatusID.DifferentialDiagnosis,
-                StatusID.EukrasianPrognosis,
-                StatusID.Galvanize
-            ) ?? false) return false;
-
-            if (EukrasiaPvE.CanUse(out act)) return true;
-
-            act = EukrasianDiagnosisPvE;
-            return true;
-        }
-
         if (!InCombat && !Player.HasStatus(true, StatusID.Eukrasia) && EukrasiaPvE.CanUse(out act)) return true;
-
-        if (HostileTarget?.IsBossFromTTK() ?? false)
-        {
-            if (EukrasianDyskrasiaPvE.CanUse(out _, skipCastingCheck: true))
-            {
-                if (EukrasiaPvE.CanUse(out act, skipCastingCheck: true)) return true;
-                if (EukrasianDyskrasiaPvE.CanUse(out act))
-                {
-                    DosisPvE.Target = EukrasianDyskrasiaPvE.Target;
-                    return true;
-                }
-            }
-        }
-
-        if (HostileTarget?.IsBossFromTTK() ?? false)
-        {
-            if (EukrasianDosisPvE.CanUse(out _, skipCastingCheck: true))
-            {
-                if (EukrasiaPvE.CanUse(out act, skipCastingCheck: true)) return true;
-                if (DosisPvE.CanUse(out act))
-                {
-                    DosisPvE.Target = EukrasianDosisPvE.Target;
-                    return true;
-                }
-            }
-        }
 
         if (PhlegmaIiiPvE.CanUse(out act, usedUp: IsMoving)) return true;
         if (PhlegmaIiPvE.CanUse(out act, usedUp: IsMoving)) return true;
@@ -393,49 +394,12 @@ public sealed class SGE_Default : SageRotation
 
         if (IsMoving && ToxikonPvE.CanUse(out act)) return true;
 
-        if (EukrasianDyskrasiaPvE.CanUse(out _, skipCastingCheck: true))
-        {
-            if (EukrasiaPvE.CanUse(out act, skipCastingCheck: true)) return true;
-            if (DyskrasiaPvE.CanUse(out act))
-            {
-                DyskrasiaPvE.Target = EukrasianDyskrasiaPvE.Target;
-                return true;
-            }
-        }
+        if (ChoiceEukrasia(out act)) return true;
+        if (DoEukrasia(out act)) return true;
 
-        if (DyskrasiaPvE.CanUse(out _))
-        {
-            if (EukrasianDyskrasiaPvE.EnoughLevel && (EukrasianDyskrasiaPvE.Target.Target?.WillStatusEnd(3, true, EukrasianDyskrasiaPvE.Setting.TargetStatusProvide ?? []) ?? false) && InCombat && (!MergedStatus.HasFlag(AutoStatus.DefenseArea) || !MergedStatus.HasFlag(AutoStatus.DefenseSingle)))
-            {
-                StatusHelper.StatusOff(StatusID.Eukrasia);
-            }
-            if (DyskrasiaPvE.CanUse(out act))
-            {
-                return true;
-            }
-        }
+        if (DyskrasiaPvE.CanUse(out act)) return true;
 
-        if (EukrasianDosisPvE.CanUse(out _, skipCastingCheck: true))
-        {
-            if (EukrasiaPvE.CanUse(out act, skipCastingCheck: true)) return true;
-            if (DosisPvE.CanUse(out act))
-            {
-                DosisPvE.Target = EukrasianDosisPvE.Target;
-                return true;
-            }
-        }
-
-        if (DosisPvE.CanUse(out _))
-        {
-            if ((EukrasianDosisPvE.Target.Target?.WillStatusEnd(3, true, EukrasianDosisPvE.Setting.TargetStatusProvide ?? []) ?? false) && InCombat && (!MergedStatus.HasFlag(AutoStatus.DefenseArea) || !MergedStatus.HasFlag(AutoStatus.DefenseSingle)))
-            {
-                StatusHelper.StatusOff(StatusID.Eukrasia);
-            }
-            if (DosisPvE.CanUse(out act))
-            {
-                return true;
-            }
-        }
+        if (DosisPvE.CanUse(out act)) return true;
 
         return base.GeneralGCD(out act);
     }
@@ -444,5 +408,14 @@ public sealed class SGE_Default : SageRotation
     #region Extra Methods
     public override bool CanHealSingleSpell => base.CanHealSingleSpell && (GCDHeal || PartyMembers.GetJobCategory(JobRole.Healer).Count() < 2);
     public override bool CanHealAreaSpell => base.CanHealAreaSpell && (GCDHeal || PartyMembers.GetJobCategory(JobRole.Healer).Count() < 2);
+
+    public override void DisplayStatus()
+    {
+        ImGui.Text($"Eukrasian Action: {_EukrasiaActionAim}");
+        ImGui.Text("HasEukrasia: " + HasEukrasia.ToString());
+        ImGui.Text("Addersgall: " + Addersgall.ToString());
+        ImGui.Text("Addersting: " + Addersting.ToString());
+        ImGui.Text("AddersgallTime: " + AddersgallTime.ToString());
+    }
     #endregion
 }

--- a/RotationSolver.Basic/Rotations/Basic/PaladinRotation.cs
+++ b/RotationSolver.Basic/Rotations/Basic/PaladinRotation.cs
@@ -227,6 +227,11 @@ partial class PaladinRotation
     static partial void ModifyClemencyPvE(ref ActionSetting setting)
     {
         setting.UnlockedByQuestID = 67572;
+        setting.CanTarget = t =>
+        {
+            if (t.HasStatus(false, StatusHelper.TankStanceStatus)) return false;
+            return true;
+        };
     }
 
     static partial void ModifyRoyalAuthorityPvE(ref ActionSetting setting)

--- a/RotationSolver.Basic/Rotations/Basic/SageRotation.cs
+++ b/RotationSolver.Basic/Rotations/Basic/SageRotation.cs
@@ -52,7 +52,6 @@ partial class SageRotation
         ImGui.Text("Addersgall: " + Addersgall.ToString());
         ImGui.Text("Addersting: " + Addersting.ToString());
         ImGui.Text("AddersgallTime: " + AddersgallTime.ToString());
-        ImGui.Text("AddersgallTimerRaw: " + AddersgallTimerRaw.ToString());
     }
     #endregion
 
@@ -118,7 +117,7 @@ partial class SageRotation
 
     static partial void ModifyEukrasianDiagnosisPvE(ref ActionSetting setting)
     {
-        setting.ActionCheck = () => HasEukrasia && !DataCenter.AllianceMembers.Any(m => m.HasStatus(true, StatusID.EukrasianDiagnosis));
+        setting.ActionCheck = () => !DataCenter.AllianceMembers.Any(m => m.HasStatus(true, StatusID.EukrasianDiagnosis));
         setting.TargetStatusProvide = [StatusID.EukrasianDiagnosis, StatusID.Galvanize]; // Effect cannot be stacked with scholar's Galvanize.
         setting.TargetType = TargetType.BeAttacked;
         setting.StatusFromSelf = false;


### PR DESCRIPTION
This pull request includes significant improvements and bug fixes to the `SGE_Default` and `PLD_Beta` rotations in the `BasicRotations` directory. The changes focus on refining the logic for Eukrasia actions for Sage and Clemency use for Paladin, as well as adding new configuration options and improving status display.

### Sage Rotation Improvements:
* Introduced new methods `SetEukrasia`, `ClearEukrasia`, and `ChoiceEukrasia` to better manage Eukrasia actions and their conditions in `SGE_Default.cs`.
* Added `DoEukrasia` method to execute Eukrasia actions based on the current game state.
* Improved the `GeneralGCD` method to incorporate the new Eukrasia logic.
* Added a new `DisplayStatus` method to show the current Eukrasia action and other relevant statuses.

### Paladin Rotation Enhancements:
* Added new configuration options for Clemency use with and without Requiescat in `PLD_Beta.cs`.
* Updated `HealSingleGCD` to use Clemency based on the new configuration options.
* Expanded `AttackAbility` method to include additional actions and improve the logic for using Requiescat and Fight or Flight.
* Modified `GeneralGCD` to enhance the use of Holy Spirit and Holy Circle based on Divine Might and Requiescat stacks.

### Additional Changes:
* Removed unnecessary lines and improved readability in `SGE_Default.cs` [[1]](diffhunk://#diff-048922cde007c3a11c8a1edea2742248b0c16ceb8806c7c8f14c6e2fbd612898L174) [[2]](diffhunk://#diff-048922cde007c3a11c8a1edea2742248b0c16ceb8806c7c8f14c6e2fbd612898L204).
* Updated `ModifyClemencyPvE` to prevent targeting allies with tank stance.
* Minor display update in `SageRotation.cs` to remove redundant status display.
* Adjusted `ModifyEukrasianDiagnosisPvE` to remove unnecessary Eukrasia check.