### PR TITLE
Cleanup and fixes for WHM, PCT, and BLM

### DIFF
--- a/BasicRotations/Duty/VariantDefault.cs
+++ b/BasicRotations/Duty/VariantDefault.cs
@@ -1,6 +1,6 @@
 ﻿using RotationSolver.Basic.Rotations.Duties;
 
-namespace DefaultRotations.Duty;
+namespace RebornRotations.Duty;
 
 [Rotation("Variant Default", CombatType.PvE)]
 

--- a/BasicRotations/Healer/AST_Default.cs
+++ b/BasicRotations/Healer/AST_Default.cs
@@ -1,4 +1,4 @@
-namespace DefaultRotations.Healer;
+namespace RebornRotations.Healer;
 
 [Rotation("Default", CombatType.PvE, GameVersion = "7.15")]
 [SourceCode(Path = "main/BasicRotations/Healer/AST_Default.cs")]

--- a/BasicRotations/Healer/SCH_Default.cs
+++ b/BasicRotations/Healer/SCH_Default.cs
@@ -1,4 +1,4 @@
-namespace DefaultRotations.Healer;
+namespace RebornRotations.Healer;
 
 [Rotation("Default", CombatType.PvE, GameVersion = "7.15")]
 [SourceCode(Path = "main/BasicRotations/Healer/SCH_Default.cs")]
@@ -187,7 +187,7 @@ public sealed class SCH_Default : ScholarRotation
         act = null;
 
         if (HasSwift && SwiftLogic && ResurrectionPvE.CanUse(out _)) return false;
-        
+
         if (AdloquiumPvE.CanUse(out act)) return true;
         if (ManifestationPvE.CanUse(out act, skipCastingCheck: true)) return true;
         if (PhysickPvE.CanUse(out act)) return true;
@@ -236,7 +236,7 @@ public sealed class SCH_Default : ScholarRotation
 
         //Single Instant for when moving.
         if (MovingTime > RuinTime && RuinIiPvE.CanUse(out act)) return true;
-        
+
         //Add dot while moving.
         if (MovingTime > DOTTime && BiolysisPvE.CanUse(out act, skipStatusProvideCheck: DOTUpkeep)) return true;
         if (MovingTime > DOTTime && BioIiPvE.CanUse(out act, skipStatusProvideCheck: DOTUpkeep)) return true;

--- a/BasicRotations/Healer/SGE_Default.cs
+++ b/BasicRotations/Healer/SGE_Default.cs
@@ -1,4 +1,4 @@
-namespace DefaultRotations.Healer;
+namespace RebornRotations.Healer;
 
 [Rotation("Default", CombatType.PvE, GameVersion = "7.15")]
 [SourceCode(Path = "main/BasicRotations/Healer/SGE_Default.cs")]
@@ -394,7 +394,7 @@ public sealed class SGE_Default : SageRotation
     #region Extra Methods
     public override bool CanHealSingleSpell => base.CanHealSingleSpell && (GCDHeal || PartyMembers.GetJobCategory(JobRole.Healer).Count() < 2);
     public override bool CanHealAreaSpell => base.CanHealAreaSpell && (GCDHeal || PartyMembers.GetJobCategory(JobRole.Healer).Count() < 2);
-    
+
     public override void DisplayStatus()
     {
         ImGui.Text($"Eukrasian Action: {_EukrasiaActionAim}");

--- a/BasicRotations/Limited Jobs/BLU_Basic.cs
+++ b/BasicRotations/Limited Jobs/BLU_Basic.cs
@@ -1,4 +1,4 @@
-namespace DefaultRotations.Magical;
+namespace RebornRotations.Magical;
 
 [Rotation("Basic BLU", CombatType.PvE, GameVersion = "7.15")]
 [SourceCode(Path = "main/BasicRotations/Limited Jobs/BLU_Basic.cs")]

--- a/BasicRotations/Limited Jobs/BLU_Default.cs
+++ b/BasicRotations/Limited Jobs/BLU_Default.cs
@@ -1,4 +1,4 @@
-namespace DefaultRotations.Magical;
+namespace RebornRotations.Magical;
 
 [Rotation("DOES NOT WORK", CombatType.PvE, GameVersion = "7.15")]
 [SourceCode(Path = "main/BasicRotations/Limited Jobs/BLU_Default.cs")]

--- a/BasicRotations/Limited Jobs/BSM_Default.cs
+++ b/BasicRotations/Limited Jobs/BSM_Default.cs
@@ -1,4 +1,4 @@
-//namespace DefaultRotations.Ranged;
+//namespace RebornRotations.Ranged;
 
 //[Rotation("Default", CombatType.PvE, GameVersion = "7.2")]
 //[SourceCode(Path = "main/BasicRotations/Limited Jobs/BSM_Default.cs")]

--- a/BasicRotations/Magical/BLM_Beta.cs
+++ b/BasicRotations/Magical/BLM_Beta.cs
@@ -1,4 +1,4 @@
-﻿namespace DefaultRotations.Magical;
+﻿namespace RebornRotations.Magical;
 
 [Rotation("Beta", CombatType.PvE, GameVersion = "7.15")]
 [SourceCode(Path = "main/BasicRotations/Magical/BLM_Beta.cs")]
@@ -512,7 +512,7 @@ public sealed class BLM_Beta : BlackMageRotation
         if (CombatElapsedLess(6)) return false;
         if (UmbralSoulPvE.CanUse(out act)) return true;
         if (InAstralFire && TransposePvE.CanUse(out act)) return true;
-        
+
         return false;
     }
 

--- a/BasicRotations/Magical/BLM_Default.cs
+++ b/BasicRotations/Magical/BLM_Default.cs
@@ -1,4 +1,4 @@
-﻿namespace DefaultRotations.Magical;
+﻿namespace RebornRotations.Magical;
 
 [Rotation("Default", CombatType.PvE, GameVersion = "7.15")]
 [SourceCode(Path = "main/BasicRotations/Magical/BLM_Default.cs")]

--- a/BasicRotations/Magical/PCT_Default.cs
+++ b/BasicRotations/Magical/PCT_Default.cs
@@ -1,4 +1,4 @@
-﻿namespace DefaultRotations.Magical;
+﻿namespace RebornRotations.Magical;
 
 [Rotation("Default", CombatType.PvE, GameVersion = "7.15")]
 [SourceCode(Path = "main/BasicRotations/Magical/PCT_Default.cs")]
@@ -93,13 +93,21 @@ public sealed class PCT_Default : PictomancerRotation
         return base.DefenseAreaAbility(nextGCD, out act);
     }
 
+    [RotationDesc(ActionID.TemperaCoatPvE)]
+    protected sealed override bool DefenseSingleAbility(IAction nextGCD, out IAction? act)
+    {
+        // Mitigations
+        if (TemperaCoatPvE.CanUse(out act)) return true;
+        return base.DefenseAreaAbility(nextGCD, out act);
+    }
+
     #endregion
 
     #region oGCD Logic
 
     protected override bool AttackAbility(IAction nextGCD, out IAction? act)
     {
-        bool burstTimingCheckerStriking = (!ScenicMusePvE.Cooldown.WillHaveOneCharge(60) || HasStarryMuse) || !StarryMusePvE.EnoughLevel;
+        bool burstTimingCheckerStriking = !ScenicMusePvE.Cooldown.WillHaveOneCharge(60) || HasStarryMuse || !StarryMusePvE.EnoughLevel;
         // Bursts
         int adjustCombatTimeForOpener = Player.Level < 92 ? 2 : 5;
         if (StarryMusePvE.CanUse(out act) && CombatTime > adjustCombatTimeForOpener && IsBurst) return true;
@@ -122,6 +130,13 @@ public sealed class PCT_Default : PictomancerRotation
         //if (ScenicMusePvE.CanUse(out act)) return true;
         //if (SteelMusePvE.CanUse(out act, usedUp: true)) return true;
         //if (LivingMusePvE.CanUse(out act, usedUp: true)) return true;
+        return base.AttackAbility(nextGCD, out act);
+    }
+
+    protected override bool GeneralAbility(IAction nextGCD, out IAction? act)
+    {
+        if ((MergedStatus.HasFlag(AutoStatus.DefenseArea) || Player.WillStatusEndGCD(2, 0, true, StatusID.TemperaCoat)) && TemperaGrassaPvE.CanUse(out act)) return true;
+
         return base.AttackAbility(nextGCD, out act);
     }
     #endregion

--- a/BasicRotations/Magical/RDM_Default.cs
+++ b/BasicRotations/Magical/RDM_Default.cs
@@ -1,4 +1,4 @@
-namespace DefaultRotations.Magical;
+namespace RebornRotations.Magical;
 
 [Rotation("Default", CombatType.PvE, GameVersion = "7.15")]
 [SourceCode(Path = "main/BasicRotations/Magical/RDM_Default.cs")]

--- a/BasicRotations/Magical/SMN_Default.cs
+++ b/BasicRotations/Magical/SMN_Default.cs
@@ -1,6 +1,6 @@
 ﻿using System.ComponentModel;
 
-namespace DefaultRotations.Magical;
+namespace RebornRotations.Magical;
 
 [Rotation("Default", CombatType.PvE, GameVersion = "7.15")]
 [SourceCode(Path = "main/BasicRotations/Magical/SMN_Default.cs")]

--- a/BasicRotations/Melee/DRG_Default.cs
+++ b/BasicRotations/Melee/DRG_Default.cs
@@ -1,6 +1,4 @@
-using System.Drawing.Text;
-
-namespace DefaultRotations.Melee;
+namespace RebornRotations.Melee;
 
 [Rotation("Default", CombatType.PvE, GameVersion = "7.15")]
 [SourceCode(Path = "main/BasicRotations/Melee/DRG_Default.cs")]
@@ -49,25 +47,25 @@ public sealed class DRG_Default : DragoonRotation
     {
         if (IsBurst && InCombat)
         {
-            bool lifeSurgeReady = (Player.HasStatus(true, StatusID.BattleLitany) || Player.HasStatus(true, StatusID.LanceCharge) 
+            bool lifeSurgeReady = (Player.HasStatus(true, StatusID.BattleLitany) || Player.HasStatus(true, StatusID.LanceCharge)
             || LOTDEndAfter(1000)) && nextGCD.IsTheSameTo(true, HeavensThrustPvE, DrakesbanePvE)
-            || (Player.HasStatus(true, StatusID.BattleLitany) && Player.HasStatus(true, StatusID.LanceCharge) && LOTDEndAfter(1000) && nextGCD.IsTheSameTo(true, ChaoticSpringPvE, LanceBarragePvE, WheelingThrustPvE, FangAndClawPvE))
-            || (nextGCD.IsTheSameTo(true, HeavensThrustPvE, DrakesbanePvE) && (LanceChargePvE.IsInCooldown || BattleLitanyPvE.IsInCooldown));
+            || Player.HasStatus(true, StatusID.BattleLitany) && Player.HasStatus(true, StatusID.LanceCharge) && LOTDEndAfter(1000) && nextGCD.IsTheSameTo(true, ChaoticSpringPvE, LanceBarragePvE, WheelingThrustPvE, FangAndClawPvE)
+            || nextGCD.IsTheSameTo(true, HeavensThrustPvE, DrakesbanePvE) && (LanceChargePvE.IsInCooldown || BattleLitanyPvE.IsInCooldown);
 
             if ((!BattleLitanyPvE.Cooldown.ElapsedAfter(60) || !BattleLitanyPvE.EnoughLevel) && LanceChargePvE.CanUse(out act)) return true;
 
             if (Player.HasStatus(true, StatusID.LanceCharge) && BattleLitanyPvE.CanUse(out act)) return true;
 
             if ((Player.HasStatus(true, StatusID.BattleLitany) || Player.HasStatus(true, StatusID.LanceCharge) || LOTDEndAfter(1000)) && nextGCD.IsTheSameTo(true, HeavensThrustPvE, DrakesbanePvE)
-            || (Player.HasStatus(true, StatusID.BattleLitany) && Player.HasStatus(true, StatusID.LanceCharge) && LOTDEndAfter(1000) && nextGCD.IsTheSameTo(true, ChaoticSpringPvE, LanceBarragePvE, WheelingThrustPvE, FangAndClawPvE))
-            || (nextGCD.IsTheSameTo(true, HeavensThrustPvE, DrakesbanePvE) && (LanceChargePvE.IsInCooldown || BattleLitanyPvE.IsInCooldown)))
+            || Player.HasStatus(true, StatusID.BattleLitany) && Player.HasStatus(true, StatusID.LanceCharge) && LOTDEndAfter(1000) && nextGCD.IsTheSameTo(true, ChaoticSpringPvE, LanceBarragePvE, WheelingThrustPvE, FangAndClawPvE)
+            || nextGCD.IsTheSameTo(true, HeavensThrustPvE, DrakesbanePvE) && (LanceChargePvE.IsInCooldown || BattleLitanyPvE.IsInCooldown))
             {
                 if (LifeSurgePvE.CanUse(out act, usedUp: true)) return true;
             }
 
-            if (lifeSurgeReady 
-                || !DisembowelPvE.EnoughLevel && nextGCD.IsTheSameTo(true, VorpalThrustPvE) 
-                || !FullThrustPvE.EnoughLevel && nextGCD.IsTheSameTo(true, VorpalThrustPvE, DisembowelPvE) 
+            if (lifeSurgeReady
+                || !DisembowelPvE.EnoughLevel && nextGCD.IsTheSameTo(true, VorpalThrustPvE)
+                || !FullThrustPvE.EnoughLevel && nextGCD.IsTheSameTo(true, VorpalThrustPvE, DisembowelPvE)
                 || !LanceChargePvE.EnoughLevel && nextGCD.IsTheSameTo(true, DisembowelPvE, FullThrustPvE)
                 || !BattleLitanyPvE.EnoughLevel && nextGCD.IsTheSameTo(true, ChaosThrustPvE, FullThrustPvE))
             {
@@ -91,7 +89,7 @@ public sealed class DRG_Default : DragoonRotation
             if (DragonfireDivePvE.CanUse(out act)) return true;
         }
 
-        if ((Player.HasStatus(true, StatusID.BattleLitany) || Player.HasStatus(true, StatusID.LanceCharge) || LOTDEndAfter(1000))
+        if (Player.HasStatus(true, StatusID.BattleLitany) || Player.HasStatus(true, StatusID.LanceCharge) || LOTDEndAfter(1000)
             || nextGCD.IsTheSameTo(true, RaidenThrustPvE, DraconianFuryPvE))
         {
             if (WyrmwindThrustPvE.CanUse(out act, usedUp: true)) return true;

--- a/BasicRotations/Melee/MNK_Default.cs
+++ b/BasicRotations/Melee/MNK_Default.cs
@@ -1,6 +1,6 @@
 using System.ComponentModel;
 
-namespace DefaultRotations.Melee;
+namespace RebornRotations.Melee;
 
 [Rotation("Default", CombatType.PvE, GameVersion = "7.15", Description = "Uses Lunar Solar Opener from The Balance")]
 [SourceCode(Path = "main/BasicRotations/Melee/MNK_Default.cs")]

--- a/BasicRotations/Melee/NIN_Default.cs
+++ b/BasicRotations/Melee/NIN_Default.cs
@@ -1,6 +1,6 @@
 using Dalamud.Interface.Colors;
 
-namespace DefaultRotations.Melee;
+namespace RebornRotations.Melee;
 
 [Rotation("Default", CombatType.PvE, GameVersion = "7.15")]
 [SourceCode(Path = "main/BasicRotations/Melee/NIN_Default.cs")]

--- a/BasicRotations/Melee/RPR_Default.cs
+++ b/BasicRotations/Melee/RPR_Default.cs
@@ -1,4 +1,4 @@
-﻿namespace DefaultRotations.Melee;
+﻿namespace RebornRotations.Melee;
 
 [Rotation("Default", CombatType.PvE, GameVersion = "7.15", Description = "")]
 [SourceCode(Path = "main/BasicRotations/Melee/RPR_Default.cs")]

--- a/BasicRotations/Melee/SAM_Default.cs
+++ b/BasicRotations/Melee/SAM_Default.cs
@@ -1,6 +1,6 @@
 ﻿using System.ComponentModel;
 
-namespace DefaultRotations.Melee;
+namespace RebornRotations.Melee;
 
 [Rotation("Default", CombatType.PvE, GameVersion = "7.15")]
 [SourceCode(Path = "main/BasicRotations/Melee/SAM_Default.cs")]

--- a/BasicRotations/Melee/VPR_Default.cs
+++ b/BasicRotations/Melee/VPR_Default.cs
@@ -1,4 +1,4 @@
-﻿namespace DefaultRotations.Melee;
+﻿namespace RebornRotations.Melee;
 
 [Rotation("Default", CombatType.PvE, GameVersion = "7.15")]
 [SourceCode(Path = "main/BasicRotations/Melee/VPR_Default.cs")]

--- a/BasicRotations/PVPRotations/Healer/AST_Default.PVP.cs
+++ b/BasicRotations/PVPRotations/Healer/AST_Default.PVP.cs
@@ -1,4 +1,4 @@
-﻿namespace DefaultRotations.Healer;
+﻿namespace RebornRotations.PVPRotations.Healer;
 
 [Rotation("Default PVP", CombatType.PvP, GameVersion = "7.00", Description = "Beta Rotation")]
 [SourceCode(Path = "main/BasicRotations/PVPRotations/Healer/AST_Default.PVP.cs")]

--- a/BasicRotations/PVPRotations/Healer/SCH_Default.PVP.cs
+++ b/BasicRotations/PVPRotations/Healer/SCH_Default.PVP.cs
@@ -1,4 +1,4 @@
-﻿namespace DefaultRotations.Healer;
+﻿namespace RebornRotations.PVPRotations.Healer;
 
 [Rotation("Default PVP", CombatType.PvP, GameVersion = "7.00", Description = "Beta Rotation")]
 [SourceCode(Path = "main/BasicRotations/PVPRotations/Healer/SCH_Default.PVP.cs")]

--- a/BasicRotations/PVPRotations/Healer/SGE_Default.PVP.cs
+++ b/BasicRotations/PVPRotations/Healer/SGE_Default.PVP.cs
@@ -1,4 +1,4 @@
-﻿namespace DefaultRotations.Healer;
+﻿namespace RebornRotations.PVPRotations.Healer;
 
 [Rotation("Default PVP", CombatType.PvP, GameVersion = "7.00", Description = "Beta Rotation")]
 [SourceCode(Path = "main/BasicRotations/PVPRotations/Healer/SGE_Default.PVP.cs")]

--- a/BasicRotations/PVPRotations/Healer/WHM_Default.PVP.cs
+++ b/BasicRotations/PVPRotations/Healer/WHM_Default.PVP.cs
@@ -1,4 +1,4 @@
-namespace DefaultRotations.Healer;
+namespace RebornRotations.PVPRotations.Healer;
 
 [Rotation("Default PVP", CombatType.PvP, GameVersion = "7.00", Description = "Beta Rotation")]
 [SourceCode(Path = "main/BasicRotations/PVPRotations/Healer/WHM_Default.PVP.cs")]

--- a/BasicRotations/PVPRotations/Magical/BLM_Default.PVP.cs
+++ b/BasicRotations/PVPRotations/Magical/BLM_Default.PVP.cs
@@ -1,4 +1,4 @@
-﻿namespace DefaultRotations.Magical;
+﻿namespace RebornRotations.PVPRotations.Magical;
 
 [Rotation("Default PVP", CombatType.PvP, GameVersion = "7.15", Description = "Beta Rotation")]
 [SourceCode(Path = "main/BasicRotations/PVPRotations/Magical/BLM_Default.PVP.cs")]

--- a/BasicRotations/PVPRotations/Magical/RDM_Default.PvP.cs
+++ b/BasicRotations/PVPRotations/Magical/RDM_Default.PvP.cs
@@ -1,4 +1,4 @@
-﻿namespace DefaultRotations.Magical;
+﻿namespace RebornRotations.PVPRotations.Magical;
 
 [Rotation("Default PVP", CombatType.PvP, GameVersion = "7.00", Description = "Beta Rotation")]
 [SourceCode(Path = "main/BasicRotations/PVPRotations/Magical/RDM_Default.PVP.cs")]

--- a/BasicRotations/PVPRotations/Magical/SMN_Default.PVP.cs
+++ b/BasicRotations/PVPRotations/Magical/SMN_Default.PVP.cs
@@ -1,4 +1,4 @@
-﻿namespace DefaultRotations.Magical;
+﻿namespace RebornRotations.PVPRotations.Magical;
 
 [Rotation("Default PVP", CombatType.PvP, GameVersion = "7.00", Description = "Beta Rotation")]
 [SourceCode(Path = "main/BasicRotations/PVPRotations/Magical/SMN_Default.PVP.cs")]

--- a/BasicRotations/PVPRotations/Melee/DRG_Default.PVP.cs
+++ b/BasicRotations/PVPRotations/Melee/DRG_Default.PVP.cs
@@ -1,4 +1,4 @@
-﻿namespace DefaultRotations.Melee;
+﻿namespace RebornRotations.PVPRotations.Melee;
 
 [Rotation("Default PVP", CombatType.PvP, GameVersion = "7.00", Description = "Beta Rotation")]
 [SourceCode(Path = "main/BasicRotations/PVPRotations/Tank/DRG_Default.PvP.cs")]

--- a/BasicRotations/PVPRotations/Melee/MNK_Default.PVP.cs
+++ b/BasicRotations/PVPRotations/Melee/MNK_Default.PVP.cs
@@ -1,4 +1,4 @@
-﻿namespace DefaultRotations.Melee;
+﻿namespace RebornRotations.PVPRotations.Melee;
 
 [Rotation("Default", CombatType.PvP, GameVersion = "7.00", Description = "Beta Rotation")]
 [SourceCode(Path = "main/BasicRotations/PVPRotations/Melee/MNK_Default.PVP.cs")]

--- a/BasicRotations/PVPRotations/Melee/NIN_Default.PVP.cs
+++ b/BasicRotations/PVPRotations/Melee/NIN_Default.PVP.cs
@@ -1,4 +1,4 @@
-﻿namespace DefaultRotations.Melee;
+﻿namespace RebornRotations.PVPRotations.Melee;
 
 [Rotation("Default PVP", CombatType.PvP, GameVersion = "7.00", Description = "Beta Rotation")]
 [SourceCode(Path = "main/BasicRotations/PVPRotations/Tank/NIN_Default.PvP.cs")]

--- a/BasicRotations/PVPRotations/Melee/RPR_Default.PVP.cs
+++ b/BasicRotations/PVPRotations/Melee/RPR_Default.PVP.cs
@@ -1,4 +1,4 @@
-﻿namespace DefaultRotations.Melee;
+﻿namespace RebornRotations.PVPRotations.Melee;
 
 [Rotation("Default PVP", CombatType.PvP, GameVersion = "7.00", Description = "Beta Rotation")]
 [SourceCode(Path = "main/BasicRotations/PVPRotations/Tank/RPR_Default.PvP.cs")]

--- a/BasicRotations/PVPRotations/Melee/SAM_Default.PVP.cs
+++ b/BasicRotations/PVPRotations/Melee/SAM_Default.PVP.cs
@@ -1,4 +1,4 @@
-﻿namespace DefaultRotations.Melee;
+﻿namespace RebornRotations.PVPRotations.Melee;
 
 [Rotation("Default PVP", CombatType.PvP, GameVersion = "7.00", Description = "Beta Rotation")]
 [SourceCode(Path = "main/BasicRotations/PVPRotations/Tank/SAM_Default.PvP.cs")]

--- a/BasicRotations/PVPRotations/Melee/VPR_Default.PVP.cs
+++ b/BasicRotations/PVPRotations/Melee/VPR_Default.PVP.cs
@@ -1,4 +1,4 @@
-﻿namespace DefaultRotations.Melee;
+﻿namespace RebornRotations.PVPRotations.Melee;
 
 [Rotation("Default PVP", CombatType.PvP, GameVersion = "7.05", Description = "Beta Rotation")]
 [SourceCode(Path = "main/BasicRotations/PVPRotations/Tank/VPR_Default.PvP.cs")]

--- a/BasicRotations/PVPRotations/Ranged/BRD_Default.PVP.cs
+++ b/BasicRotations/PVPRotations/Ranged/BRD_Default.PVP.cs
@@ -1,4 +1,4 @@
-﻿namespace DefaultRotations.Ranged;
+﻿namespace RebornRotations.PVPRotations.Ranged;
 
 [Rotation("Default PVP", CombatType.PvP, GameVersion = "7.1", Description = "Beta Rotation")]
 [SourceCode(Path = "main/BasicRotations/PVPRotations/Ranged/BRD_Default.PvP.cs")]

--- a/BasicRotations/PVPRotations/Ranged/DNC_Default.PVP.cs
+++ b/BasicRotations/PVPRotations/Ranged/DNC_Default.PVP.cs
@@ -1,4 +1,4 @@
-﻿namespace DefaultRotations.Ranged;
+﻿namespace RebornRotations.PVPRotations.Ranged;
 
 [Rotation("Default PVP", CombatType.PvP, GameVersion = "7.00", Description = "Beta Rotation")]
 [SourceCode(Path = "main/BasicRotations/PVPRotations/Ranged/DNC_Default.PvP.cs")]

--- a/BasicRotations/PVPRotations/Ranged/MCH_Default.PvP.cs
+++ b/BasicRotations/PVPRotations/Ranged/MCH_Default.PvP.cs
@@ -1,4 +1,4 @@
-namespace DefaultRotations.Ranged;
+namespace RebornRotations.PVPRotations.Ranged;
 
 [Rotation("Default PVP", CombatType.PvP, GameVersion = "7.00", Description = "Beta Rotation")]
 [SourceCode(Path = "main/BasicRotations/PVPRotations/Ranged/MCH_Default.PvP.cs")]

--- a/BasicRotations/PVPRotations/Tank/DRK_Default.PVP.cs
+++ b/BasicRotations/PVPRotations/Tank/DRK_Default.PVP.cs
@@ -1,4 +1,4 @@
-namespace DefaultRotations.Tank;
+namespace RebornRotations.PVPRotations.Tank;
 
 [Rotation("Default PVP", CombatType.PvP, GameVersion = "7.00", Description = "Beta Rotation")]
 [SourceCode(Path = "main/BasicRotations/PVPRotations/Tank/DRK_Default.PvP.cs")]

--- a/BasicRotations/PVPRotations/Tank/GNB_Default.PVP.cs
+++ b/BasicRotations/PVPRotations/Tank/GNB_Default.PVP.cs
@@ -1,4 +1,4 @@
-﻿namespace DefaultRotations.Tank;
+﻿namespace RebornRotations.PVPRotations.Tank;
 
 [Rotation("Default PVP", CombatType.PvP, GameVersion = "7.15", Description = "Beta Rotation")]
 [SourceCode(Path = "main/BasicRotations/PVPRotations/Tank/GNB_Default.PvP.cs")]

--- a/BasicRotations/PVPRotations/Tank/PLD_Default.PVP.cs
+++ b/BasicRotations/PVPRotations/Tank/PLD_Default.PVP.cs
@@ -1,4 +1,4 @@
-﻿namespace DefaultRotations.Tank;
+﻿namespace RebornRotations.PVPRotations.Tank;
 
 [Rotation("Default PVP", CombatType.PvP, GameVersion = "7.00", Description = "Beta Rotation")]
 [SourceCode(Path = "main/BasicRotations/PVPRotations/Tank/PLD_Default.PvP.cs")]

--- a/BasicRotations/PVPRotations/Tank/WAR_Default.PVP.cs
+++ b/BasicRotations/PVPRotations/Tank/WAR_Default.PVP.cs
@@ -1,4 +1,4 @@
-﻿namespace DefaultRotations.Tank;
+﻿namespace RebornRotations.PVPRotations.Tank;
 
 [Rotation("Default PVP", CombatType.PvP, GameVersion = "7.00", Description = "Beta Rotation")]
 [SourceCode(Path = "main/BasicRotations/PVPRotations/Tank/WAR_Default.PvP.cs")]

--- a/BasicRotations/Ranged/BRD_Default.cs
+++ b/BasicRotations/Ranged/BRD_Default.cs
@@ -1,4 +1,4 @@
-namespace DefaultRotations.Ranged;
+namespace RebornRotations.Ranged;
 
 [Rotation("Default", CombatType.PvE, GameVersion = "7.15",
     Description = "Please make sure that the three song times add up to 120 seconds, Wanderers default first song for now.")]
@@ -37,9 +37,9 @@ public sealed class BRD_Default : BardRotation
     private float MAGERemainTime => 45 - MAGETime;
     private float ARMYRemainTime => 45 - ARMYTime;
 
-    private static bool InBurstStatus => (Player.Level > 50 && !Player.WillStatusEnd(0, true, StatusID.RagingStrikes))
-        || (Player.Level >= 50 && Player.Level < 90 && !Player.WillStatusEnd(0, true, StatusID.RagingStrikes) && !Player.WillStatusEnd(0, true, StatusID.BattleVoice))
-        || (MinstrelsCodaTrait.EnoughLevel && !Player.WillStatusEnd(0, true, StatusID.RagingStrikes) && !Player.WillStatusEnd(0, true, StatusID.RadiantFinale) && !Player.WillStatusEnd(0, true, StatusID.BattleVoice));
+    private static bool InBurstStatus => Player.Level > 50 && !Player.WillStatusEnd(0, true, StatusID.RagingStrikes)
+        || Player.Level >= 50 && Player.Level < 90 && !Player.WillStatusEnd(0, true, StatusID.RagingStrikes) && !Player.WillStatusEnd(0, true, StatusID.BattleVoice)
+        || MinstrelsCodaTrait.EnoughLevel && !Player.WillStatusEnd(0, true, StatusID.RagingStrikes) && !Player.WillStatusEnd(0, true, StatusID.RadiantFinale) && !Player.WillStatusEnd(0, true, StatusID.BattleVoice);
 
     #endregion
 
@@ -147,15 +147,15 @@ public sealed class BRD_Default : BardRotation
 
         if (IsBurst && Song != Song.NONE && MagesBalladPvE.EnoughLevel)
         {
-            if (((!RadiantFinalePvE.EnoughLevel && !RagingStrikesPvE.Cooldown.IsCoolingDown)
-                    || (RadiantFinalePvE.EnoughLevel && !RadiantFinalePvE.Cooldown.IsCoolingDown && RagingStrikesPvE.EnoughLevel && (!RagingStrikesPvE.Cooldown.IsCoolingDown || RagingStrikesPvE.Cooldown.WillHaveOneCharge(BuffAlignment))))
-                    && (HostileTarget?.HasStatus(true, StatusID.Windbite, StatusID.Stormbite) == true) && (HostileTarget?.HasStatus(true, StatusID.VenomousBite, StatusID.CausticBite) == true) && BattleVoicePvE.CanUse(out act, isLastAbility: OGCDTimers)) return true;
+            if ((!RadiantFinalePvE.EnoughLevel && !RagingStrikesPvE.Cooldown.IsCoolingDown
+                    || RadiantFinalePvE.EnoughLevel && !RadiantFinalePvE.Cooldown.IsCoolingDown && RagingStrikesPvE.EnoughLevel && (!RagingStrikesPvE.Cooldown.IsCoolingDown || RagingStrikesPvE.Cooldown.WillHaveOneCharge(BuffAlignment)))
+                    && HostileTarget?.HasStatus(true, StatusID.Windbite, StatusID.Stormbite) == true && HostileTarget?.HasStatus(true, StatusID.VenomousBite, StatusID.CausticBite) == true && BattleVoicePvE.CanUse(out act, isLastAbility: OGCDTimers)) return true;
 
             if (!Player.WillStatusEnd(0, true, StatusID.BattleVoice) && RadiantFinalePvE.CanUse(out act, isFirstAbility: OGCDTimers)) return true;
 
-            if (((RadiantFinalePvE.EnoughLevel && !Player.WillStatusEnd(0, true, StatusID.RadiantFinale) && !Player.WillStatusEnd(0, true, StatusID.BattleVoice))
-                || (!RadiantFinalePvE.EnoughLevel && BattleVoicePvE.EnoughLevel && !Player.WillStatusEnd(0, true, StatusID.BattleVoice))
-                || (!RadiantFinalePvE.EnoughLevel && !BattleVoicePvE.EnoughLevel))
+            if ((RadiantFinalePvE.EnoughLevel && !Player.WillStatusEnd(0, true, StatusID.RadiantFinale) && !Player.WillStatusEnd(0, true, StatusID.BattleVoice)
+                || !RadiantFinalePvE.EnoughLevel && BattleVoicePvE.EnoughLevel && !Player.WillStatusEnd(0, true, StatusID.BattleVoice)
+                || !RadiantFinalePvE.EnoughLevel && !BattleVoicePvE.EnoughLevel)
                 && RagingStrikesPvE.CanUse(out act, isLastAbility: OGCDTimers)) return true;
         }
 
@@ -237,7 +237,7 @@ public sealed class BRD_Default : BardRotation
         if (LadonsbitePvE.CanUse(out act) && !Player.HasStatus(true, StatusID.HawksEye_3861)) return true;
         if (QuickNockPvE.CanUse(out act) && !Player.HasStatus(true, StatusID.HawksEye_3861)) return true;
 
-        if (IronJawsPvE.EnoughLevel && (HostileTarget?.HasStatus(true, StatusID.Windbite, StatusID.Stormbite) == true) && (HostileTarget?.HasStatus(true, StatusID.VenomousBite, StatusID.CausticBite) == true))
+        if (IronJawsPvE.EnoughLevel && HostileTarget?.HasStatus(true, StatusID.Windbite, StatusID.Stormbite) == true && HostileTarget?.HasStatus(true, StatusID.VenomousBite, StatusID.CausticBite) == true)
         {
             // Do not use WindbitePvE or VenomousBitePvE if both statuses are present and IronJawsPvE has enough level
         }
@@ -290,25 +290,25 @@ public sealed class BRD_Default : BardRotation
 
         if (HeartbreakShotPvE.CanUse(out act, usedUp: true))
         {
-            if ((!isRagingStrikesLevel)
-                || (isRagingStrikesLevel && !isBattleVoiceLevel && Player.HasStatus(true, StatusID.RagingStrikes))
-                || (isBattleVoiceLevel && !isRadiantFinaleLevel && Player.HasStatus(true, StatusID.RagingStrikes) && Player.HasStatus(true, StatusID.BattleVoice))
+            if (!isRagingStrikesLevel
+                || isRagingStrikesLevel && !isBattleVoiceLevel && Player.HasStatus(true, StatusID.RagingStrikes)
+                || isBattleVoiceLevel && !isRadiantFinaleLevel && Player.HasStatus(true, StatusID.RagingStrikes) && Player.HasStatus(true, StatusID.BattleVoice)
                 || isRadiantFinaleLevel && Player.HasStatus(true, StatusID.RagingStrikes) && Player.HasStatus(true, StatusID.BattleVoice) && Player.HasStatus(true, StatusID.RadiantFinale)) return true;
         }
 
         if (RainOfDeathPvE.CanUse(out act, usedUp: true))
         {
-            if ((!isRagingStrikesLevel)
-                || (isRagingStrikesLevel && !isBattleVoiceLevel && Player.HasStatus(true, StatusID.RagingStrikes))
-                || (isBattleVoiceLevel && !isRadiantFinaleLevel && Player.HasStatus(true, StatusID.RagingStrikes) && Player.HasStatus(true, StatusID.BattleVoice))
+            if (!isRagingStrikesLevel
+                || isRagingStrikesLevel && !isBattleVoiceLevel && Player.HasStatus(true, StatusID.RagingStrikes)
+                || isBattleVoiceLevel && !isRadiantFinaleLevel && Player.HasStatus(true, StatusID.RagingStrikes) && Player.HasStatus(true, StatusID.BattleVoice)
                 || isRadiantFinaleLevel && Player.HasStatus(true, StatusID.RagingStrikes) && Player.HasStatus(true, StatusID.BattleVoice) && Player.HasStatus(true, StatusID.RadiantFinale)) return true;
         }
 
         if (BloodletterPvE.CanUse(out act, usedUp: true))
         {
-            if ((!isRagingStrikesLevel)
-                || (isRagingStrikesLevel && !isBattleVoiceLevel && Player.HasStatus(true, StatusID.RagingStrikes))
-                || (isBattleVoiceLevel && !isRadiantFinaleLevel && Player.HasStatus(true, StatusID.RagingStrikes) && Player.HasStatus(true, StatusID.BattleVoice))
+            if (!isRagingStrikesLevel
+                || isRagingStrikesLevel && !isBattleVoiceLevel && Player.HasStatus(true, StatusID.RagingStrikes)
+                || isBattleVoiceLevel && !isRadiantFinaleLevel && Player.HasStatus(true, StatusID.RagingStrikes) && Player.HasStatus(true, StatusID.BattleVoice)
                 || isRadiantFinaleLevel && Player.HasStatus(true, StatusID.RagingStrikes) && Player.HasStatus(true, StatusID.BattleVoice) && Player.HasStatus(true, StatusID.RadiantFinale)) return true;
         }
         return false;

--- a/BasicRotations/Ranged/DNC_Default.cs
+++ b/BasicRotations/Ranged/DNC_Default.cs
@@ -1,4 +1,4 @@
-namespace DefaultRotations.Ranged;
+namespace RebornRotations.Ranged;
 
 [Rotation("Default", CombatType.PvE, GameVersion = "7.15", Description = "")]
 [SourceCode(Path = "main/BasicRotations/Ranged/DNC_Default.cs")]

--- a/BasicRotations/Ranged/MCH_Default.cs
+++ b/BasicRotations/Ranged/MCH_Default.cs
@@ -1,4 +1,4 @@
-namespace DefaultRotations.Ranged;
+namespace RebornRotations.Ranged;
 
 [Rotation("Default", CombatType.PvE, GameVersion = "7.15")]
 [SourceCode(Path = "main/BasicRotations/Ranged/MCH_Default.cs")]

--- a/BasicRotations/Ranged/MCH_HighEnd.cs
+++ b/BasicRotations/Ranged/MCH_HighEnd.cs
@@ -1,4 +1,4 @@
-namespace DefaultRotations.Ranged;
+namespace RebornRotations.Ranged;
 
 [Rotation("High End", CombatType.PvE, GameVersion = "7.15")]
 [SourceCode(Path = "main/BasicRotations/Ranged/MCH_HighEnd.cs")]

--- a/BasicRotations/Tank/DRK_Default.cs
+++ b/BasicRotations/Tank/DRK_Default.cs
@@ -1,4 +1,4 @@
-namespace DefaultRotations.Tank;
+namespace RebornRotations.Tank;
 
 [Rotation("Default", CombatType.PvE, GameVersion = "7.15")]
 [SourceCode(Path = "main/BasicRotations/Tank/DRK_Default.cs")]
@@ -177,7 +177,7 @@ public sealed class DRK_Default : DarkKnightRotation
             if (!DeliriumPvE.EnoughLevel || !LivingShadowPvE.EnoughLevel) return true;
             if (Player.HasStatus(true, StatusID.Delirium_3836)) return true;
             if ((Player.HasStatus(true, StatusID.Delirium_1972) || Player.HasStatus(true, StatusID.Delirium_3836)) && LivingShadowPvE.Cooldown.IsCoolingDown) return true;
-            if ((DeliriumPvE.Cooldown.WillHaveOneChargeGCD(1) && !LivingShadowPvE.Cooldown.WillHaveOneChargeGCD(3)) || Blood >= 90 && !LivingShadowPvE.Cooldown.WillHaveOneChargeGCD(1)) return true;
+            if (DeliriumPvE.Cooldown.WillHaveOneChargeGCD(1) && !LivingShadowPvE.Cooldown.WillHaveOneChargeGCD(3) || Blood >= 90 && !LivingShadowPvE.Cooldown.WillHaveOneChargeGCD(1)) return true;
 
             return false;
 
@@ -188,7 +188,7 @@ public sealed class DRK_Default : DarkKnightRotation
     {
         get
         {
-            if ((BloodWeaponPvE.Cooldown.IsCoolingDown && DeliriumPvE.Cooldown.IsCoolingDown && ((LivingShadowPvE.Cooldown.IsCoolingDown && !(LivingShadowPvE.Cooldown.ElapsedAfter(15))) || !LivingShadowPvE.EnoughLevel))) return true;
+            if (BloodWeaponPvE.Cooldown.IsCoolingDown && DeliriumPvE.Cooldown.IsCoolingDown && (LivingShadowPvE.Cooldown.IsCoolingDown && !LivingShadowPvE.Cooldown.ElapsedAfter(15) || !LivingShadowPvE.EnoughLevel)) return true;
             else return false;
         }
     }
@@ -202,9 +202,9 @@ public sealed class DRK_Default : DarkKnightRotation
 
             if (CombatElapsedLess(3)) return false;
 
-            if ((InTwoMIsBurst && HasDarkArts) || (HasDarkArts && Player.HasStatus(true, StatusID.BlackestNight)) || (HasDarkArts && DarkSideEndAfterGCD(3))) return true;
+            if (InTwoMIsBurst && HasDarkArts || HasDarkArts && Player.HasStatus(true, StatusID.BlackestNight) || HasDarkArts && DarkSideEndAfterGCD(3)) return true;
 
-            if ((InTwoMIsBurst && BloodWeaponPvE.Cooldown.IsCoolingDown && LivingShadowPvE.Cooldown.IsCoolingDown && SaltedEarthPvE.Cooldown.IsCoolingDown && ShadowbringerPvE.Cooldown.CurrentCharges == 0 && CarveAndSpitPvE.Cooldown.IsCoolingDown)) return true;
+            if (InTwoMIsBurst && BloodWeaponPvE.Cooldown.IsCoolingDown && LivingShadowPvE.Cooldown.IsCoolingDown && SaltedEarthPvE.Cooldown.IsCoolingDown && ShadowbringerPvE.Cooldown.CurrentCharges == 0 && CarveAndSpitPvE.Cooldown.IsCoolingDown) return true;
 
             if (TheBlackestNight && CurrentMp < 6000) return false;
 

--- a/BasicRotations/Tank/GNB_Default.cs
+++ b/BasicRotations/Tank/GNB_Default.cs
@@ -1,4 +1,4 @@
-namespace DefaultRotations.Tank;
+namespace RebornRotations.Tank;
 
 [Rotation("Default", CombatType.PvE, GameVersion = "7.15")]
 [SourceCode(Path = "main/BasicRotations/Tank/GNB_Default.cs")]

--- a/BasicRotations/Tank/PLD_Default.cs
+++ b/BasicRotations/Tank/PLD_Default.cs
@@ -1,4 +1,4 @@
-﻿namespace DefaultRotations.Tank;
+﻿namespace RebornRotations.Tank;
 
 [Rotation("Beta", CombatType.PvE, GameVersion = "7.15")]
 [SourceCode(Path = "main/BasicRotations/Tank/PLD_Default.cs")]

--- a/BasicRotations/Tank/WAR_Default.cs
+++ b/BasicRotations/Tank/WAR_Default.cs
@@ -1,4 +1,4 @@
-namespace DefaultRotations.Tank;
+namespace RebornRotations.Tank;
 
 [Rotation("Default", CombatType.PvE, GameVersion = "7.15")]
 [SourceCode(Path = "main/BasicRotations/Tank/WAR_Default.cs")]

--- a/RotationSolver.Basic/Configuration/Configs.cs
+++ b/RotationSolver.Basic/Configuration/Configs.cs
@@ -635,27 +635,27 @@ internal partial class Configs : IPluginConfiguration
 
     [JobConfig, UI("Ignore Invincibility for PvP purposes.", Filter = PvPSpecificControls)]
     private readonly bool _ignorePvPInvincibility = false;
-    
+
     [ConditionBool, UI("Auto turn off when dead in PvP.",
          Filter = PvPSpecificControls)]
     private static readonly bool _autoOffWhenDeadPvP = true;
-    
+
     [ConditionBool, UI("Auto turn off when PvP match ends.",
          Filter = PvPSpecificControls)]
     private static readonly bool _autoOffPvPMatchEnd = true;
-    
+
     [ConditionBool, UI("Auto turn on when PvP match starts.",
          Filter = PvPSpecificControls)]
     private static readonly bool _autoOnPvPMatchStart = true;
-    
+
     #endregion
-    
+
     #region Jobs
-    
+
     [JobConfig, UI("MP threshold under which to use Lucid Dreaming", Filter = HealingActionCondition)]
     [Range(0, 10000, ConfigUnitType.None)]
     private readonly int _lucidDreamingMpThreshold = 6000;
-    
+
     [JobConfig, Range(0, 1, ConfigUnitType.Percent)]
     private readonly float _healthAreaAbilityHot = 0.55f;
 

--- a/RotationSolver.Basic/Helpers/ObjectHelper.cs
+++ b/RotationSolver.Basic/Helpers/ObjectHelper.cs
@@ -6,7 +6,6 @@ using ECommons.DalamudServices;
 using ECommons.GameFunctions;
 using ECommons.GameHelpers;
 using FFXIVClientStructs.FFXIV.Client.Game;
-using FFXIVClientStructs.FFXIV.Client.Game.Character;
 using FFXIVClientStructs.FFXIV.Client.Game.Event;
 using FFXIVClientStructs.FFXIV.Client.Graphics;
 using FFXIVClientStructs.FFXIV.Client.UI;
@@ -142,7 +141,7 @@ public static class ObjectHelper
             TargetHostileType.AllTargetsWhenSoloInDutyTargetIsInEnemiesList => DataCenter.PartyMembers.Count < 2 || battleChara.TargetObject is IBattleChara target && target.IsInEnemiesList(),
             _ => true,
         };
-        }
+    }
 
     private static string RemoveControlCharacters(string input)
     {
@@ -600,8 +599,8 @@ public static class ObjectHelper
         }
 
         return (float)(DateTime.Now - _aliveStartTimes[b.GameObjectId]).TotalSeconds;
-    } 
-    
+    }
+
     private static readonly ConcurrentDictionary<ulong, DateTime> _deadStartTimes = new();
 
     /// <summary>

--- a/RotationSolver.Basic/Rotations/Basic/BlackMageRotation.cs
+++ b/RotationSolver.Basic/Rotations/Basic/BlackMageRotation.cs
@@ -276,6 +276,7 @@ partial class BlackMageRotation
 
     static partial void ModifyUmbralSoulPvE(ref ActionSetting setting)
     {
+        setting.ActionCheck = () => InUmbralIce;
         setting.UnlockedByQuestID = 66609;
     }
 
@@ -584,7 +585,7 @@ partial class BlackMageRotation
             AoeCount = 1,
         };
     }
-    
+
     static partial void ModifyFrostStarPvP(ref ActionSetting setting)
     {
         setting.StatusNeed = [StatusID.ElementalStar];

--- a/RotationSolver.Basic/Rotations/Basic/BlueMageRotation.cs
+++ b/RotationSolver.Basic/Rotations/Basic/BlueMageRotation.cs
@@ -1,6 +1,4 @@
-﻿using ECommons;
-
-namespace RotationSolver.Basic.Rotations.Basic;
+﻿namespace RotationSolver.Basic.Rotations.Basic;
 
 partial class BlueMageRotation
 {
@@ -176,7 +174,7 @@ partial class BlueMageRotation
 
     static partial void ModifySharpenedKnifePvE(ref ActionSetting setting)
     {
-        
+
     }
 
     static partial void ModifyChocoMeteorPvE(ref ActionSetting setting)

--- a/RotationSolver.Basic/Rotations/Basic/DarkKnightRotation.cs
+++ b/RotationSolver.Basic/Rotations/Basic/DarkKnightRotation.cs
@@ -17,7 +17,7 @@ partial class DarkKnightRotation
     /// 
     /// </summary>
     public static bool HasDarkArts => JobGauge.HasDarkArts;
-    
+
     /// <summary>
     /// 
     /// </summary>
@@ -422,17 +422,17 @@ partial class DarkKnightRotation
     /// 
     /// </summary>
     public static bool ScarletDeliriumPvPReady => Service.GetAdjustedActionId(ActionID.SouleaterPvP) == ActionID.ScarletDeliriumPvP;
-    
+
     /// <summary>
     /// 
     /// </summary>
     public static bool ComeuppancePvPReady => Service.GetAdjustedActionId(ActionID.SouleaterPvP) == ActionID.ComeuppancePvP;
-    
+
     /// <summary>
     /// 
     /// </summary>
     public static bool TorcleaverPvPReady => Service.GetAdjustedActionId(ActionID.SouleaterPvP) == ActionID.TorcleaverPvP;
-    
+
     /// <summary>
     /// 
     /// </summary>
@@ -479,6 +479,6 @@ partial class DarkKnightRotation
     {
         setting.ActionCheck = () => SaltAndDarknessPvPReady;
     }
-    
+
     #endregion
 }

--- a/RotationSolver.Basic/Rotations/Basic/NinjaRotation.cs
+++ b/RotationSolver.Basic/Rotations/Basic/NinjaRotation.cs
@@ -198,7 +198,7 @@ partial class NinjaRotation
     {
         setting.ActionCheck = () => RabbitMediumPvEActive;
     }
-    
+
     static partial void ModifySpinningEdgePvE(ref ActionSetting setting)
     {
 
@@ -355,7 +355,7 @@ partial class NinjaRotation
         setting.StatusProvide = [StatusID.TenChiJin, StatusID.TenriJindoReady];
         setting.UnlockedByQuestID = 68488;
     }
-    
+
     static partial void ModifyMeisuiPvE(ref ActionSetting setting)
     {
         setting.StatusNeed = [StatusID.ShadowWalker];

--- a/RotationSolver.Basic/Rotations/Basic/SummonerRotation.cs
+++ b/RotationSolver.Basic/Rotations/Basic/SummonerRotation.cs
@@ -324,7 +324,7 @@ partial class SummonerRotation
 
     static partial void ModifyResurrectionPvE(ref ActionSetting setting)
     {
- 
+
     }
 
     static partial void ModifySummonTopazPvE(ref ActionSetting setting)
@@ -445,7 +445,7 @@ partial class SummonerRotation
 
     static partial void ModifySummonGarudaIiPvE(ref ActionSetting setting)
     {
-        
+
     }
 
     static partial void ModifyNecrotizePvE(ref ActionSetting setting)

--- a/RotationSolver.Basic/Rotations/CustomRotation_Ability.cs
+++ b/RotationSolver.Basic/Rotations/CustomRotation_Ability.cs
@@ -428,7 +428,7 @@ partial class CustomRotation
         }
 
         #region PvP
-        if (GuardPvP.CanUse(out act) && Player.GetHealthRatio() <= Service.Config.HealthForGuard )
+        if (GuardPvP.CanUse(out act) && Player.GetHealthRatio() <= Service.Config.HealthForGuard)
         {
             return true;
         }

--- a/RotationSolver.Basic/Rotations/CustomRotation_GCD.cs
+++ b/RotationSolver.Basic/Rotations/CustomRotation_GCD.cs
@@ -145,7 +145,7 @@ partial class CustomRotation
 
         return LimitBreakLevel switch
         {
-            1 => (DataCenter.IsPvP? LimitBreakPvP?.CanUse(out act, skipAoeCheck: true) : LimitBreak1?.CanUse(out act, skipAoeCheck: true)) ?? false,
+            1 => (DataCenter.IsPvP ? LimitBreakPvP?.CanUse(out act, skipAoeCheck: true) : LimitBreak1?.CanUse(out act, skipAoeCheck: true)) ?? false,
             2 => LimitBreak2?.CanUse(out act, skipAoeCheck: true) ?? false,
             3 => LimitBreak3?.CanUse(out act, skipAoeCheck: true) ?? false,
             _ => false,

--- a/RotationSolver.Basic/Rotations/CustomRotation_OtherInfo.cs
+++ b/RotationSolver.Basic/Rotations/CustomRotation_OtherInfo.cs
@@ -658,7 +658,7 @@ partial class CustomRotation
     /// </summary>
     [Description("Health of dying tank")]
     public static float HealthForDyingTanks => Service.Config.HealthForDyingTanks;
-    
+
     /// <summary>
     /// 
     /// </summary>

--- a/RotationSolver/Commands/RSCommands_OtherCommand.cs
+++ b/RotationSolver/Commands/RSCommands_OtherCommand.cs
@@ -2,7 +2,6 @@
 using RotationSolver.Basic.Configuration;
 using RotationSolver.Data;
 using RotationSolver.Updaters;
-using System.Reflection;
 
 namespace RotationSolver.Commands;
 
@@ -85,13 +84,21 @@ public static partial class RSCommands
 
             if (property.PropertyType == typeof(ConditionBoolean))
             {
-                var relay = (ConditionBoolean)property.GetValue(Service.Config)!;
-                relay.Value = (bool)convertedValue;
-                convertedValue = relay;
+                if (convertedValue is bool boolValue)
+                {
+                    var relay = (ConditionBoolean)property.GetValue(Service.Config)!;
+                    relay.Value = boolValue;
+                    convertedValue = relay;
+                }
+                else
+                {
+                    Svc.Chat.PrintError("Failed to parse the value as boolean.");
+                    return;
+                }
             }
 
             property.SetValue(Service.Config, convertedValue);
-            command = convertedValue.ToString();
+            command = convertedValue?.ToString();
 
             if (Service.Config.ShowToggledActionInChat)
             {

--- a/RotationSolver/Data/UiString.cs
+++ b/RotationSolver/Data/UiString.cs
@@ -681,10 +681,10 @@ namespace RotationSolver.Data
 
         [Description("Recent Changes:")]
         WelcomeWindow_Changelog,
-        
+
         [Description("Reorder AutoStatus Priorities")]
         ConfigWindow_Auto_PrioritiesOrganizer,
-        
+
         [Description("PvP Specific Controls")]
         ConfigWindow_Auto_PvPSpecific,
     }

--- a/RotationSolver/Helpers/RotationLoadContext.cs
+++ b/RotationSolver/Helpers/RotationLoadContext.cs
@@ -1,8 +1,8 @@
 ﻿using Dalamud.Plugin;
+using ECommons.DalamudServices;
 using Lumina.Excel;
 //using Lumina.Excel.CustomSheets;
 using System.Runtime.Loader;
-using ECommons.DalamudServices;
 
 namespace RotationSolver.Helpers;
 

--- a/RotationSolver/UI/ImGuiHelper.cs
+++ b/RotationSolver/UI/ImGuiHelper.cs
@@ -9,9 +9,6 @@ using ECommons.LanguageHelpers;
 using RotationSolver.Basic.Configuration;
 using RotationSolver.Commands;
 using RotationSolver.Data;
-using System;
-using System.Collections.Generic;
-using System.Numerics;
 
 namespace RotationSolver.UI;
 

--- a/RotationSolver/UI/RotationConfigWindow.cs
+++ b/RotationSolver/UI/RotationConfigWindow.cs
@@ -2839,10 +2839,10 @@ public partial class RotationConfigWindow : Window
     private static unsafe void DrawParty()
     {
         ImGui.Text($"Your combat state: {DataCenter.InCombat}");
-        
+
         ImGui.Text($"Number of Party Members: {DataCenter.PartyMembers.Count}");
         ImGui.Text($"Number of Alliance Members: {DataCenter.AllianceMembers.Count}");
-        ImGui.Text($"Average Party HP Percent: {DataCenter.PartyMembersAverHP*100}");
+        ImGui.Text($"Average Party HP Percent: {DataCenter.PartyMembersAverHP * 100}");
         foreach (var p in Svc.Party)
         {
             if (p.GameObject is not IBattleChara b) continue;
@@ -2858,7 +2858,7 @@ public partial class RotationConfigWindow : Window
     {
         var target = Svc.Targets.Target;
         if (target == null) return;
-        
+
         ImGui.Text($"Height: {target.Struct()->Height}");
         ImGui.Text($"Kind: {target.GetObjectKind()}");
         ImGui.Text($"SubKind: {target.GetBattleNPCSubKind()}");

--- a/RotationSolver/UI/RotationConfigWindow_Config.cs
+++ b/RotationSolver/UI/RotationConfigWindow_Config.cs
@@ -303,7 +303,7 @@ public partial class RotationConfigWindow
         ImGui.Separator();
         _allSearchable.DrawItems(Configs.PvPSpecificControls);
     }
-    
+
     /// <summary>
     /// Draws the Action Usage and Control section.
     /// </summary>

--- a/RotationSolver/Updaters/MajorUpdater.cs
+++ b/RotationSolver/Updaters/MajorUpdater.cs
@@ -32,7 +32,7 @@ internal static class MajorUpdater
         ActionSequencerUpdater.Enable(Svc.PluginInterface.ConfigDirectory.FullName + "\\Conditions");
         Svc.Framework.Update += RSRUpdate;
     }
-    
+
     // "Transition locked" means when !MajorUpdater.IsValid
     // TransitionSafeCommands are any function that are qualified safe for RSRUpdate to run, even when other updates should not happen.
     // TransitionSafeCommands *should* be duplicated elsewhere for commands that should also run when otherwise safe to update.
@@ -49,7 +49,7 @@ internal static class MajorUpdater
         RotationSolverPlugin.UpdateDisplayWindow();
 
         if (!IsValid)
-        {   
+        {
             TransitionSafeCommands();
             ActionUpdater.ClearNextAction();
             CustomRotation.MoveTarget = null;


### PR DESCRIPTION
This pull request includes changes to update the namespaces across multiple files and adds new functionality to the `WHM_Default` class. The most important changes include updating the namespaces from `DefaultRotations` to `RebornRotations`, adding a new configuration option for using medicine in the `WHM_Default` class, and improving the logic for emergency abilities and general abilities in various classes.

Namespace updates:

* Updated namespaces from `DefaultRotations` to `RebornRotations` in multiple files, including `Duty`, `Healer`, `Magical`, `Melee`, and `PVPRotations` directories. [[1]](diffhunk://#diff-01e29005068684f83b563c7d44afe50f18a17151536a58c6b80f77da03e841f0L3-R3) [[2]](diffhunk://#diff-330bfb6ae846185576f35b43bc761c7df2df5783898500d8d4500a10b8523918L1-R1) [[3]](diffhunk://#diff-47b613c092bac6c0fca7f78e0876e61724dc22b2706305872f6854f87940aea8L1-R1) [[4]](diffhunk://#diff-048922cde007c3a11c8a1edea2742248b0c16ceb8806c7c8f14c6e2fbd612898L1-R1) [[5]](diffhunk://#diff-fbffa564df294aeb6931debccf5f27492b868d6d4314d7d96f31689233ec0936L3-R13) [[6]](diffhunk://#diff-3e56e9f9ab22f53d36d367513c7042b42af1482f3836b95d20eadc7e1f4c50a1L1-R1) [[7]](diffhunk://#diff-fa0f690f671b57eb26ec5c64e29551eac26a6601e23cf37cdc0f3da2bd9224e3L1-R1) [[8]](diffhunk://#diff-ca31a7b264a11b1cc37ccd5851cfd89b864c323c7ffe2d13ce2eb6046cfecd82L1-R1) [[9]](diffhunk://#diff-fea58d15ea107c183c0b0ea21e482945083e556d0a9a93d6219c2b59450b12e8L1-R1) [[10]](diffhunk://#diff-4f7fb3f0ec8449090ad12494e3154d686176039423a8a0ea71732fe9a9e406d3L1-R1) [[11]](diffhunk://#diff-1dba57f32afcb34c62ded341d867ea72affff6da11d4fb6a9ad4f1c74625467eL1-R1) [[12]](diffhunk://#diff-124b9f747e1a79431fec6fd7539133f4f99db00bcb2e9e7d59ce59009fe9da88L1-R1) [[13]](diffhunk://#diff-83d53925ae6d8c58ca3a83c9acc9c24e4b19aee37422b55b17623abbe6cc2eecL3-R3) [[14]](diffhunk://#diff-408e51743495f585bdfcad7e9eaab67629eb3c88c8726ed094b6cf54ee32cc6cL1-R1) [[15]](diffhunk://#diff-c8f54622438b0935ab3c9c0d37c4ef394d8a28f6a371bdf821005760f98f7ca3L3-R3) [[16]](diffhunk://#diff-40e0f154b39c23ffccde39af86843b1915010db8c01b77c83f1395ec31890f08L3-R3) [[17]](diffhunk://#diff-41766f5a9e8781501954ec98e728f10db303d9af6d66cda08bc4b5d2fbe35259L1-R1) [[18]](diffhunk://#diff-e913e7d87d2c2dc2110b83a10d2cfdcca6566f88f9ec2b3b11feaf645fb7bda6L3-R3) [[19]](diffhunk://#diff-7427c87a4c87139d96976bd9e060154f4dca608d51a6e2484ceeaef68dcdcc76L1-R1) [[20]](diffhunk://#diff-d16ee651f49d153a9d3cbbe44ab45c424cb04ae1d49c96ab64d8dafcc1e73e56L1-R1)

New functionality in `WHM_Default` class:

* Added a new configuration option `UseMedicine` to use Tincture/Gemdraught when about to use Presence of Mind.
* Improved logic for emergency abilities to include the use of medicine when Presence of Mind is not cooling down.
* Enhanced general GCD logic to prevent actions other than Raise when Swiftcast is active.
* Removed redundant constructor logic for `AfflatusRapturePvE` and `AfflatusSolacePvE`.

Other improvements:

* Added logic to `PCT_Default` class to handle defense single abilities and general abilities. [[1]](diffhunk://#diff-1dba57f32afcb34c62ded341d867ea72affff6da11d4fb6a9ad4f1c74625467eR96-R110) [[2]](diffhunk://#diff-1dba57f32afcb34c62ded341d867ea72affff6da11d4fb6a9ad4f1c74625467eR135-R141)
* Simplified emergency ability and attack ability logic in `DRG_Default` class. [[1]](diffhunk://#diff-408e51743495f585bdfcad7e9eaab67629eb3c88c8726ed094b6cf54ee32cc6cL54-R61) [[2]](diffhunk://#diff-408e51743495f585bdfcad7e9eaab67629eb3c88c8726ed094b6cf54ee32cc6cL94-R92)