### PR TITLE
PCT level<70 hammer fix

### DIFF
--- a/BasicRotations/Magical/PCT_Default.cs
+++ b/BasicRotations/Magical/PCT_Default.cs
@@ -101,7 +101,7 @@ public sealed class PCT_Default : PictomancerRotation
 
     protected override bool AttackAbility(IAction nextGCD, out IAction? act)
     {
-        bool burstTimingCheckerStriking = !ScenicMusePvE.Cooldown.WillHaveOneCharge(60) || HasStarryMuse;
+        bool burstTimingCheckerStriking = (!ScenicMusePvE.Cooldown.WillHaveOneCharge(60) || HasStarryMuse) || !StarryMusePvE.EnoughLevel;
         // Bursts
         int adjustCombatTimeForOpener = Player.Level < 92 ? 2 : 5;
         if (StarryMusePvE.CanUse(out act) && CombatTime > adjustCombatTimeForOpener && IsBurst) return true;


### PR DESCRIPTION
At first glance `burstTimingCheckerStriking` should be irrelevant when player's level isn't high enough to use `Starry Muse`, so i made it be true if that happens. This fixes the hammer usage for levels <70 and the rotation doesn't seem to be negatively affected when level is high enough for `Starry Muse` to be unlocked.

Tested on Lv 60,70 SSS.