### PR TITLE
PLD Confiteor low level fix, Autoduty menu update, new pointer for main menu

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ lib/
 .idea/
 RotationSolver/Localization/Localization.json
 /Resources/AutoStatusOrder.json
+/RotationSolver.GameData/RotationSolver.GameData.csproj.user

--- a/BasicRotations/Tank/PLD_Beta.cs
+++ b/BasicRotations/Tank/PLD_Beta.cs
@@ -213,10 +213,10 @@ public sealed class PLD_Beta : PaladinRotation
         if (PassageProtec && Player.HasStatus(true, StatusID.PassageOfArms)) return false;
 
         // Confiteor Combo
-        if (BladeOfValorPvE.CanUse(out act)) return true;
-        if (BladeOfTruthPvE.CanUse(out act)) return true;
-        if (BladeOfFaithPvE.CanUse(out act)) return true;
-        if (Player.HasStatus(true, StatusID.Requiescat) && ConfiteorPvE.CanUse(out act, usedUp: true, skipAoeCheck: true)) return true;
+        if (BladeOfValorPvE.EnoughLevel && BladeOfValorPvE.CanUse(out act)) return true;
+        if (BladeOfTruthPvE.EnoughLevel && BladeOfTruthPvE.CanUse(out act)) return true;
+        if (BladeOfFaithPvE.EnoughLevel && BladeOfFaithPvE.CanUse(out act)) return true;
+        if (Player.HasStatus(true, StatusID.ConfiteorReady) && ConfiteorPvE.CanUse(out act, usedUp: true, skipAoeCheck: true)) return true;
 
         if (GoringBladePvE.CanUse(out act)) return true;
 

--- a/RotationSolver.Basic/Configuration/Configs.cs
+++ b/RotationSolver.Basic/Configuration/Configs.cs
@@ -28,6 +28,7 @@ internal partial class Configs : IPluginConfiguration
 
     public const int CurrentVersion = 12;
     public int Version { get; set; } = CurrentVersion;
+    public bool HasShownMainMenuMessage { get; set; } = false;
 
     public string LastSeenChangelog { get; set; } = "0.0.0.0";
     public bool FirstTimeSetupDone { get; set; } = false;

--- a/RotationSolver.Basic/Rotations/Basic/BlueMageRotation.cs
+++ b/RotationSolver.Basic/Rotations/Basic/BlueMageRotation.cs
@@ -24,6 +24,11 @@ partial class BlueMageRotation
         /// </summary>
         GoblinPunch,
 
+        /// <summary>
+        /// 
+        /// </summary>
+        SharpenedKnife,
+
     }
 
     /// <summary>
@@ -70,6 +75,11 @@ partial class BlueMageRotation
         /// 
         /// </summary>
         ThousandNeedles,
+
+        /// <summary>
+        /// 
+        /// </summary>
+        ChocoMeteor,
     }
 
     /// <summary>
@@ -86,6 +96,11 @@ partial class BlueMageRotation
         /// 
         /// </summary>
         AngelsSnack,
+
+        /// <summary>
+        /// 
+        /// </summary>
+        PomCure,
     }
 
     /// <summary>
@@ -158,6 +173,24 @@ partial class BlueMageRotation
     /// </summary>
     [RotationConfig(CombatType.PvE, Name = "Aetheric Mimicry Role")]
     public static BLUID BlueId { get; set; } = BLUID.DPS;
+
+    static partial void ModifySharpenedKnifePvE(ref ActionSetting setting)
+    {
+        
+    }
+
+    static partial void ModifyChocoMeteorPvE(ref ActionSetting setting)
+    {
+        setting.CreateConfig = () => new ActionConfig()
+        {
+            AoeCount = 3,
+        };
+    }
+
+    static partial void ModifyPomCurePvE(ref ActionSetting setting)
+    {
+        setting.IsFriendly = true;
+    }
 
     static partial void ModifySongOfTormentPvE(ref ActionSetting setting)
     {


### PR DESCRIPTION
This pull request includes several changes focused on improving the functionality and readability of the codebase, particularly within the `RotationSolver` project. The most important changes include updates to the `GeneralGCD` method, modifications to the `RotationConfigWindow` class, and enhancements to the `BlueMageRotation` configuration.

### Key Changes:

#### Functionality Improvements:
* [`BasicRotations/Tank/PLD_Beta.cs`](diffhunk://#diff-a3a9a9026a4a0c8a1f5225bc7e0ec105c6cb90febbc87cf76f83f31db5fea6b0L216-R219): Updated the `GeneralGCD` method to include level checks for `BladeOfValorPvE`, `BladeOfTruthPvE`, and `BladeOfFaithPvE`, and replaced the status check for `ConfiteorPvE` with `ConfiteorReady`.

#### Configuration Updates:
* [`RotationSolver.Basic/Configuration/Configs.cs`](diffhunk://#diff-8146c07f057c08a985ecf11930f19a1ce5444efc69fcc45f0edd4e6c341dbe16R31): Added a new property `HasShownMainMenuMessage` to track whether the main menu message has been shown.

#### Blue Mage Rotation Enhancements:
* [`RotationSolver.Basic/Rotations/Basic/BlueMageRotation.cs`](diffhunk://#diff-1178167386c0a6f4a44d37f4f71e3a5b758c56096ae715b0a11110196540402eR27-R31): Added new spells `SharpenedKnife`, `ChocoMeteor`, and `PomCure` to the `BluDPSSpell`, `BluAOESpell`, and `BluHealSpell` enums, respectively. Implemented partial methods to modify these spells' configurations. [[1]](diffhunk://#diff-1178167386c0a6f4a44d37f4f71e3a5b758c56096ae715b0a11110196540402eR27-R31) [[2]](diffhunk://#diff-1178167386c0a6f4a44d37f4f71e3a5b758c56096ae715b0a11110196540402eR78-R82) [[3]](diffhunk://#diff-1178167386c0a6f4a44d37f4f71e3a5b758c56096ae715b0a11110196540402eR99-R103) [[4]](diffhunk://#diff-1178167386c0a6f4a44d37f4f71e3a5b758c56096ae715b0a11110196540402eR177-R194)

#### UI Enhancements:
* [`RotationSolver/UI/RotationConfigWindow.cs`](diffhunk://#diff-44969e3ee4b8d522e4eb8b1ff7712a14af282526ae777e1bbe2ec561a1e9ef0eR53-R54): Multiple updates to improve the `DrawErrorZone` and `DrawSideBar` methods by replacing LINQ queries with more readable `foreach` loops. Added conditional rendering for the main menu message and updated the configuration to save the state. [[1]](diffhunk://#diff-44969e3ee4b8d522e4eb8b1ff7712a14af282526ae777e1bbe2ec561a1e9ef0eR53-R54) [[2]](diffhunk://#diff-44969e3ee4b8d522e4eb8b1ff7712a14af282526ae777e1bbe2ec561a1e9ef0eL148-R158) [[3]](diffhunk://#diff-44969e3ee4b8d522e4eb8b1ff7712a14af282526ae777e1bbe2ec561a1e9ef0eL160-R184) [[4]](diffhunk://#diff-44969e3ee4b8d522e4eb8b1ff7712a14af282526ae777e1bbe2ec561a1e9ef0eL311-R328) [[5]](diffhunk://#diff-44969e3ee4b8d522e4eb8b1ff7712a14af282526ae777e1bbe2ec561a1e9ef0eR375-R388) [[6]](diffhunk://#diff-44969e3ee4b8d522e4eb8b1ff7712a14af282526ae777e1bbe2ec561a1e9ef0eR398-R402) [[7]](diffhunk://#diff-44969e3ee4b8d522e4eb8b1ff7712a14af282526ae777e1bbe2ec561a1e9ef0eL425-R463) [[8]](diffhunk://#diff-44969e3ee4b8d522e4eb8b1ff7712a14af282526ae777e1bbe2ec561a1e9ef0eL1253-R1300) [[9]](diffhunk://#diff-44969e3ee4b8d522e4eb8b1ff7712a14af282526ae777e1bbe2ec561a1e9ef0eL2207-R2259)

#### Subproject Update:
* [`ECommons`](diffhunk://#diff-e347001520b30beb27d6d2af61f0ac96655dea8d449d396616012d03575182d9L1-R1): Updated the subproject commit to a new version.