### PR TITLE
PvP Invincibillity and UI changes

### DIFF
--- a/RotationSolver.Basic/Configuration/Configs.cs
+++ b/RotationSolver.Basic/Configuration/Configs.cs
@@ -15,8 +15,8 @@ internal partial class Configs : IPluginConfiguration
         BasicParams = "BasicParams",
         UiInformation = "UiInformation",
         UiWindows = "UiWindows",
+        PvPSpecificControls = "PvPSpecificControls",
         AutoActionUsage = "AutoActionUsage",
-        AutoActionCondition = "AutoActionCondition",
         HealingActionCondition = "HealingActionCondition",
         TargetConfig = "TargetConfig",
         Extra = "Extra",
@@ -61,10 +61,6 @@ internal partial class Configs : IPluginConfiguration
         Filter = BasicAutoSwitch)]
     private static readonly bool _autoOffWhenDead = true;
 
-    [ConditionBool, UI("Auto turn off when dead in PvP.",
-        Filter = BasicAutoSwitch)]
-    private static readonly bool _autoOffWhenDeadPvP = true;
-
     [ConditionBool, UI("Auto turn off when duty completed.",
         Filter = BasicAutoSwitch)]
     private static readonly bool _autoOffWhenDutyCompleted = true;
@@ -104,9 +100,6 @@ internal partial class Configs : IPluginConfiguration
 
     [JobConfig, UI("Only used automatically if coded into the rotation", Filter = AutoActionUsage, PvPFilter = JobFilterType.NoJob)]
     private readonly TinctureUseType _TinctureType = TinctureUseType.Nowhere;
-    
-    [JobConfig, UI("Ignore Invincibility for PvP purposes.", Filter = AutoActionUsage)]
-    public bool IgnorePvPInvincibility { get; set; } = false;
 
     [ConditionBool, UI("Automatically use Anti-Knockback role actions (Arms Length, Surecast)", Filter = AutoActionUsage)]
     private static readonly bool _useKnockback = true;
@@ -118,10 +111,6 @@ internal partial class Configs : IPluginConfiguration
     [ConditionBool, UI("Automatically use MP Potions", Description = "Experimental.",
         Filter = AutoActionUsage)]
     private static readonly bool _useMpPotions = false;
-
-    [JobConfig, UI("MP threshold under which to use Lucid Dreaming", Filter = AutoActionUsage)]
-    [Range(0, 10000, ConfigUnitType.None)]
-    public int LucidDreamingMpThreshold { get; set; } = 6000;
 
     [ConditionBool, UI("Prioritize mob/object targets with attack markers",
         Filter = TargetConfig)]
@@ -643,9 +632,26 @@ internal partial class Configs : IPluginConfiguration
         PvEFilter = JobFilterType.Tank)]
     [Range(1, 8, ConfigUnitType.None, 0.05f)]
     public int AutoDefenseNumber { get; set; } = 2;
-    #endregion
 
+    #endregion
+    
+    #region PvP
+    
+    [JobConfig, UI("Ignore Invincibility for PvP purposes.", Filter = PvPSpecificControls)]
+    private readonly bool _ignorePvPInvincibility = false;
+    
+    [ConditionBool, UI("Auto turn off when dead in PvP.",
+         Filter = PvPSpecificControls)]
+    private static readonly bool _autoOffWhenDeadPvP = true;
+    
+    #endregion
+    
     #region Jobs
+    
+    [JobConfig, UI("MP threshold under which to use Lucid Dreaming", Filter = HealingActionCondition)]
+    [Range(0, 10000, ConfigUnitType.None)]
+    private readonly int _lucidDreamingMpThreshold = 6000;
+    
     [JobConfig, Range(0, 1, ConfigUnitType.Percent)]
     private readonly float _healthAreaAbilityHot = 0.55f;
 

--- a/RotationSolver.Basic/Configuration/Configs.cs
+++ b/RotationSolver.Basic/Configuration/Configs.cs
@@ -104,6 +104,9 @@ internal partial class Configs : IPluginConfiguration
 
     [JobConfig, UI("Only used automatically if coded into the rotation", Filter = AutoActionUsage, PvPFilter = JobFilterType.NoJob)]
     private readonly TinctureUseType _TinctureType = TinctureUseType.Nowhere;
+    
+    [JobConfig, UI("Ignore Invincibility for PvP purposes.", Filter = AutoActionUsage)]
+    public bool IgnorePvPInvincibility { get; set; } = false;
 
     [ConditionBool, UI("Automatically use Anti-Knockback role actions (Arms Length, Surecast)", Filter = AutoActionUsage)]
     private static readonly bool _useKnockback = true;

--- a/RotationSolver.Basic/Helpers/ObjectHelper.cs
+++ b/RotationSolver.Basic/Helpers/ObjectHelper.cs
@@ -93,7 +93,7 @@ public static class ObjectHelper
 
         foreach (var status in battleChara.StatusList)
         {
-            if (StatusHelper.IsInvincible(status)) return false;
+            if (StatusHelper.IsInvincible(status) && (DataCenter.IsPvP && !Service.Config.IgnorePvPInvincibility || !DataCenter.IsPvP)) return false;
         }
 
         if (Svc.ClientState == null) return false;

--- a/RotationSolver.Basic/Rotations/CustomRotation_OtherInfo.cs
+++ b/RotationSolver.Basic/Rotations/CustomRotation_OtherInfo.cs
@@ -639,6 +639,12 @@ partial class CustomRotation
     /// </summary>
     [Description("Health of dying tank")]
     public static float HealthForDyingTanks => Service.Config.HealthForDyingTanks;
+    
+    /// <summary>
+    /// 
+    /// </summary>
+    [Description("Whether or not Invincibility should be ignored for a PvP action.")]
+    public static bool IgnorePvPInvincibility => Service.Config.IgnorePvPInvincibility;
     #endregion
 
     /// <summary>

--- a/RotationSolver/Data/UiString.cs
+++ b/RotationSolver/Data/UiString.cs
@@ -681,6 +681,12 @@ namespace RotationSolver.Data
 
         [Description("Recent Changes:")]
         WelcomeWindow_Changelog,
+        
+        [Description("Reorder AutoStatus Priorities")]
+        ConfigWindow_Auto_PrioritiesOrganizer,
+        
+        [Description("PvP Specific Controls")]
+        ConfigWindow_Auto_PvPSpecific,
     }
 
     public static class EnumExtensions

--- a/RotationSolver/UI/RotationConfigWindow.cs
+++ b/RotationSolver/UI/RotationConfigWindow.cs
@@ -800,9 +800,9 @@ public partial class RotationConfigWindow : Window
         _aboutHeaders.Draw();
     }
 
-    private void DrawAutoStatusOrderConfig()
+    private static void DrawAutoStatusOrderConfig()
     {
-        ImGui.Text("Reorder AutoStatus Priorities:");
+        ImGui.Text(UiString.ConfigWindow_Auto_PrioritiesOrganizer.GetDescription());
         ImGui.Spacing();
 
         if (ImGui.Button("Reset to Default"))
@@ -2847,7 +2847,11 @@ public partial class RotationConfigWindow : Window
     {
         var target = Svc.Targets.Target;
         if (target == null) return;
-
+        
+        ImGui.Text($"Targetting through invuln:{(target.HasStatus(true, StatusID.Guard) && (DataCenter.IsPvP && !Service.Config.IgnorePvPInvincibility || !DataCenter.IsPvP))}");
+        ImGui.Text($"Guarding: {target.HasStatus(true, StatusID.Guard)}");
+        ImGui.Text($"IsPvP: {DataCenter.IsPvP}");
+        ImGui.Text($"IgnorePvPInvincibility: {Service.Config.IgnorePvPInvincibility}");
         ImGui.Text($"Height: {target.Struct()->Height}");
         ImGui.Text($"Kind: {target.GetObjectKind()}");
         ImGui.Text($"SubKind: {target.GetBattleNPCSubKind()}");

--- a/RotationSolver/UI/RotationConfigWindow_Config.cs
+++ b/RotationSolver/UI/RotationConfigWindow_Config.cs
@@ -33,7 +33,7 @@ public partial class RotationConfigWindow
         _baseHeader?.Draw();
     }
 
-    private static readonly CollapsingHeaderGroup _baseHeader = new CollapsingHeaderGroup(new()
+    private static readonly CollapsingHeaderGroup _baseHeader = new CollapsingHeaderGroup(new Dictionary<Func<string>, Action>
     {
         { UiString.ConfigWindow_Basic_Timer.GetDescription, DrawBasicTimer },
         { UiString.ConfigWindow_Basic_AutoSwitch.GetDescription, DrawBasicAutoSwitch },
@@ -110,7 +110,7 @@ public partial class RotationConfigWindow
         _allSearchable.DrawItems(Configs.BasicTimer);
     }
 
-    private static readonly CollapsingHeaderGroup _autoSwitch = new CollapsingHeaderGroup(new()
+    private static readonly CollapsingHeaderGroup _autoSwitch = new CollapsingHeaderGroup(new Dictionary<Func<string>, Action>
     {
         {
             UiString.ConfigWindow_Basic_SwitchCancelConditionSet.GetDescription,
@@ -259,7 +259,7 @@ public partial class RotationConfigWindow
         _UIHeader?.Draw();
     }
 
-    private static readonly CollapsingHeaderGroup _UIHeader = new CollapsingHeaderGroup(new()
+    private static readonly CollapsingHeaderGroup _UIHeader = new CollapsingHeaderGroup(new Dictionary<Func<string>, Action>
     {
         {
             UiString.ConfigWindow_UI_Information.GetDescription,
@@ -282,26 +282,37 @@ public partial class RotationConfigWindow
     private void DrawAuto()
     {
         ImGui.TextWrapped(UiString.ConfigWindow_Auto_Description.GetDescription());
-        DrawAutoStatusOrderConfig();
         _autoHeader?.Draw();
     }
 
-    private static readonly CollapsingHeaderGroup _autoHeader = new(new()
+    private static readonly CollapsingHeaderGroup _autoHeader = new(new Dictionary<Func<string>, Action>
     {
-        { UiString.ConfigWindow_Auto_ActionUsage.GetDescription, () =>
-            {
-                ImGui.TextWrapped(UiString.ConfigWindow_Auto_ActionUsage_Description.GetDescription());
-                ImGui.Separator();
-
-                _allSearchable.DrawItems(Configs.AutoActionUsage);
-            }
-        },
+        { UiString.ConfigWindow_Auto_PrioritiesOrganizer.GetDescription, DrawAutoStatusOrderConfig },
+        { UiString.ConfigWindow_Auto_ActionUsage.GetDescription, DrawActionUsageControl },
         { UiString.ConfigWindow_Auto_HealingCondition.GetDescription, DrawHealingActionCondition },
+        { UiString.ConfigWindow_Auto_PvPSpecific.GetDescription, DrawPvPSpecificControls },
         { UiString.ConfigWindow_Auto_StateCondition.GetDescription, () => _autoState?.Draw() },
     })
     {
         HeaderSize = HeaderSize,
     };
+
+    private static void DrawPvPSpecificControls()
+    {
+        ImGui.TextWrapped(UiString.ConfigWindow_Auto_PvPSpecific.GetDescription());
+        ImGui.Separator();
+        _allSearchable.DrawItems(Configs.PvPSpecificControls);
+    }
+    
+    /// <summary>
+    /// Draws the Action Usage and Control section.
+    /// </summary>
+    private static void DrawActionUsageControl()
+    {
+        ImGui.TextWrapped(UiString.ConfigWindow_Auto_ActionUsage_Description.GetDescription());
+        ImGui.Separator();
+        _allSearchable.DrawItems(Configs.AutoActionUsage);
+    }
 
     /// <summary>
     /// Draws the healing action condition section.
@@ -310,11 +321,10 @@ public partial class RotationConfigWindow
     {
         ImGui.TextWrapped(UiString.ConfigWindow_Auto_HealingCondition_Description.GetDescription());
         ImGui.Separator();
-
         _allSearchable.DrawItems(Configs.HealingActionCondition);
     }
 
-    private static readonly CollapsingHeaderGroup _autoState = new(new()
+    private static readonly CollapsingHeaderGroup _autoState = new(new Dictionary<Func<string>, Action>
     {
         {
             UiString.ConfigWindow_Auto_HealAreaConditionSet.GetDescription,
@@ -375,8 +385,8 @@ public partial class RotationConfigWindow
     /// <summary>
     /// Header group for target-related configurations.
     /// </summary>
-    private static readonly CollapsingHeaderGroup _targetHeader = new(new()
-{
+    private static readonly CollapsingHeaderGroup _targetHeader = new(new Dictionary<Func<string>, Action>
+    {
     { UiString.ConfigWindow_Target_Config.GetDescription, DrawTargetConfig },
     { UiString.ConfigWindow_List_Hostile.GetDescription, DrawTargetHostile },
     { UiString.ConfigWindow_List_TargetPriority.GetDescription, DrawTargetPriority },
@@ -488,8 +498,8 @@ public partial class RotationConfigWindow
         _extraHeader?.Draw();
     }
 
-    private static readonly CollapsingHeaderGroup _extraHeader = new(new()
-{
+    private static readonly CollapsingHeaderGroup _extraHeader = new(new Dictionary<Func<string>, Action>
+    {
     { UiString.ConfigWindow_EventItem.GetDescription, DrawEventTab },
     {
         UiString.ConfigWindow_Extra_Others.GetDescription,

--- a/RotationSolver/Updaters/TargetUpdater.cs
+++ b/RotationSolver/Updaters/TargetUpdater.cs
@@ -145,7 +145,7 @@ internal static partial class TargetUpdater
             {
                 if (target == null) continue;
                 if (!target.IsEnemy() || !target.IsTargetable) continue;
-                if (target.StatusList?.Any(StatusHelper.IsInvincible) == true) continue;
+                if (target.StatusList?.Any(StatusHelper.IsInvincible) == true && (DataCenter.IsPvP && !Service.Config.IgnorePvPInvincibility || !DataCenter.IsPvP)) continue;
                 if (target.HasStatus(true, StatusID.StrongOfShield) && strongOfShieldPositional != target.FindEnemyPositional()) continue;
 
                 hostileTargets.Add(target);


### PR DESCRIPTION
This significant commit has three pieces:
1. It creates logic for ignoring invincibility when in PvP, this is a job specific setting.
2. It fixes LucidDreamingMP check, previously it did not function as expected (and was not job specific as indicated)
3. Reorganizes the Auto UI to be more consistent in appearance and in code structure.