### PR TITLE
Update target priorities and add check in DancerRotation

### DIFF
--- a/RotationSolver.Basic/Actions/ActionTargetInfo.cs
+++ b/RotationSolver.Basic/Actions/ActionTargetInfo.cs
@@ -813,7 +813,7 @@ public struct ActionTargetInfo(IBaseAction action)
         IBattleChara? FindTheSpear()
         {
             // The Spear priority based on the info from The Balance Discord for Level 100 Dance Partner
-            Job[] TheSpearpriority = { Job.PCT, Job.SAM, Job.RPR, Job.VPR, Job.MNK, Job.NIN, Job.DRG, Job.PCT, Job.SAM, Job.BLM, Job.RDM, Job.SMN, Job.MCH, Job.BRD, Job.DNC };
+            Job[] TheSpearpriority = { Job.PCT, Job.SAM, Job.BLM, Job.RDM, Job.SMN, Job.MCH, Job.BRD, Job.DNC, Job.RPR, Job.VPR, Job.MNK, Job.NIN, Job.DRG };
 
             if (IGameObjects == null) return null;
 
@@ -847,7 +847,7 @@ public struct ActionTargetInfo(IBaseAction action)
         IBattleChara? FindTheBalance()
         {
             // The Balance priority based on the info from The Balance Discord for Level 100 Dance Partner
-            Job[] TheBalancepriority = { Job.PCT, Job.SAM, Job.BLM, Job.RDM, Job.SMN, Job.MCH, Job.BRD, Job.DNC, Job.RPR, Job.VPR, Job.MNK, Job.NIN, Job.DRG };
+            Job[] TheBalancepriority = { Job.RPR, Job.VPR, Job.MNK, Job.NIN, Job.DRG, Job.PCT, Job.SAM, Job.BLM, Job.RDM, Job.SMN, Job.MCH, Job.BRD, Job.DNC };
 
             if (IGameObjects == null) return null;
 

--- a/RotationSolver.Basic/Rotations/Basic/DancerRotation.cs
+++ b/RotationSolver.Basic/Rotations/Basic/DancerRotation.cs
@@ -204,7 +204,7 @@ partial class DancerRotation
     {
         setting.IsFriendly = true;
         setting.TargetType = TargetType.DancePartner;
-        setting.ActionCheck = () => !AllianceMembers.Any(b => b.HasStatus(true, StatusID.ClosedPosition_2026));
+        setting.ActionCheck = () => !IsDancing && !AllianceMembers.Any(b => b.HasStatus(true, StatusID.ClosedPosition_2026));
     }
 
     static partial void ModifyDevilmentPvE(ref ActionSetting setting)


### PR DESCRIPTION
This pull request includes changes to the `RotationSolver.Basic` project, specifically focusing on updating job priorities and modifying action checks for the Dancer rotation. The most important changes are as follows:

### Job Priority Updates:
* [`RotationSolver.Basic/Actions/ActionTargetInfo.cs`](diffhunk://#diff-c48c5d8b4fd41fe622aa573e5ca583106eb40f1fc24db44fcc12935cd35c1774L816-R816): Updated the job priority for `FindTheSpear` to reflect the latest recommendations from The Balance Discord for Level 100 Dance Partner.
* [`RotationSolver.Basic/Actions/ActionTargetInfo.cs`](diffhunk://#diff-c48c5d8b4fd41fe622aa573e5ca583106eb40f1fc24db44fcc12935cd35c1774L850-R850): Updated the job priority for `FindTheBalance` to reflect the latest recommendations from The Balance Discord for Level 100 Dance Partner.

### Action Check Modifications:
* [`RotationSolver.Basic/Rotations/Basic/DancerRotation.cs`](diffhunk://#diff-dbd5d52f701f3b33527c928994f99654a967489ba8d4dc26d285a162e72e0e09L207-R207): Modified the `ActionCheck` in `ModifyClosedPositionPvE` to include a check for the `IsDancing` status, ensuring that the action is only performed when the character is not dancing.