### PR TITLE
Chaotic heal

### DIFF
--- a/BasicRotations/Healer/SGE_Default.cs
+++ b/BasicRotations/Healer/SGE_Default.cs
@@ -253,7 +253,7 @@ public sealed class SGE_Default : SageRotation
 
         // If the last action performed matches any of a list of specific actions, it clears the Eukrasia aim.
         // This serves as a reset/cleanup mechanism to ensure the decision logic starts fresh for the next cycle.
-        if (IsLastGCD(false, EukrasianPrognosisIiPvE, EukrasianPrognosisPvE,
+        if (IsLastGCD(true, EukrasianPrognosisIiPvE, EukrasianPrognosisPvE,
             EukrasianDiagnosisPvE, EukrasianDyskrasiaPvE, EukrasianDosisIiiPvE, EukrasianDosisIiPvE,
             EukrasianDosisPvE) || !InCombat)
         {

--- a/BasicRotations/Melee/MNK_Default.cs
+++ b/BasicRotations/Melee/MNK_Default.cs
@@ -17,6 +17,13 @@ public sealed class MNK_Default : MonkRotation
         [Description("Perfect Balance")] PerfectBalance,
     }
 
+    public enum MasterfulBlitzUse : byte
+    {
+        [Description("Use Immediately")] UseAsAble,
+
+        [Description("With ROF burst logic")] RiddleOfFireUse,
+    }
+
     [RotationConfig(CombatType.PvE, Name = "Use Form Shift")]
     public bool AutoFormShift { get; set; } = true;
 
@@ -31,6 +38,9 @@ public sealed class MNK_Default : MonkRotation
 
     [RotationConfig(CombatType.PvE, Name = "Enable TEA Checker.")]
     public bool EnableTEAChecker { get; set; } = false;
+
+    [RotationConfig(CombatType.PvE, Name = "Use Masterful Blitz abilites as soon as they are available.")]
+    public MasterfulBlitzUse MBAbilities { get; set; } = MasterfulBlitzUse.RiddleOfFireUse;
 
     [RotationConfig(CombatType.PvE, Name = "Use Riddle of Fire after this ability")]
     public RiddleOfFireFirst ROFFirst { get; set; } = RiddleOfFireFirst.Brotherhood;
@@ -91,11 +101,16 @@ public sealed class MNK_Default : MonkRotation
             // 'If you are in brotherhood and forbidden chakra is available, use it.'
             if (TheForbiddenChakraPvE.CanUse(out act)) return true;
         }
-        if (!InBrotherhood)
+        else
         {
             // 'If you are not in brotherhood and brotherhood is about to be available, hold for burst.'
-            if (BrotherhoodPvE.Cooldown.WillHaveOneChargeGCD(1) && TheForbiddenChakraPvE.CanUse(out act)) return false;
+            if (BrotherhoodPvE.Cooldown.WillHaveOneChargeGCD(1) && TheForbiddenChakraPvE.CanUse(out act)) return true;
             // 'If you are not in brotherhood use it.'
+            if (TheForbiddenChakraPvE.CanUse(out act)) return true;
+        }
+        if (!BrotherhoodPvE.EnoughLevel)
+        {
+            // 'If you are not high enough level for brotherhood, use it.'
             if (TheForbiddenChakraPvE.CanUse(out act)) return true;
         }
         if (!TheForbiddenChakraPvE.EnoughLevel)
@@ -239,22 +254,47 @@ public sealed class MNK_Default : MonkRotation
 
         // bullet proofed finisher - use when during burst
         // or if burst was missed, and next burst is not arriving in time, use it better than waste it, otherwise, hold it for next rof
-        if (!BeastChakras.Contains(BeastChakra.NONE) && (Player.HasStatus(true, StatusID.RiddleOfFire) || RiddleOfFirePvE.Cooldown.JustUsedAfter(42)))
+        if (!BeastChakras.Contains(BeastChakra.NONE))
         {
-            // Both Nadi and 3 beasts
-            if (PhantomRushPvE.CanUse(out act)) return true;
-            if (TornadoKickPvE.CanUse(out act)) return true;
+            switch (MBAbilities)
+            {
+                case MasterfulBlitzUse.UseAsAble:
+                default:
+                    if (PhantomRushPvE.CanUse(out act)) return true;
+                    if (TornadoKickPvE.CanUse(out act)) return true;
 
-            // Needing Solar Nadi and has 3 different beasts
-            if (RisingPhoenixPvE.CanUse(out act)) return true;
-            if (FlintStrikePvE.CanUse(out act)) return true;
+                    // Needing Solar Nadi and has 3 different beasts
+                    if (RisingPhoenixPvE.CanUse(out act)) return true;
+                    if (FlintStrikePvE.CanUse(out act)) return true;
 
-            // Needing Lunar Nadi and has 3 of the same beasts
-            if (ElixirBurstPvE.CanUse(out act)) return true;
-            if (ElixirFieldPvE.CanUse(out act)) return true;
+                    // Needing Lunar Nadi and has 3 of the same beasts
+                    if (ElixirBurstPvE.CanUse(out act)) return true;
+                    if (ElixirFieldPvE.CanUse(out act)) return true;
 
-            // No Nadi and 3 beasts
-            if (CelestialRevolutionPvE.CanUse(out act)) return true;
+                    // No Nadi and 3 beasts
+                    if (CelestialRevolutionPvE.CanUse(out act)) return true;
+                    break;
+
+                case MasterfulBlitzUse.RiddleOfFireUse:
+                    if (Player.HasStatus(true, StatusID.RiddleOfFire) || RiddleOfFirePvE.Cooldown.JustUsedAfter(42))
+                    {
+                        // Both Nadi and 3 beasts
+                        if (PhantomRushPvE.CanUse(out act)) return true;
+                        if (TornadoKickPvE.CanUse(out act)) return true;
+
+                        // Needing Solar Nadi and has 3 different beasts
+                        if (RisingPhoenixPvE.CanUse(out act)) return true;
+                        if (FlintStrikePvE.CanUse(out act)) return true;
+
+                        // Needing Lunar Nadi and has 3 of the same beasts
+                        if (ElixirBurstPvE.CanUse(out act)) return true;
+                        if (ElixirFieldPvE.CanUse(out act)) return true;
+
+                        // No Nadi and 3 beasts
+                        if (CelestialRevolutionPvE.CanUse(out act)) return true;
+                    }
+                    break;
+            }
         }
 
         // 'Because Fire¡¯s Reply grants formless, we have an imposed restriction that we prefer not to use it while under PB, or if we have a formless already.' + 'Cast Fire's Reply after an opo gcd'

--- a/RotationSolver.Basic/Actions/ActionTargetInfo.cs
+++ b/RotationSolver.Basic/Actions/ActionTargetInfo.cs
@@ -189,7 +189,7 @@ public struct ActionTargetInfo(IBaseAction action)
     {
         if (!gameObject.IsTargetable) return false;
 
-        if (Service.Config.RaiseType == RaiseType.PartyOnly && gameObject.IsAlliance() && !gameObject.IsParty())
+        if (Service.Config.RaiseType == RaiseType.PartyOnly && !gameObject.IsParty())
         {
             return false;
         }

--- a/RotationSolver.Basic/Actions/BaseAction.cs
+++ b/RotationSolver.Basic/Actions/BaseAction.cs
@@ -173,7 +173,7 @@ public class BaseAction : IBaseAction
         {
             return IsLastAbilityv2Usable();
         }
-        return DataCenter.InCombat && (DataCenter.NextAbilityToNextGCD <= Math.Max(ActionManagerHelper.GetCurrentAnimationLock(), DataCenter.MinAnimationLock) + Service.Config.isLastAbilityTimer);
+        return DataCenter.InCombat && (DataCenter.NextAbilityToNextGCD <= Math.Max(ActionManagerHelper.GetCurrentAnimationLock(), DataCenter.MinAnimationLock) + Service.Config.IsLastAbilityTimer);
     }
 
     private bool IsFirstAbilityUsable()
@@ -182,7 +182,7 @@ public class BaseAction : IBaseAction
         {
             return IsFirstAbilityv2Usable();
         }
-        return DataCenter.InCombat && (DataCenter.NextAbilityToNextGCD >= Math.Max(ActionManagerHelper.GetCurrentAnimationLock(), DataCenter.MinAnimationLock) + Service.Config.isFirstAbilityTimer);
+        return DataCenter.InCombat && (DataCenter.NextAbilityToNextGCD >= Math.Max(ActionManagerHelper.GetCurrentAnimationLock(), DataCenter.MinAnimationLock) + Service.Config.IsFirstAbilityTimer);
     }
 
     private bool IsLastAbilityv2Usable()

--- a/RotationSolver.Basic/Configuration/Configs.cs
+++ b/RotationSolver.Basic/Configuration/Configs.cs
@@ -382,12 +382,12 @@ internal partial class Configs : IPluginConfiguration
     [UI("isLastAbilityTimer", Description = "Don't fuck with this if you dont know what it does",
         Filter = Extra)]
     [Range(0.100f, 2.500f, ConfigUnitType.Seconds, 0.001f)]
-    public float isLastAbilityTimer { get; set; } = 0.800f;
+    public float IsLastAbilityTimer { get; set; } = 0.800f;
 
     [UI("isFirstAbilityTimer", Description = "Don't fuck with this if you dont know what it does",
         Filter = Extra)]
     [Range(0.100f, 2.500f, ConfigUnitType.Seconds, 0.001f)]
-    public float isFirstAbilityTimer { get; set; } = 0.600f;
+    public float IsFirstAbilityTimer { get; set; } = 0.600f;
 
     [UI("Auto turn off RSR when combat is over more for more then...",
         Parent = nameof(AutoOffAfterCombat))]
@@ -478,7 +478,7 @@ internal partial class Configs : IPluginConfiguration
         Filter = HealingActionCondition, Section = 3)]
     private static readonly bool _chocoboPartyMember = false;
 
-    [ConditionBool, UI("Treat focus targetted player as party member", Description = "Experimental.",
+    [ConditionBool, UI("Treat focus targeted player as party member in alliance raids", Description = "Experimental, includes Chaotic.",
         Filter = HealingActionCondition, Section = 3)]
     private static readonly bool _focusTargetIsParty = false;
 

--- a/RotationSolver.Basic/Configuration/Configs.cs
+++ b/RotationSolver.Basic/Configuration/Configs.cs
@@ -478,6 +478,10 @@ internal partial class Configs : IPluginConfiguration
         Filter = HealingActionCondition, Section = 3)]
     private static readonly bool _chocoboPartyMember = false;
 
+    [ConditionBool, UI("Treat focus targetted player as party member", Description = "Experimental.",
+        Filter = HealingActionCondition, Section = 3)]
+    private static readonly bool _focusTargetIsParty = false;
+
     [ConditionBool, UI("Heal party members with GCD if there is nothing to do in combat.",
         Filter = HealingActionCondition, Section = 3)]
     private static readonly bool _healWhenNothingTodo = true;

--- a/RotationSolver.Basic/DataCenter.cs
+++ b/RotationSolver.Basic/DataCenter.cs
@@ -271,8 +271,8 @@ internal static class DataCenter
     public static bool LastAbilityv2 => DataCenter.InCombat && !ActionHelper.CanUseGCD && (ActionManagerHelper.GetCurrentAnimationLock() == 0) && !Player.Object.IsCasting && (DataCenter.DefaultGCDElapsed >= DataCenter.DefaultGCDRemain);
     public static bool FirstAbilityv2 => DataCenter.InCombat && !ActionHelper.CanUseGCD && (ActionManagerHelper.GetCurrentAnimationLock() == 0) && !Player.Object.IsCasting && (DataCenter.DefaultGCDRemain >= DataCenter.DefaultGCDElapsed);
 
-    public static bool LastAbilityorNot => DataCenter.InCombat && (DataCenter.NextAbilityToNextGCD <= Math.Max(ActionManagerHelper.GetCurrentAnimationLock(), DataCenter.MinAnimationLock) + Service.Config.isLastAbilityTimer);
-    public static bool FirstAbilityorNot => DataCenter.InCombat && (DataCenter.NextAbilityToNextGCD >= Math.Max(ActionManagerHelper.GetCurrentAnimationLock(), DataCenter.MinAnimationLock) + Service.Config.isFirstAbilityTimer);
+    public static bool LastAbilityorNot => DataCenter.InCombat && (DataCenter.NextAbilityToNextGCD <= Math.Max(ActionManagerHelper.GetCurrentAnimationLock(), DataCenter.MinAnimationLock) + Service.Config.IsLastAbilityTimer);
+    public static bool FirstAbilityorNot => DataCenter.InCombat && (DataCenter.NextAbilityToNextGCD >= Math.Max(ActionManagerHelper.GetCurrentAnimationLock(), DataCenter.MinAnimationLock) + Service.Config.IsFirstAbilityTimer);
     #endregion
 
     public static uint[] BluSlots { get; internal set; } = new uint[24];

--- a/RotationSolver.Basic/DataCenter.cs
+++ b/RotationSolver.Basic/DataCenter.cs
@@ -104,6 +104,18 @@ internal static class DataCenter
     public static TerritoryInfo? Territory { get; set; }
 
     public static bool IsPvP => Territory?.IsPvP ?? false;
+    public static bool IsInDuty => Svc.Condition[ConditionFlag.BoundByDuty] || Svc.Condition[ConditionFlag.BoundByDuty56];
+    public static bool IsInAllianceRaid
+    {
+        get
+        {
+            var allianceTerritoryIds = new HashSet<ushort>
+        {
+            151, 174, 372, 508, 556, 627, 734, 776, 826, 882, 917, 966, 1054, 1118, 1178, 1248, 1241
+        };
+            return allianceTerritoryIds.Contains(TerritoryID);
+        }
+    }
 
     public static ushort TerritoryID => Svc.ClientState.TerritoryType;
     public static bool IsInUCoB => TerritoryID == 733;
@@ -112,6 +124,8 @@ internal static class DataCenter
     public static bool IsInDSR => TerritoryID == 968;
     public static bool IsInTOP => TerritoryID == 1122;
     public static bool IsInFRU => TerritoryID == 1238;
+    public static bool IsInCOD => TerritoryID == 1241;
+
 
     public static AutoStatus MergedStatus => AutoStatus | CommandStatus;
 
@@ -322,13 +336,13 @@ internal static class DataCenter
         }
     }
 
-    public static List<IBattleChara> PartyMembers { get; set; } = new();
+    public static List<IBattleChara> PartyMembers { get; set; } = [];
 
-    public static List<IBattleChara> AllianceMembers { get; set; } = new();
+    public static List<IBattleChara> AllianceMembers { get; set; } = [];
 
-    public static List<IBattleChara> FriendlyNPCMembers { get; set; } = new();
+    public static List<IBattleChara> FriendlyNPCMembers { get; set; } = [];
 
-    public static List<IBattleChara> AllHostileTargets { get; set; } = new();
+    public static List<IBattleChara> AllHostileTargets { get; set; } = [];
 
     public static IBattleChara? InterruptTarget { get; set; }
 
@@ -338,7 +352,7 @@ internal static class DataCenter
 
     public static IBattleChara? DispelTarget { get; set; }
 
-    public static List<IBattleChara> AllTargets { get; set; } = new();
+    public static List<IBattleChara> AllTargets { get; set; } = [];
 
     public static ulong[] TreasureCharas
     {

--- a/RotationSolver.Basic/Helpers/ObjectHelper.cs
+++ b/RotationSolver.Basic/Helpers/ObjectHelper.cs
@@ -83,7 +83,7 @@ public static class ObjectHelper
 
     internal static bool IsAttackable(this IBattleChara battleChara)
     {
-        if (battleChara.IsAlliance() == true) return false;
+        if (battleChara.IsAllianceMember() == true) return false;
 
         // Dead.
         if (Service.Config.FilterOneHpInvincible && battleChara.CurrentHp <= 1) return false;
@@ -245,7 +245,7 @@ public static class ObjectHelper
     => obj != null
     && ActionManager.CanUseActionOnTarget((uint)ActionID.BlizzardPvE, obj.Struct());
 
-    internal static unsafe bool IsAlliance(this IGameObject obj)
+    internal static unsafe bool IsAllianceMember(this IGameObject obj)
         => obj.GameObjectId is not 0
         && (!DataCenter.IsPvP && DataCenter.IsInAllianceRaid && obj is IPlayerCharacter
         || DataCenter.IsInAllianceRaid && ActionManager.CanUseActionOnTarget((uint)ActionID.CurePvE, obj.Struct()));
@@ -268,7 +268,7 @@ public static class ObjectHelper
             if (Service.Config.FriendlyPartyNpcHealRaise2 && gameObject.GetBattleNPCSubKind() == BattleNpcSubKind.NpcPartyMember) return true;
             if (Service.Config.ChocoboPartyMember && gameObject.GetNameplateKind() == NameplateKind.PlayerCharacterChocobo) return true;
             if (Service.Config.FriendlyBattleNpcHeal && gameObject.GetNameplateKind() == NameplateKind.FriendlyBattleNPC) return true;
-            if (Service.Config.FocusTargetIsParty && gameObject.IsFocusTarget() == true && gameObject.IsAlliance() == true) return true;
+            if (Service.Config.FocusTargetIsParty && gameObject.IsFocusTarget() == true && gameObject.IsAllianceMember() == true) return true;
         }
         return false;
     }
@@ -342,7 +342,7 @@ public static class ObjectHelper
     /// </returns>
     internal static bool IsTopPriorityHostile(this IGameObject obj)
     {
-        if (obj.IsAlliance() || obj.IsParty() || obj == null) return false;
+        if (obj.IsAllianceMember() || obj.IsParty() || obj == null) return false;
 
         var fateId = DataCenter.FateId;
 

--- a/RotationSolver.Basic/Rotations/Basic/SageRotation.cs
+++ b/RotationSolver.Basic/Rotations/Basic/SageRotation.cs
@@ -198,16 +198,6 @@ partial class SageRotation
 
     static partial void ModifyPepsisPvE(ref ActionSetting setting)
     {
-        setting.ActionCheck = () =>
-        {
-            foreach (var chara in DataCenter.PartyMembers)
-            {
-                if (chara.HasStatus(true, StatusID.EukrasianDiagnosis, StatusID.EukrasianPrognosis)
-                && chara.GetHealthRatio() < 0.9) return true;
-            }
-
-            return false;
-        };
         setting.CreateConfig = () => new ActionConfig()
         {
             AoeCount = 1,

--- a/RotationSolver.Basic/Rotations/CustomRotation_OtherInfo.cs
+++ b/RotationSolver.Basic/Rotations/CustomRotation_OtherInfo.cs
@@ -84,7 +84,7 @@ partial class CustomRotation
     /// Whether the number of party members is 8.
     /// </summary>
     [Description("Is Full Party")]
-    public static bool IsFullParty => PartyMembers.Count() is 8;
+    public static bool IsFullParty => PartyMembers.Count() is 8 or 9;
 
     /// <summary>
     /// party members HP.

--- a/RotationSolver.Basic/Rotations/CustomRotation_OtherInfo.cs
+++ b/RotationSolver.Basic/Rotations/CustomRotation_OtherInfo.cs
@@ -292,6 +292,12 @@ partial class CustomRotation
     public static bool IsInHighEndDuty => DataCenter.Territory?.IsHighEndDuty ?? false;
 
     /// <summary>
+    /// Is player in a normal or chaotic Alliance Raid.
+    /// </summary>
+    [Description("Is in an Alliance Raid (including Chaotic)")]
+    public static bool IsInAllianceRaid => DataCenter.IsInAllianceRaid;
+
+    /// <summary>
     /// Is player in UCoB duty.
     /// </summary>
     [Description("Is in UCoB duty")]
@@ -327,11 +333,17 @@ partial class CustomRotation
     [Description("Is in FRU duty")]
     public static bool IsInFRU => DataCenter.IsInFRU;
 
+    ///<summary>
+    /// Is player in COD duty.
+    ///</summary>
+    [Description("Is in FRU duty")]
+    public static bool IsInCOD => DataCenter.IsInCOD;
+
     /// <summary>
-    /// Is player in duty.
+    /// Is player in any instanced duty.
     /// </summary>
     [Description("Is player in duty")]
-    public static bool IsInDuty => Svc.Condition[ConditionFlag.BoundByDuty];
+    public static bool IsInDuty => DataCenter.IsInDuty;
 
     /// <summary>
     /// Your ping.

--- a/RotationSolver/UI/RotationConfigWindow.cs
+++ b/RotationSolver/UI/RotationConfigWindow.cs
@@ -2709,6 +2709,7 @@ public partial class RotationConfigWindow : Window
 
     private static unsafe void DrawStatus()
     {
+        ImGui.Text($"Merged Status: {DataCenter.MergedStatus}");
         if ((IntPtr)FateManager.Instance() != IntPtr.Zero)
         {
             ImGui.Text($"Fate: {DataCenter.FateId}");
@@ -2729,7 +2730,6 @@ public partial class RotationConfigWindow : Window
         ImGui.Text($"Stop Moving: {DataCenter.StopMovingRaw}");
         ImGui.Text($"CountDownTime: {Service.CountDownTime}");
         ImGui.Text($"Combo Time: {DataCenter.ComboTime}");
-        ImGui.Text($"Merged Status: {DataCenter.MergedStatus}");
         ImGui.Text($"TargetingType: {DataCenter.TargetingType}");
         ImGui.Text($"DeathTarget: {DataCenter.DeathTarget}");
         foreach (var item in DataCenter.AttackedTargets)
@@ -2839,8 +2839,8 @@ public partial class RotationConfigWindow : Window
     private static unsafe void DrawParty()
     {
         ImGui.Text($"Your combat state: {DataCenter.InCombat}");
-
         ImGui.Text($"Number of Party Members: {DataCenter.PartyMembers.Count}");
+        ImGui.Text($"Is in Alliance Raid: {DataCenter.IsInAllianceRaid}");
         ImGui.Text($"Number of Alliance Members: {DataCenter.AllianceMembers.Count}");
         ImGui.Text($"Average Party HP Percent: {DataCenter.PartyMembersAverHP * 100}");
         foreach (var p in Svc.Party)
@@ -2872,6 +2872,7 @@ public partial class RotationConfigWindow : Window
         if (target is IBattleChara battleChara)
         {
             ImGui.Text($"HP: {battleChara.CurrentHp} / {battleChara.MaxHp}");
+            ImGui.Text($"Is Current Focus Target: {battleChara.IsFocusTarget()}");
             ImGui.Text($"TTK: {battleChara.GetTimeToKill()}");
             ImGui.Text($"Is Boss TTK: {battleChara.IsBossFromTTK()}");
             ImGui.Text($"Is Boss Icon: {battleChara.IsBossFromIcon()}");

--- a/RotationSolver/UI/RotationConfigWindow.cs
+++ b/RotationSolver/UI/RotationConfigWindow.cs
@@ -2882,7 +2882,7 @@ public partial class RotationConfigWindow : Window
             ImGui.Text($"Is Alive: {battleChara.IsAlive()}");
             ImGui.Text($"Is Party: {battleChara.IsParty()}");
             ImGui.Text($"Is Healer: {battleChara.IsJobCategory(JobRole.Healer)}");
-            ImGui.Text($"Is Alliance: {battleChara.IsAlliance()}");
+            ImGui.Text($"Is Alliance: {battleChara.IsAllianceMember()}");
             ImGui.Text($"Is Enemy: {battleChara.IsEnemy()}");
             ImGui.Text($"Distance To Player: {battleChara.DistanceToPlayer()}");
             ImGui.Text($"Is In EnemiesList: {battleChara.IsInEnemiesList()}");

--- a/RotationSolver/Updaters/TargetUpdater.cs
+++ b/RotationSolver/Updaters/TargetUpdater.cs
@@ -76,7 +76,7 @@ internal static partial class TargetUpdater
             {
                 foreach (var target in DataCenter.AllTargets)
                 {
-                    if (ObjectHelper.IsAlliance(target) && target.Character() != null &&
+                    if (ObjectHelper.IsAllianceMember(target) && target.Character() != null &&
                         target.Character()->CharacterData.OnlineStatus != 15 &&
                         target.Character()->CharacterData.OnlineStatus != 5 && target.IsTargetable)
                     {


### PR DESCRIPTION
This pull request includes several changes to the `RotationSolver.Basic` project, focusing on improving the logic for handling abilities and statuses, as well as adding new configurations and conditions. The most important changes include updates to the `BasicRotations` for healers and melee classes, adjustments to configuration settings, and enhancements to the data center and helper methods.

### Updates to Basic Rotations:
* [`BasicRotations/Healer/SGE_Default.cs`](diffhunk://#diff-048922cde007c3a11c8a1edea2742248b0c16ceb8806c7c8f14c6e2fbd612898L256-R256): Modified the `ChoiceEukrasia` method to reset the Eukrasia aim if the last GCD was performed (`[BasicRotations/Healer/SGE_Default.csL256-R256](diffhunk://#diff-048922cde007c3a11c8a1edea2742248b0c16ceb8806c7c8f14c6e2fbd612898L256-R256)`).
* [`BasicRotations/Melee/MNK_Default.cs`](diffhunk://#diff-c8f54622438b0935ab3c9c0d37c4ef394d8a28f6a371bdf821005760f98f7ca3R20-R26): Added the `MasterfulBlitzUse` enum and related configuration for using abilities as soon as they are available (`[[1]](diffhunk://#diff-c8f54622438b0935ab3c9c0d37c4ef394d8a28f6a371bdf821005760f98f7ca3R20-R26)`, `[[2]](diffhunk://#diff-c8f54622438b0935ab3c9c0d37c4ef394d8a28f6a371bdf821005760f98f7ca3R42-R44)`). Enhanced the `EmergencyAbility` and `GeneralGCD` methods to handle ability usage based on the new `MasterfulBlitzUse` setting (`[[3]](diffhunk://#diff-c8f54622438b0935ab3c9c0d37c4ef394d8a28f6a371bdf821005760f98f7ca3L94-R115)`, `[[4]](diffhunk://#diff-c8f54622438b0935ab3c9c0d37c4ef394d8a28f6a371bdf821005760f98f7ca3L242-R279)`, `[[5]](diffhunk://#diff-c8f54622438b0935ab3c9c0d37c4ef394d8a28f6a371bdf821005760f98f7ca3R296-R298)`).

### Configuration Adjustments:
* [`RotationSolver.Basic/Configuration/Configs.cs`](diffhunk://#diff-8146c07f057c08a985ecf11930f19a1ce5444efc69fcc45f0edd4e6c341dbe16L385-R390): Renamed configuration fields `isLastAbilityTimer` and `isFirstAbilityTimer` to `IsLastAbilityTimer` and `IsFirstAbilityTimer` respectively (`[[1]](diffhunk://#diff-8146c07f057c08a985ecf11930f19a1ce5444efc69fcc45f0edd4e6c341dbe16L385-R390)`, `[[2]](diffhunk://#diff-8146c07f057c08a985ecf11930f19a1ce5444efc69fcc45f0edd4e6c341dbe16R481-R484)`).

### Enhancements to Data Center:
* [`RotationSolver.Basic/DataCenter.cs`](diffhunk://#diff-2c3e758beb8d040501567ca05ffcedd46534840df24596c1119e971896e8eb42R107-R118): Added properties to check if the player is in an alliance raid and other specific duties (`[[1]](diffhunk://#diff-2c3e758beb8d040501567ca05ffcedd46534840df24596c1119e971896e8eb42R107-R118)`, `[[2]](diffhunk://#diff-2c3e758beb8d040501567ca05ffcedd46534840df24596c1119e971896e8eb42R127-R128)`). Updated lists for party members, alliance members, and other targets to use empty arrays instead of new instances (`[[3]](diffhunk://#diff-2c3e758beb8d040501567ca05ffcedd46534840df24596c1119e971896e8eb42L325-R345)`, `[[4]](diffhunk://#diff-2c3e758beb8d040501567ca05ffcedd46534840df24596c1119e971896e8eb42L341-R355)`).

### Helper Method Improvements:
* [`RotationSolver.Basic/Helpers/ObjectHelper.cs`](diffhunk://#diff-44cc6e98dcd8c3d2aa47210ec76d800058560df9bbff9ce225b3116c47ddc1fcL85-R86): Renamed `IsAlliance` method to `IsAllianceMember` and added a check for focus targets being treated as party members (`[[1]](diffhunk://#diff-44cc6e98dcd8c3d2aa47210ec76d800058560df9bbff9ce225b3116c47ddc1fcL85-R86)`, `[[2]](diffhunk://#diff-44cc6e98dcd8c3d2aa47210ec76d800058560df9bbff9ce225b3116c47ddc1fcL247-R251)`, `[[3]](diffhunk://#diff-44cc6e98dcd8c3d2aa47210ec76d800058560df9bbff9ce225b3116c47ddc1fcR271-R281)`, `[[4]](diffhunk://#diff-44cc6e98dcd8c3d2aa47210ec76d800058560df9bbff9ce225b3116c47ddc1fcL304-R312)`, `[[5]](diffhunk://#diff-44cc6e98dcd8c3d2aa47210ec76d800058560df9bbff9ce225b3116c47ddc1fcL337-R345)`).

### Other Notable Changes:
* [`RotationSolver.Basic/Rotations/CustomRotation_OtherInfo.cs`](diffhunk://#diff-dcfd2506d1ce54221fa2d12787392346547585e896b48e48de6d5fa8be631af4L87-R87): Adjusted logic to determine if the party is full and added a description for checking if the player is in an alliance raid (`[[1]](diffhunk://#diff-dcfd2506d1ce54221fa2d12787392346547585e896b48e48de6d5fa8be631af4L87-R87)`, `[[2]](diffhunk://#diff-dcfd2506d1ce54221fa2d12787392346547585e896b48e48de6d5fa8be631af4R294-R299)`).