### PR TITLE
Enhance healing and defense logic, update configurations

### DIFF
--- a/BasicRotations/Healer/SCH_Default.cs
+++ b/BasicRotations/Healer/SCH_Default.cs
@@ -99,12 +99,15 @@ public sealed class SCH_Default : ScholarRotation
     protected override bool HealSingleAbility(IAction nextGCD, out IAction? act)
     {
         var haveLink = PartyMembers.Any(p => p.HasStatus(true, StatusID.FeyUnion_1223));
-        if (ManifestationPvE.CanUse(out act)) return true;
-        if (AetherpactPvE.CanUse(out act) && FairyGauge >= 70 && !haveLink) return true;
         if (ProtractionPvE.CanUse(out act)) return true;
+        if (IsLastAbility(ActionID.RecitationPvE) && ExcogitationPvE.CanUse(out act)) return true;
+
+        if (AetherpactPvE.CanUse(out act) && FairyGauge >= 70 && !haveLink) return true;
         if (ExcogitationPvE.CanUse(out act)) return true;
         if (LustratePvE.CanUse(out act)) return true;
         if (AetherpactPvE.CanUse(out act) && !haveLink) return true;
+
+        if (ExcogitationPvE.CanUse(out act)) return true;
 
         return base.HealSingleAbility(nextGCD, out act);
     }
@@ -172,6 +175,8 @@ public sealed class SCH_Default : ScholarRotation
         if (HasSwift && SwiftLogic && ResurrectionPvE.CanUse(out _)) return false;
 
         if (SuccorPvE.CanUse(out act)) return true;
+        if (ConcitationPvE.CanUse(out act, skipCastingCheck: true)) return true;
+        if (AccessionPvE.CanUse(out act)) return true;
 
         return base.HealAreaGCD(out act);
     }
@@ -182,8 +187,9 @@ public sealed class SCH_Default : ScholarRotation
         act = null;
 
         if (HasSwift && SwiftLogic && ResurrectionPvE.CanUse(out _)) return false;
-
+        
         if (AdloquiumPvE.CanUse(out act)) return true;
+        if (ManifestationPvE.CanUse(out act, skipCastingCheck: true)) return true;
         if (PhysickPvE.CanUse(out act)) return true;
 
         return base.HealSingleGCD(out act);
@@ -197,6 +203,9 @@ public sealed class SCH_Default : ScholarRotation
         if (HasSwift && SwiftLogic && ResurrectionPvE.CanUse(out _)) return false;
 
         if (SuccorPvE.CanUse(out act)) return true;
+        if (ConcitationPvE.CanUse(out act, skipCastingCheck: true)) return true;
+        if (AccessionPvE.CanUse(out act)) return true;
+
         return base.DefenseAreaGCD(out act);
     }
 

--- a/BasicRotations/Healer/SGE_Default.cs
+++ b/BasicRotations/Healer/SGE_Default.cs
@@ -65,9 +65,10 @@ public sealed class SGE_Default : SageRotation
     #region Countdown Logic
     protected override IAction? CountDownAction(float remainTime)
     {
-        if (remainTime < DosisPvE.Info.CastTime + CountDownAhead
-            && DosisPvE.CanUse(out var act)) return act;
+        if (remainTime < PneumaPvE.Info.CastTime + CountDownAhead
+            && PneumaPvE.CanUse(out var act)) return act;
         if (remainTime <= 3 && UseBurstMedicine(out act)) return act;
+        if (remainTime <= 5 && EukrasiaPvE.CanUse(out act)) return act;
         return base.CountDownAction(remainTime);
     }
     #endregion
@@ -85,20 +86,17 @@ public sealed class SGE_Default : SageRotation
     {
         if (base.EmergencyAbility(nextGCD, out act)) return true;
 
-        if (nextGCD.IsTheSameTo(false, PneumaPvE, EukrasianDiagnosisPvE,
-            EukrasianPrognosisPvE, EukrasianPrognosisIiPvE, DiagnosisPvE, PrognosisPvE))
+        if (nextGCD.IsTheSameTo(false, PneumaPvE, EukrasianPrognosisPvE, EukrasianPrognosisIiPvE))
         {
             if (ZoePvE.CanUse(out act)) return true;
         }
 
-        if (nextGCD.IsTheSameTo(false, PneumaPvE, EukrasianDiagnosisPvE,
-             EukrasianPrognosisPvE, EukrasianPrognosisIiPvE, DiagnosisPvE, PrognosisPvE))
+        if (nextGCD.IsTheSameTo(false, PneumaPvE, EukrasianDiagnosisPvE, DiagnosisPvE, PrognosisPvE))
         {
             if (KrasisPvE.CanUse(out act)) return true;
         }
 
-        if (nextGCD.IsTheSameTo(false, PneumaPvE, EukrasianDiagnosisPvE,
-             EukrasianPrognosisPvE, EukrasianPrognosisIiPvE, DiagnosisPvE, PrognosisPvE))
+        if (nextGCD.IsTheSameTo(false, PneumaPvE, EukrasianPrognosisPvE, EukrasianPrognosisIiPvE, DiagnosisPvE, PrognosisPvE))
         {
             if (PhilosophiaPvE.CanUse(out act)) return true;
         }
@@ -109,6 +107,11 @@ public sealed class SGE_Default : SageRotation
     [RotationDesc(ActionID.PanhaimaPvE, ActionID.KeracholePvE, ActionID.HolosPvE)]
     protected override bool DefenseAreaAbility(IAction nextGCD, out IAction? act)
     {
+        if (!PanhaimaPvE.Cooldown.IsCoolingDown)
+        {
+            if (PhysisIiPvE.CanUse(out act)) return true;
+        }
+
         if (Addersgall <= 1)
         {
             if (PanhaimaPvE.CanUse(out act)) return true;
@@ -124,6 +127,11 @@ public sealed class SGE_Default : SageRotation
     [RotationDesc(ActionID.HaimaPvE, ActionID.TaurocholePvE, ActionID.PanhaimaPvE, ActionID.KeracholePvE, ActionID.HolosPvE)]
     protected override bool DefenseSingleAbility(IAction nextGCD, out IAction? act)
     {
+        if (!HaimaPvE.Cooldown.IsCoolingDown)
+        {
+            if (KrasisPvE.CanUse(out act)) return true;
+        }
+
         if (Addersgall <= 1)
         {
             if (HaimaPvE.CanUse(out act)) return true;
@@ -146,16 +154,14 @@ public sealed class SGE_Default : SageRotation
     [RotationDesc(ActionID.KeracholePvE, ActionID.PhysisPvE, ActionID.HolosPvE, ActionID.IxocholePvE)]
     protected override bool HealAreaAbility(IAction nextGCD, out IAction? act)
     {
-        if (PhysisIiPvE.CanUse(out act)) return true;
-        if (!PhysisIiPvE.EnoughLevel && PhysisPvE.CanUse(out act)) return true;
-
         if (KeracholePvE.CanUse(out act) && EnhancedKeracholeTrait.EnoughLevel) return true;
-
-        if (HolosPvE.CanUse(out act) && PartyMembersAverHP < HolosHeal) return true;
 
         if (IxocholePvE.CanUse(out act)) return true;
 
-        if (KeracholePvE.CanUse(out act)) return true;
+        if (PhysisIiPvE.CanUse(out act)) return true;
+        if (!PhysisIiPvE.EnoughLevel && PhysisPvE.CanUse(out act)) return true;
+
+        if (HolosPvE.CanUse(out act) && PartyMembersAverHP < HolosHeal) return true;
 
         return base.HealAreaAbility(nextGCD, out act);
     }
@@ -164,8 +170,6 @@ public sealed class SGE_Default : SageRotation
     protected override bool HealSingleAbility(IAction nextGCD, out IAction? act)
     {
         if (TaurocholePvE.CanUse(out act)) return true;
-
-        if (KeracholePvE.CanUse(out act) && EnhancedKeracholeTrait.EnoughLevel) return true;
 
         if ((!TaurocholePvE.EnoughLevel || TaurocholePvE.Cooldown.IsCoolingDown) && DruocholePvE.CanUse(out act)) return true;
 
@@ -193,8 +197,6 @@ public sealed class SGE_Default : SageRotation
         {
             if (KrasisPvE.CanUse(out act)) return true;
         }
-
-        if (KeracholePvE.CanUse(out act)) return true;
 
         return base.HealSingleAbility(nextGCD, out act);
     }

--- a/RotationSolver.Basic/Helpers/ObjectHelper.cs
+++ b/RotationSolver.Basic/Helpers/ObjectHelper.cs
@@ -47,7 +47,7 @@ public static class ObjectHelper
         {
             foreach (var n in ns1)
             {
-                if (!string.IsNullOrEmpty(n) && new Regex(n).Match(target.Name.ExtractText()).Success)
+                if (!string.IsNullOrEmpty(n) && new Regex(n).Match(target.Name?.ExtractText() ?? string.Empty).Success)
                 {
                     return false;
                 }
@@ -55,13 +55,14 @@ public static class ObjectHelper
         }
 
         //Target can move or too big and has a target
-        if ((target.GetObjectNPC()?.Unknown0 == 0 || target.HitboxRadius >= 5) // Unknown12 used to be the flag checked for the mobs ability to move, honestly just guessing on this one
+        var targetNpc = target.GetObjectNPC();
+        if ((targetNpc?.Unknown0 == 0 || target.HitboxRadius >= 5) // Unknown12 used to be the flag checked for the mobs ability to move, honestly just guessing on this one
             && (target.TargetObject?.IsValid() ?? false))
         {
             //the target is not a tank role
             if (Svc.Objects.SearchById(target.TargetObjectId) is IBattleChara battle
                 && !battle.IsJobCategory(JobRole.Tank)
-                && (Vector3.Distance(target.Position, Player.Object.Position) > 5))
+                && (Vector3.Distance(target.Position, Player.Object?.Position ?? Vector3.Zero) > 5))
             {
                 return true;
             }

--- a/RotationSolver.Basic/Rotations/Basic/SageRotation.cs
+++ b/RotationSolver.Basic/Rotations/Basic/SageRotation.cs
@@ -380,6 +380,7 @@ partial class SageRotation
     {
         setting.StatusProvide = [StatusID.Philosophia];
         setting.TargetStatusProvide = [StatusID.Eudaimonia];
+        setting.TargetType = TargetType.Self;
         setting.CreateConfig = () => new ActionConfig()
         {
             AoeCount = 1,

--- a/RotationSolver.Basic/Rotations/Basic/WarriorRotation.cs
+++ b/RotationSolver.Basic/Rotations/Basic/WarriorRotation.cs
@@ -12,6 +12,11 @@ partial class WarriorRotation
     public static byte BeastGauge => JobGauge.BeastGauge;
 
     /// <summary>
+    /// 
+    /// </summary>
+    public static byte OnslaughtMax => EnhancedOnslaughtTrait.EnoughLevel ? (byte)3 : (byte)2;
+
+    /// <summary>
     /// Holds the remaining amount of InnerRelease stacks
     /// </summary>
     public static byte InnerReleaseStacks
@@ -34,13 +39,14 @@ partial class WarriorRotation
             return stacks == byte.MaxValue ? (byte)3 : stacks;
         }
     }
-
+    
     /// <inheritdoc/>
     public override void DisplayStatus()
     {
         ImGui.Text("InnerReleaseStacks: " + InnerReleaseStacks.ToString());
         ImGui.Text("BerserkStacks: " + BerserkStacks.ToString());
         ImGui.Text("BeastGaugeValue: " + BeastGauge.ToString());
+        ImGui.Text("OnslaughtMax: " + OnslaughtMax.ToString());
     }
 
     private sealed protected override IBaseAction TankStance => DefiancePvE;

--- a/RotationSolver/UI/RotationConfigWindow.cs
+++ b/RotationSolver/UI/RotationConfigWindow.cs
@@ -1017,7 +1017,6 @@ public partial class RotationConfigWindow : Window
 
     private void DrawAutoduty()
     {
-
         ImGui.TextWrapped("This is a gentle reminder that RSR is not a botting tool, and while I have taken steps to help it work better with Autoduty please keep that in mind");
         ImGui.Spacing();
         ImGui.TextWrapped("This menu is mostly for troubleshooting purposes and is a good first step to share to get assistance.");
@@ -1085,15 +1084,15 @@ public partial class RotationConfigWindow : Window
         // Create a new list of AutoDutyPlugin objects
         var pluginsToCheck = new List<IncompatiblePlugin>
     {
-        new IncompatiblePlugin { Name = "AutoDuty" },
-        new IncompatiblePlugin { Name = "vnavmesh" },
-        new IncompatiblePlugin { Name = "BossMod Reborn" },
-        new IncompatiblePlugin { Name = "Boss Mod" },
-        new IncompatiblePlugin { Name = "Avarice" },
-        new IncompatiblePlugin { Name = "Deliveroo" },
-        new IncompatiblePlugin { Name = "AutoRetainer" },
-        new IncompatiblePlugin { Name = "SkipCutscene" },
-        new IncompatiblePlugin { Name = "AntiAfkKick" },
+        new IncompatiblePlugin { Name = "AutoDuty", Url = "https://puni.sh/api/repository/herc" },
+        new IncompatiblePlugin { Name = "vnavmesh", Url = "https://puni.sh/api/repository/veyn" },
+        new IncompatiblePlugin { Name = "BossMod Reborn", Url = "https://raw.githubusercontent.com/FFXIV-CombatReborn/CombatRebornRepo/main/pluginmaster.json" },
+        new IncompatiblePlugin { Name = "Boss Mod", Url = "" },
+        new IncompatiblePlugin { Name = "Avarice", Url = "https://love.puni.sh/ment.json" },
+        new IncompatiblePlugin { Name = "Deliveroo", Url = "https://plugins.carvel.li/" },
+        new IncompatiblePlugin { Name = "AutoRetainer", Url = "https://love.puni.sh/ment.json" },
+        new IncompatiblePlugin { Name = "SkipCutscene", Url = "https://raw.githubusercontent.com/KangasZ/DalamudPluginRepository/main/plugin_repository.json" },
+        new IncompatiblePlugin { Name = "AntiAfkKick", Url = "https://raw.githubusercontent.com/NightmareXIV/MyDalamudPlugins/main/pluginmaster.json" },
         // Add more plugins as needed
     };
 
@@ -1111,6 +1110,16 @@ public partial class RotationConfigWindow : Window
             }
 
             bool isInstalled = plugin.IsInstalled;
+
+            // Add a button to copy the URL to the clipboard if the plugin is not installed
+            if (!isInstalled)
+            {
+                if (ImGui.Button($"Copy Repo URL##{plugin.Name}"))
+                {
+                    ImGui.SetClipboardText(plugin.Url);
+                }
+                ImGui.SameLine();
+            }
 
             // Determine the color and text for "Boss Mod"
             Vector4 color;
@@ -1130,6 +1139,7 @@ public partial class RotationConfigWindow : Window
             ImGui.PushStyleColor(ImGuiCol.Text, color);
             ImGui.TextWrapped(text);
             ImGui.PopStyleColor();
+
             ImGui.Spacing();
         }
     }


### PR DESCRIPTION
This pull request includes several changes to the healing and defensive abilities of various character classes in the game. The changes primarily focus on adjusting the conditions under which certain abilities are used, adding new configuration options, and improving the robustness of the code.

### Healer Class Adjustments:
* [`BasicRotations/Healer/SCH_Default.cs`](diffhunk://#diff-47b613c092bac6c0fca7f78e0876e61724dc22b2706305872f6854f87940aea8L102-R111): Reordered the conditions for using abilities like `AetherpactPvE` and `ExcogitationPvE` to optimize healing logic. Added new checks for abilities like `ConcitationPvE` and `AccessionPvE` in area healing methods. [[1]](diffhunk://#diff-47b613c092bac6c0fca7f78e0876e61724dc22b2706305872f6854f87940aea8L102-R111) [[2]](diffhunk://#diff-47b613c092bac6c0fca7f78e0876e61724dc22b2706305872f6854f87940aea8R178-R179) [[3]](diffhunk://#diff-47b613c092bac6c0fca7f78e0876e61724dc22b2706305872f6854f87940aea8R192) [[4]](diffhunk://#diff-47b613c092bac6c0fca7f78e0876e61724dc22b2706305872f6854f87940aea8R206-R208)
* [`BasicRotations/Healer/SGE_Default.cs`](diffhunk://#diff-048922cde007c3a11c8a1edea2742248b0c16ceb8806c7c8f14c6e2fbd612898L68-R71): Modified the logic for emergency and defense abilities, including adding checks for `PhysisIiPvE` and `KrasisPvE`. Adjusted the countdown logic to use `PneumaPvE` and added `EukrasiaPvE`. [[1]](diffhunk://#diff-048922cde007c3a11c8a1edea2742248b0c16ceb8806c7c8f14c6e2fbd612898L68-R71) [[2]](diffhunk://#diff-048922cde007c3a11c8a1edea2742248b0c16ceb8806c7c8f14c6e2fbd612898L88-R99) [[3]](diffhunk://#diff-048922cde007c3a11c8a1edea2742248b0c16ceb8806c7c8f14c6e2fbd612898R110-R114) [[4]](diffhunk://#diff-048922cde007c3a11c8a1edea2742248b0c16ceb8806c7c8f14c6e2fbd612898R130-R134) [[5]](diffhunk://#diff-048922cde007c3a11c8a1edea2742248b0c16ceb8806c7c8f14c6e2fbd612898L149-R164) [[6]](diffhunk://#diff-048922cde007c3a11c8a1edea2742248b0c16ceb8806c7c8f14c6e2fbd612898L168-L169) [[7]](diffhunk://#diff-048922cde007c3a11c8a1edea2742248b0c16ceb8806c7c8f14c6e2fbd612898L197-L198)

### Tank Class Adjustments:
* [`BasicRotations/Tank/WAR_Default.cs`](diffhunk://#diff-eae4d6a3e2a4e0e4e9f8e21321a88c6d03946aa3c7a270769b20d2651417e98aR15-R27): Added new configuration options for `Bloodwhetting/Raw Intuition` healing thresholds and `Onslaught` usage during burst and cooldown periods. Enhanced the logic for using these abilities based on combat conditions. [[1]](diffhunk://#diff-eae4d6a3e2a4e0e4e9f8e21321a88c6d03946aa3c7a270769b20d2651417e98aR15-R27) [[2]](diffhunk://#diff-eae4d6a3e2a4e0e4e9f8e21321a88c6d03946aa3c7a270769b20d2651417e98aL72-R95) [[3]](diffhunk://#diff-eae4d6a3e2a4e0e4e9f8e21321a88c6d03946aa3c7a270769b20d2651417e98aR106-R115)

### Code Robustness Improvements:
* [`RotationSolver.Basic/Helpers/ObjectHelper.cs`](diffhunk://#diff-44cc6e98dcd8c3d2aa47210ec76d800058560df9bbff9ce225b3116c47ddc1fcL50-R65): Improved null safety by adding null checks and using the null-coalescing operator.
* [`RotationSolver.Basic/Rotations/Basic/SageRotation.cs`](diffhunk://#diff-4923d6574c66a67dad40cfd76b572d75e7ea0c71acbc5a0cf29a409da5866ae9R383): Set the target type for `PhilosophiaPvE` to `Self` to ensure correct targeting.
* [`RotationSolver.Basic/Rotations/Basic/WarriorRotation.cs`](diffhunk://#diff-6a11b29b86ada0d6004ad83093439e83f4e15234c9c60825356141007091bf14R14-R18): Added a new property `OnslaughtMax` to determine the maximum number of `Onslaught` charges based on the enhanced trait level. [[1]](diffhunk://#diff-6a11b29b86ada0d6004ad83093439e83f4e15234c9c60825356141007091bf14R14-R18) [[2]](diffhunk://#diff-6a11b29b86ada0d6004ad83093439e83f4e15234c9c60825356141007091bf14R49)

### UI Enhancements:
* [`RotationSolver/UI/RotationConfigWindow.cs`](diffhunk://#diff-44969e3ee4b8d522e4eb8b1ff7712a14af282526ae777e1bbe2ec561a1e9ef0eL1020): Added URLs for incompatible plugins and a button to copy these URLs to the clipboard for easier access. [[1]](diffhunk://#diff-44969e3ee4b8d522e4eb8b1ff7712a14af282526ae777e1bbe2ec561a1e9ef0eL1020) [[2]](diffhunk://#diff-44969e3ee4b8d522e4eb8b1ff7712a14af282526ae777e1bbe2ec561a1e9ef0eL1088-R1095) [[3]](diffhunk://#diff-44969e3ee4b8d522e4eb8b1ff7712a14af282526ae777e1bbe2ec561a1e9ef0eR1114-R1123) [[4]](diffhunk://#diff-44969e3ee4b8d522e4eb8b1ff7712a14af282526ae777e1bbe2ec561a1e9ef0eR1142)