### PR TITLE
PLD and NIN ability modifications, SGE dot fix

### DIFF
--- a/BasicRotations/Melee/NIN_Default.cs
+++ b/BasicRotations/Melee/NIN_Default.cs
@@ -315,6 +315,11 @@ public sealed class NIN_Default : NinjaRotation
         // If Ninjutsu is available or not in combat, defers to the base class's emergency ability logic.
         if (!NoNinjutsu || !InCombat) return base.EmergencyAbility(nextGCD, out act);
 
+        if (NoNinjutsu)
+        {
+            if (!CombatElapsedLess(10) && FleetingRaijuPvE.CanUse(out act)) return true;
+        }
+
         // First priority is given to Kassatsu if it's available, allowing for an immediate powerful Ninjutsu.
         if (NoNinjutsu && KassatsuPvE.CanUse(out act)) return true;
 
@@ -331,7 +336,7 @@ public sealed class NIN_Default : NinjaRotation
             if (!KunaisBanePvE.EnoughLevel && TrickAttackPvE.CanUse(out act, skipStatusProvideCheck: IsShadowWalking)) return true;
 
             // If Trick Attack is on cooldown but will not be ready soon, considers using Meisui to recover Ninki.
-            if (TrickAttackPvE.Cooldown.IsCoolingDown && !TrickAttackPvE.Cooldown.WillHaveOneCharge(19) && MeisuiPvE.CanUse(out act)) return true;
+            if (TrickAttackPvE.Cooldown.IsCoolingDown && !TrickAttackPvE.Cooldown.WillHaveOneCharge(19) && TenChiJinPvE.Cooldown.IsCoolingDown && MeisuiPvE.CanUse(out act)) return true;
         }
 
         // If none of the specific conditions are met, falls back to the base class's emergency ability logic.

--- a/BasicRotations/Tank/PLD_Beta.cs
+++ b/BasicRotations/Tank/PLD_Beta.cs
@@ -44,12 +44,6 @@ public sealed class PLD_Beta : PaladinRotation
     public float ClemencyNoRequi { get; set; } = 0.4f;
     #endregion
 
-    private const ActionID ConfiteorPvEActionId = (ActionID)16459;
-    private new readonly IBaseAction ConfiteorPvE = new BaseAction(ConfiteorPvEActionId);
-
-    private const ActionID ImperatorPvEActionId = (ActionID)36921;
-    private new readonly IBaseAction ImperatorPvE = new BaseAction(ImperatorPvEActionId);
-
     #region Countdown Logic
     protected override IAction? CountDownAction(float remainTime)
     {
@@ -173,7 +167,7 @@ public sealed class PLD_Beta : PaladinRotation
         // if requiscat is not able to proc confiteor, use it as AOE tool if able, otherwise as Single Target
         if (!RequiescatMasteryTrait.EnoughLevel)
         {
-            if (HolyCirclePvE.EnoughLevel && NumberOfHostilesInRange > 1 && RequiescatPvE.CanUse(out act, skipAoeCheck: true, usedUp: true)) return true;
+            if (HolyCirclePvE.EnoughLevel && NumberOfHostilesInRange >= 1 && IsLastAbility(true, FightOrFlightPvE) && RequiescatPvE.CanUse(out act, skipAoeCheck: true, usedUp: true)) return true;
             if (!HolyCirclePvE.EnoughLevel && (NumberOfHostilesInRange == 1 || (RequiescatPvE.Target.Target?.IsBossFromIcon() ?? false)) && RequiescatPvE.CanUse(out act, skipAoeCheck: true, usedUp: true)) return true;
         }
 
@@ -213,13 +207,11 @@ public sealed class PLD_Beta : PaladinRotation
         if (PassageProtec && Player.HasStatus(true, StatusID.PassageOfArms)) return false;
 
         // Confiteor Combo
-        if (BladeOfValorPvE.EnoughLevel && BladeOfValorPvE.CanUse(out act)) return true;
-        if (BladeOfTruthPvE.EnoughLevel && BladeOfTruthPvE.CanUse(out act)) return true;
-        if (BladeOfFaithPvE.EnoughLevel && BladeOfFaithPvE.CanUse(out act)) return true;
-        if (Player.HasStatus(true, StatusID.ConfiteorReady) && ConfiteorPvE.CanUse(out act, usedUp: true, skipAoeCheck: true)) return true;
+        if (ConfiteorPvE.CanUse(out act, usedUp: true, skipAoeCheck: true)) return true;
 
         if (GoringBladePvE.CanUse(out act)) return true;
 
+        // Atonement Combo
         if (SepulchrePvE.CanUse(out act)) return true;
         if (SupplicationPvE.CanUse(out act)) return true;
         if (AtonementPvE.CanUse(out act)) return true;

--- a/RotationSolver.Basic/Rotations/Basic/PaladinRotation.cs
+++ b/RotationSolver.Basic/Rotations/Basic/PaladinRotation.cs
@@ -16,16 +16,6 @@ partial class PaladinRotation
     public override bool CanHealAreaAbility => false;
 
     /// <summary>
-    /// 
-    /// </summary>
-    public static bool HasDivineMight => !Player.WillStatusEndGCD(0, 0, true, StatusID.DivineMight);
-
-    /// <summary>
-    /// 
-    /// </summary>
-    public static bool HasFightOrFlight => !Player.WillStatusEndGCD(0, 0, true, StatusID.FightOrFlight);
-
-    /// <summary>
     /// Holds the remaining amount of Requiescat stacks
     /// </summary>
     public static byte RequiescatStacks
@@ -44,6 +34,30 @@ partial class PaladinRotation
     public static byte OathGauge => JobGauge.OathGauge;
     #endregion
 
+
+    #region Status Tracking
+
+    /// <summary>
+    /// 
+    /// </summary>
+    public static bool HasDivineMight => !Player.WillStatusEndGCD(0, 0, true, StatusID.DivineMight);
+
+    /// <summary>
+    /// 
+    /// </summary>
+    public static bool HasFightOrFlight => !Player.WillStatusEndGCD(0, 0, true, StatusID.FightOrFlight);
+
+    /// <summary>
+    /// 
+    /// </summary>
+    public static bool HasConfiteorReady => !Player.WillStatusEndGCD(0, 0, true, StatusID.ConfiteorReady);
+
+    /// <summary>
+    /// 
+    /// </summary>
+    public static bool HasAtonementReady => !Player.WillStatusEndGCD(0, 0, true, StatusID.AtonementReady);
+    #endregion
+
     #region Actions Unassignable
 
     /// <summary>
@@ -54,7 +68,7 @@ partial class PaladinRotation
     /// <summary>
     /// 
     /// </summary>
-    public static bool SepulchreReady => Service.GetAdjustedActionId(ActionID.SupplicationPvE) == ActionID.SepulchrePvE;
+    public static bool SepulchreReady => Service.GetAdjustedActionId(ActionID.AtonementPvE) == ActionID.SepulchrePvE;
 
     /// <summary>
     /// 
@@ -64,12 +78,12 @@ partial class PaladinRotation
     /// <summary>
     /// 
     /// </summary>
-    public static bool BladeOfTruthReady => Service.GetAdjustedActionId(ActionID.BladeOfFaithPvE) == ActionID.BladeOfTruthPvE;
+    public static bool BladeOfTruthReady => Service.GetAdjustedActionId(ActionID.ConfiteorPvE) == ActionID.BladeOfTruthPvE;
 
     /// <summary>
     /// 
     /// </summary>
-    public static bool BladeOfValorReady => Service.GetAdjustedActionId(ActionID.BladeOfTruthPvE) == ActionID.BladeOfValorPvE;
+    public static bool BladeOfValorReady => Service.GetAdjustedActionId(ActionID.ConfiteorPvE) == ActionID.BladeOfValorPvE;
 
     /// <summary>
     /// 
@@ -86,12 +100,16 @@ partial class PaladinRotation
         ImGui.Text("HasDivineMight: " + HasDivineMight.ToString());
         ImGui.Text("HasFightOrFlight: " + HasFightOrFlight.ToString());
         ImGui.Text("CanHealAreaAbility: " + CanHealAreaAbility.ToString());
-        ImGui.Text("SupplicationReady: " + SupplicationReady.ToString());
-        ImGui.Text("SepulchreReady: " + SepulchreReady.ToString());
+        ImGui.Spacing();
+        ImGui.Text("HasConfiteorReady: " + HasConfiteorReady.ToString());
         ImGui.Text("BladeOfFaithReady: " + BladeOfFaithReady.ToString());
         ImGui.Text("BladeOfTruthReady: " + BladeOfTruthReady.ToString());
         ImGui.Text("BladeOfValorReady: " + BladeOfValorReady.ToString());
         ImGui.Text("BladeOfHonorReady: " + BladeOfHonorReady.ToString());
+        ImGui.Spacing();
+        ImGui.Text("HasAtonementReady: " + HasAtonementReady.ToString());
+        ImGui.Text("SupplicationReady: " + SupplicationReady.ToString());
+        ImGui.Text("SepulchreReady: " + SepulchreReady.ToString());
     }
 
     #endregion
@@ -282,18 +300,18 @@ partial class PaladinRotation
 
     static partial void ModifyAtonementPvE(ref ActionSetting setting)
     {
-        setting.StatusNeed = [StatusID.AtonementReady];
+        setting.ActionCheck = () => HasAtonementReady;
         setting.StatusProvide = [StatusID.SupplicationReady];
     }
 
     static partial void ModifySepulchrePvE(ref ActionSetting setting)
     {
-        setting.StatusNeed = [StatusID.SepulchreReady];
+        setting.ActionCheck = () => SepulchreReady;
     }
 
     static partial void ModifyConfiteorPvE(ref ActionSetting setting)
     {
-        setting.StatusNeed = [StatusID.ConfiteorReady];
+        setting.ActionCheck = () => HasConfiteorReady || BladeOfFaithReady || BladeOfTruthReady || BladeOfValorReady || IsLastAction(ActionID.ImperatorPvE) || (IsLastAction(ActionID.RequiescatPvE) && RequiescatMasteryTrait.EnoughLevel);
         setting.CreateConfig = () => new ActionConfig()
         {
             AoeCount = 1,
@@ -319,7 +337,6 @@ partial class PaladinRotation
     static partial void ModifyBladeOfFaithPvE(ref ActionSetting setting)
     {
         setting.ActionCheck = () => BladeOfFaithReady;
-        setting.ComboIds = [ActionID.ConfiteorPvE];
         setting.CreateConfig = () => new ActionConfig()
         {
             AoeCount = 1,
@@ -329,7 +346,6 @@ partial class PaladinRotation
     static partial void ModifyBladeOfTruthPvE(ref ActionSetting setting)
     {
         setting.ActionCheck = () => BladeOfTruthReady;
-        setting.ComboIds = [ActionID.BladeOfFaithPvE];
         setting.CreateConfig = () => new ActionConfig()
         {
             AoeCount = 1,
@@ -339,7 +355,6 @@ partial class PaladinRotation
     static partial void ModifyBladeOfValorPvE(ref ActionSetting setting)
     {
         setting.ActionCheck = () => BladeOfValorReady;
-        setting.ComboIds = [ActionID.BladeOfTruthPvE];
         setting.CreateConfig = () => new ActionConfig()
         {
             AoeCount = 1,
@@ -374,7 +389,6 @@ partial class PaladinRotation
     static partial void ModifySupplicationPvE(ref ActionSetting setting)
     {
         setting.ActionCheck = () => SupplicationReady;
-        setting.StatusNeed = [StatusID.SupplicationReady];
         setting.StatusProvide = [StatusID.SepulchreReady];
     }
 

--- a/RotationSolver.Basic/Rotations/Basic/SageRotation.cs
+++ b/RotationSolver.Basic/Rotations/Basic/SageRotation.cs
@@ -330,7 +330,13 @@ partial class SageRotation
 
     static partial void ModifyEukrasianDyskrasiaPvE(ref ActionSetting setting)
     {
-        setting.TargetStatusProvide = [StatusID.EukrasianDyskrasia];
+        setting.TargetStatusProvide =
+        [
+            StatusID.EukrasianDosis,
+            StatusID.EukrasianDosisIi,
+            StatusID.EukrasianDosisIii,
+            StatusID.EukrasianDyskrasia
+        ];
         setting.CreateConfig = () => new ActionConfig()
         {
             AoeCount = 3,


### PR DESCRIPTION
This pull request includes several changes to the `BasicRotations` project, focusing on improving the logic for emergency abilities and status tracking for various classes. The most important changes include updates to the `EmergencyAbility` method for the NIN class, adjustments to the attack and general GCD logic for the PLD class, and enhancements to status tracking and action settings.

### Improvements to Emergency Ability Logic:

* [`BasicRotations/Melee/NIN_Default.cs`](diffhunk://#diff-40e0f154b39c23ffccde39af86843b1915010db8c01b77c83f1395ec31890f08R318-R322): Updated the `EmergencyAbility` method to include a check for `FleetingRaijuPvE` when `NoNinjutsu` is active and added an additional condition for `TenChiJinPvE` cooldown when using `MeisuiPvE`. [[1]](diffhunk://#diff-40e0f154b39c23ffccde39af86843b1915010db8c01b77c83f1395ec31890f08R318-R322) [[2]](diffhunk://#diff-40e0f154b39c23ffccde39af86843b1915010db8c01b77c83f1395ec31890f08L334-R339)

### Enhancements to PLD Class Logic:

* [`BasicRotations/Tank/PLD_Beta.cs`](diffhunk://#diff-a3a9a9026a4a0c8a1f5225bc7e0ec105c6cb90febbc87cf76f83f31db5fea6b0L47-L52): Removed redundant action definitions and improved the conditions for using `RequiescatPvE` and `ConfiteorPvE` in the `AttackAbility` and `GeneralGCD` methods. [[1]](diffhunk://#diff-a3a9a9026a4a0c8a1f5225bc7e0ec105c6cb90febbc87cf76f83f31db5fea6b0L47-L52) [[2]](diffhunk://#diff-a3a9a9026a4a0c8a1f5225bc7e0ec105c6cb90febbc87cf76f83f31db5fea6b0L176-R170) [[3]](diffhunk://#diff-a3a9a9026a4a0c8a1f5225bc7e0ec105c6cb90febbc87cf76f83f31db5fea6b0L216-R214)

### Status Tracking and Action Settings:

* [`RotationSolver.Basic/Rotations/Basic/PaladinRotation.cs`](diffhunk://#diff-8800ff40d56d646b12789196146c8bdf131b0dd771c3fc89eb426ffdb7395706L18-L27): Reintroduced and added new status tracking properties such as `HasConfiteorReady` and `HasAtonementReady`, and updated the action settings to use these properties for checks and status provision. [[1]](diffhunk://#diff-8800ff40d56d646b12789196146c8bdf131b0dd771c3fc89eb426ffdb7395706L18-L27) [[2]](diffhunk://#diff-8800ff40d56d646b12789196146c8bdf131b0dd771c3fc89eb426ffdb7395706R37-R60) [[3]](diffhunk://#diff-8800ff40d56d646b12789196146c8bdf131b0dd771c3fc89eb426ffdb7395706L57-R71) [[4]](diffhunk://#diff-8800ff40d56d646b12789196146c8bdf131b0dd771c3fc89eb426ffdb7395706L67-R86) [[5]](diffhunk://#diff-8800ff40d56d646b12789196146c8bdf131b0dd771c3fc89eb426ffdb7395706L89-R112) [[6]](diffhunk://#diff-8800ff40d56d646b12789196146c8bdf131b0dd771c3fc89eb426ffdb7395706L285-R314) [[7]](diffhunk://#diff-8800ff40d56d646b12789196146c8bdf131b0dd771c3fc89eb426ffdb7395706L322) [[8]](diffhunk://#diff-8800ff40d56d646b12789196146c8bdf131b0dd771c3fc89eb426ffdb7395706L332) [[9]](diffhunk://#diff-8800ff40d56d646b12789196146c8bdf131b0dd771c3fc89eb426ffdb7395706L342) [[10]](diffhunk://#diff-8800ff40d56d646b12789196146c8bdf131b0dd771c3fc89eb426ffdb7395706L377)

### Sage Class Adjustments:

* [`RotationSolver.Basic/Rotations/Basic/SageRotation.cs`](diffhunk://#diff-4923d6574c66a67dad40cfd76b572d75e7ea0c71acbc5a0cf29a409da5866ae9L333-R339): Modified `EukrasianDyskrasiaPvE` action setting to provide multiple statuses, enhancing the flexibility of status application.