### PR TITLE
Add new configs, refactor, and enhance documentation

### DIFF
--- a/RotationSolver.Basic/Configuration/Configs.cs
+++ b/RotationSolver.Basic/Configuration/Configs.cs
@@ -132,6 +132,18 @@ internal partial class Configs : IPluginConfiguration
         Filter = TargetConfig)]
     private static readonly bool _filterOneHPInvincible = true;
 
+    [ConditionBool, UI("Ignore immune Ark Angels in Jenuo: The First Walk.",
+        Filter = TargetConfig)]
+    private static readonly bool _jeunoTarget = true;
+
+    [ConditionBool, UI("Ignore immune targets in Cloud of Darkenss Chaotic.",
+        Filter = TargetConfig)]
+    private static readonly bool _cODTarget = true;
+
+    [ConditionBool, UI("Ignore Strong of Shield target (Hansel and Gretel) in The Tower at Paradigm's Breach if you will hit shield.",
+        Filter = TargetConfig)]
+    private static readonly bool _strongOfSheildTarget = true;
+
     [ConditionBool, UI("Teaching mode", Filter = UiInformation)]
     private static readonly bool _teachingMode = false;
 

--- a/RotationSolver.Basic/Helpers/ObjectHelper.cs
+++ b/RotationSolver.Basic/Helpers/ObjectHelper.cs
@@ -88,7 +88,9 @@ public static class ObjectHelper
         if (Service.Config.FilterOneHpInvincible && battleChara.CurrentHp <= 1) return false;
 
         // Check if the target is invincible.
-        if (battleChara.IsJeunoBossImmune()) return false;
+        if (Service.Config.CodTarget && battleChara.IsCODBossImmune()) return false;
+        if (Service.Config.JeunoTarget && battleChara.IsJeunoBossImmune()) return false;
+        if (Service.Config.StrongOfSheildTarget && battleChara.IsHanselorGretelSheilded()) return false;
 
         // Ensure StatusList is not null before accessing it
         if (battleChara.StatusList == null) return false;
@@ -437,6 +439,12 @@ public static class ObjectHelper
         {
             if (o is not IBattleChara b) return false;
 
+            // Ensure the IBattleChara object is valid before accessing its properties
+            unsafe
+            {
+                if (b.Struct() == null) return false;
+            }
+
             var baseCheck = b.IsCasting && b.IsCastInterruptible && b.TotalCastTime >= 2;
             if (!baseCheck) return false;
             if (!Service.Config.InterruptibleMoreCheck) return false;
@@ -496,6 +504,74 @@ public static class ObjectHelper
                 if (Service.Config.InDebug)
                 {
                     Svc.Log.Information("IsJeunoBossImmune: FatedVillain status found");
+                }
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Is target COD Boss immune.
+    /// </summary>
+    /// <param name="obj">the object.</param>
+    /// <returns></returns>
+    public static bool IsCODBossImmune(this IBattleChara obj)
+    {
+        var player = Player.Object;
+
+        var StygianStatus = StatusID.UnnamedStatus_4388;
+        var CloudOfDarknessStatus = StatusID.VeilOfDarkness;
+        var AntiCloudOfDarknessStatus = StatusID.Rsv41771100S74Cfc3B0E74Cfc3B0;
+        var AntiStygianStatus = StatusID.Rsv41771100S74Cfc3B0E74Cfc3B0;
+
+        if (obj.IsEnemy())
+        {
+            if (obj.HasStatus(false, CloudOfDarknessStatus) &&
+                player.HasStatus(false, AntiCloudOfDarknessStatus))
+            {
+                if (Service.Config.InDebug)
+                {
+                    Svc.Log.Information("IsCODBossImmune: VeilOfDarkness status found, CloudOfDarkness immune");
+                }
+                return true;
+            }
+
+            if (obj.HasStatus(false, StygianStatus) &&
+                player.HasStatus(false, AntiStygianStatus))
+            {
+                if (Service.Config.InDebug)
+                {
+                    Svc.Log.Information("IsCODBossImmune: UnnamedStatus4388 status found, Stygian immune");
+                }
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Is target Jeuno Boss immune.
+    /// </summary>
+    /// <param name="obj">the object.</param>
+    /// <returns></returns>
+    public static bool IsHanselorGretelSheilded(this IBattleChara obj)
+    {
+        var player = Player.Object;
+
+        var strongOfShieldPositional = EnemyPositional.Front;
+        var strongOfShieldStatus = StatusID.StrongOfShield;
+
+        if (obj.IsEnemy())
+        {
+            if (obj.HasStatus(false, strongOfShieldStatus) &&
+                strongOfShieldPositional != obj.FindEnemyPositional())
+            {
+                if (Service.Config.InDebug)
+                {
+                    Svc.Log.Information("IsHanselorGretelSheilded: StrongOfShield status found, ignoring status haver if player is out of position");
                 }
                 return true;
             }

--- a/RotationSolver.GameData/Getters/Actions/ActionCategoryGetter.cs
+++ b/RotationSolver.GameData/Getters/Actions/ActionCategoryGetter.cs
@@ -1,17 +1,29 @@
 ﻿using Lumina.Excel.GeneratedSheets;
 
 namespace RotationSolver.GameData.Getters.Actions;
+
+/// <summary>
+/// Class for getting ActionCategory rows from the game data.
+/// </summary>
 internal class ActionCategoryGetter(Lumina.GameData gameData)
     : ExcelRowGetter<ActionCategory>(gameData)
 {
-    private readonly List<string> _addedNames = [];
+    private readonly HashSet<string> _addedNames = new();
 
+    /// <summary>
+    /// Called before creating the list of items. Clears the list of added names.
+    /// </summary>
     protected override void BeforeCreating()
     {
         _addedNames.Clear();
         base.BeforeCreating();
     }
 
+    /// <summary>
+    /// Determines whether the specified ActionCategory item should be added to the list.
+    /// </summary>
+    /// <param name="item">The ActionCategory item to check.</param>
+    /// <returns>True if the item should be added; otherwise, false.</returns>
     protected override bool AddToList(ActionCategory item)
     {
         var name = item.Name.RawString;
@@ -20,6 +32,11 @@ internal class ActionCategoryGetter(Lumina.GameData gameData)
         return true;
     }
 
+    /// <summary>
+    /// Converts the specified ActionCategory item to its code representation.
+    /// </summary>
+    /// <param name="item">The ActionCategory item to convert.</param>
+    /// <returns>The code representation of the item.</returns>
     protected override string ToCode(ActionCategory item)
     {
         var name = item.Name.RawString.ToPascalCase();

--- a/RotationSolver.GameData/Getters/Actions/ActionGetterBase.cs
+++ b/RotationSolver.GameData/Getters/Actions/ActionGetterBase.cs
@@ -3,48 +3,60 @@ using Action = Lumina.Excel.GeneratedSheets.Action;
 
 namespace RotationSolver.GameData.Getters.Actions;
 
-internal abstract class ActionGetterBase(Lumina.GameData gameData)
-    : ExcelRowGetter<Action>(gameData)
+/// <summary>
+/// Abstract base class for getting action rows from the Excel sheet.
+/// </summary>
+internal abstract class ActionGetterBase : ExcelRowGetter<Action>
 {
-    public List<string> AddedNames { get; } = [];
-    private string[] _notCombatJobs = [];
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ActionGetterBase"/> class.
+    /// </summary>
+    /// <param name="gameData">The game data.</param>
+    protected ActionGetterBase(Lumina.GameData gameData) : base(gameData) { }
+
+    /// <summary>
+    /// Gets the list of added names.
+    /// </summary>
+    public List<string> AddedNames { get; } = new();
+
+    private string[] _notCombatJobs = Array.Empty<string>();
+
+    /// <summary>
+    /// Called before creating the list of items.
+    /// </summary>
     protected override void BeforeCreating()
     {
         AddedNames.Clear();
-        _notCombatJobs = [.. _gameData.GetExcelSheet<ClassJob>()!.Where(c =>
-        {
-            return c.ClassJobCategory.Row is 32 or 33;
-        }).Select(c => c.Abbreviation.RawString)];
+        _notCombatJobs = _gameData.GetExcelSheet<ClassJob>()!
+            .Where(c => c.ClassJobCategory.Row is 32 or 33)
+            .Select(c => c.Abbreviation.RawString)
+            .ToArray();
         base.BeforeCreating();
     }
 
+    /// <summary>
+    /// Determines whether the specified action should be added to the list.
+    /// </summary>
+    /// <param name="item">The action to check.</param>
+    /// <returns>True if the action should be added; otherwise, false.</returns>
     protected override bool AddToList(Action item)
     {
-        if (item.RowId is 3 or 120) return true; //Sprint and cure.
+        if (item.RowId is 3 or 120) return true; // Sprint and cure.
         if (item.ClassJobCategory.Row == 0) return false;
+
         var name = item.Name.RawString;
         if (string.IsNullOrEmpty(name)) return false;
         if (!name.All(char.IsAscii)) return false;
         if (item.Icon is 0 or 405) return false;
 
-        if (item.ActionCategory.Row
-            is 6 or 7 // No DoL or DoH Action
-            or 8 //No Event.
-            or 12 // No Mount,
-            or > 14 // No item manipulation and other thing.
-            or 9 //No LB,
-            ) return false;
+        if (item.ActionCategory.Row is 6 or 7 or 8 or 12 or > 14 or 9) return false;
 
-        //No crafting or gathering.
         var category = item.ClassJobCategory.Value;
         if (category == null) return false;
 
         if (category.RowId == 1) return true;
 
-        if (_notCombatJobs.Any(name =>
-        {
-            return (bool?)category.GetType().GetRuntimeProperty(name)?.GetValue(category) ?? false;
-        }))
+        if (_notCombatJobs.Any(jobName => (bool?)category.GetType().GetRuntimeProperty(jobName)?.GetValue(category) ?? false))
         {
             return false;
         }
@@ -52,14 +64,18 @@ internal abstract class ActionGetterBase(Lumina.GameData gameData)
         return true;
     }
 
+    /// <summary>
+    /// Gets the name of the specified action.
+    /// </summary>
+    /// <param name="item">The action.</param>
+    /// <returns>The name of the action.</returns>
     protected string GetName(Action item)
     {
-        var name = item.Name.RawString.ToPascalCase()
-            + (item.IsPvP ? "PvP" : "PvE");
+        var name = item.Name.RawString.ToPascalCase() + (item.IsPvP ? "PvP" : "PvE");
 
         if (AddedNames.Contains(name))
         {
-            name += "_" + item.RowId.ToString();
+            name += "_" + item.RowId;
         }
         else
         {
@@ -68,10 +84,14 @@ internal abstract class ActionGetterBase(Lumina.GameData gameData)
         return name;
     }
 
+    /// <summary>
+    /// Gets the description of the specified action.
+    /// </summary>
+    /// <param name="item">The action.</param>
+    /// <returns>The description of the action.</returns>
     protected string GetDesc(Action item)
     {
         var desc = _gameData.GetExcelSheet<ActionTransient>()?.GetRow(item.RowId)?.Description.RawString ?? string.Empty;
-
         return $"<para>{desc.Replace("\n", "</para>\n/// <para>")}</para>";
     }
 }

--- a/RotationSolver.GameData/Getters/Actions/ActionIdGetter.cs
+++ b/RotationSolver.GameData/Getters/Actions/ActionIdGetter.cs
@@ -2,9 +2,25 @@
 
 namespace RotationSolver.GameData.Getters.Actions;
 
-internal class ActionIdGetter(Lumina.GameData gameData)
-    : ActionGetterBase(gameData)
+/// <summary>
+/// Class for getting action IDs from the Excel sheet.
+/// </summary>
+internal class ActionIdGetter : ActionGetterBase
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ActionIdGetter"/> class.
+    /// </summary>
+    /// <param name="gameData">The game data.</param>
+    public ActionIdGetter(Lumina.GameData gameData)
+        : base(gameData)
+    {
+    }
+
+    /// <summary>
+    /// Converts the specified action to its code representation.
+    /// </summary>
+    /// <param name="item">The action to convert.</param>
+    /// <returns>The code representation of the action.</returns>
     protected override string ToCode(Action item)
     {
         var name = GetName(item);

--- a/RotationSolver.GameData/Getters/Actions/ActionRotationGetterBase.cs
+++ b/RotationSolver.GameData/Getters/Actions/ActionRotationGetterBase.cs
@@ -1,7 +1,24 @@
 ﻿namespace RotationSolver.GameData.Getters.Actions;
-internal abstract class ActionRotationGetterBase(Lumina.GameData gameData)
-    : ActionGetterBase(gameData)
+
+/// <summary>
+/// Abstract base class for getting action rotation rows from the Excel sheet.
+/// </summary>
+internal abstract class ActionRotationGetterBase : ActionGetterBase
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ActionRotationGetterBase"/> class.
+    /// </summary>
+    /// <param name="gameData">The game data.</param>
+    protected ActionRotationGetterBase(Lumina.GameData gameData)
+        : base(gameData)
+    {
+    }
+
+    /// <summary>
+    /// Converts the specified action item to its code representation.
+    /// </summary>
+    /// <param name="item">The action item to convert.</param>
+    /// <returns>The code representation of the action item.</returns>
     protected override string ToCode(Lumina.Excel.GeneratedSheets.Action item)
     {
         var name = GetName(item);
@@ -10,5 +27,8 @@ internal abstract class ActionRotationGetterBase(Lumina.GameData gameData)
         return item.ToCode(name, descName, GetDesc(item), IsDutyAction);
     }
 
+    /// <summary>
+    /// Gets a value indicating whether the action is a duty action.
+    /// </summary>
     public abstract bool IsDutyAction { get; }
 }

--- a/RotationSolver.GameData/Getters/Actions/ActionRotationGetters.cs
+++ b/RotationSolver.GameData/Getters/Actions/ActionRotationGetters.cs
@@ -2,28 +2,45 @@
 
 namespace RotationSolver.GameData.Getters.Actions;
 
+/// <summary>
+/// Gets the single rotation actions for a specific job.
+/// </summary>
 internal class ActionSingleRotationGetter(Lumina.GameData gameData, ClassJob job)
     : ActionRotationGetterBase(gameData)
 {
+    /// <summary>
+    /// Gets a value indicating whether the action is a duty action.
+    /// </summary>
     public override bool IsDutyAction => false;
 
+    /// <summary>
+    /// Adds the specified action to the list if it meets the criteria.
+    /// </summary>
+    /// <param name="item">The action item to check.</param>
+    /// <returns>True if the action is added; otherwise, false.</returns>
     protected override bool AddToList(Lumina.Excel.GeneratedSheets.Action item)
     {
         if (!base.AddToList(item)) return false;
 
         var category = item.ClassJobCategory.Value;
-        if (category == null) return false;
-
-        if (!category.IsSingleJobForCombat()) return false;
+        if (category == null || !category.IsSingleJobForCombat()) return false;
 
         var jobName = job.Abbreviation.RawString;
         return (bool?)category.GetType().GetRuntimeProperty(jobName)?.GetValue(category) ?? false;
     }
 }
 
+/// <summary>
+/// Abstract base class for getting multi-rotation actions.
+/// </summary>
 internal abstract class ActionMultiRotationGetter(Lumina.GameData gameData)
     : ActionRotationGetterBase(gameData)
 {
+    /// <summary>
+    /// Determines whether the specified action is a duty action.
+    /// </summary>
+    /// <param name="action">The action to check.</param>
+    /// <returns>True if the action is a duty action; otherwise, false.</returns>
     protected static bool IsADutyAction(Lumina.Excel.GeneratedSheets.Action action)
     {
         return !action.IsRoleAction && !action.IsPvP && action.ActionCategory.Row
@@ -31,24 +48,38 @@ internal abstract class ActionMultiRotationGetter(Lumina.GameData gameData)
             and not 9 and not 15; // Not LB.
     }
 
+    /// <summary>
+    /// Adds the specified action to the list if it meets the criteria.
+    /// </summary>
+    /// <param name="item">The action item to check.</param>
+    /// <returns>True if the action is added; otherwise, false.</returns>
     protected override bool AddToList(Lumina.Excel.GeneratedSheets.Action item)
     {
         if (!base.AddToList(item)) return false;
 
         var category = item.ClassJobCategory.Value;
-        if (category == null) return false;
-
-        if (category.IsSingleJobForCombat()) return false;
+        if (category == null || category.IsSingleJobForCombat()) return false;
 
         return true;
     }
 }
 
+/// <summary>
+/// Gets the duty rotation actions.
+/// </summary>
 internal class ActionDutyRotationGetter(Lumina.GameData gameData)
     : ActionMultiRotationGetter(gameData)
 {
+    /// <summary>
+    /// Gets a value indicating whether the action is a duty action.
+    /// </summary>
     public override bool IsDutyAction => true;
 
+    /// <summary>
+    /// Adds the specified action to the list if it meets the criteria.
+    /// </summary>
+    /// <param name="item">The action item to check.</param>
+    /// <returns>True if the action is added; otherwise, false.</returns>
     protected override bool AddToList(Lumina.Excel.GeneratedSheets.Action item)
     {
         if (!base.AddToList(item)) return false;
@@ -56,11 +87,22 @@ internal class ActionDutyRotationGetter(Lumina.GameData gameData)
     }
 }
 
+/// <summary>
+/// Gets the role rotation actions.
+/// </summary>
 internal class ActionRoleRotationGetter(Lumina.GameData gameData)
     : ActionMultiRotationGetter(gameData)
 {
+    /// <summary>
+    /// Gets a value indicating whether the action is a duty action.
+    /// </summary>
     public override bool IsDutyAction => false;
 
+    /// <summary>
+    /// Adds the specified action to the list if it meets the criteria.
+    /// </summary>
+    /// <param name="item">The action item to check.</param>
+    /// <returns>True if the action is added; otherwise, false.</returns>
     protected override bool AddToList(Lumina.Excel.GeneratedSheets.Action item)
     {
         if (!base.AddToList(item)) return false;

--- a/RotationSolver.GameData/Getters/ContentTypeGetter.cs
+++ b/RotationSolver.GameData/Getters/ContentTypeGetter.cs
@@ -1,17 +1,33 @@
 ﻿using Lumina.Excel.GeneratedSheets;
 
 namespace RotationSolver.GameData.Getters;
+
+/// <summary>
+/// A class to get content types from the game data.
+/// </summary>
 internal class ContentTypeGetter(Lumina.GameData gameData)
     : ExcelRowGetter<ContentType>(gameData)
 {
+    /// <summary>
+    /// Determines whether the specified item should be added to the list.
+    /// </summary>
+    /// <param name="item">The content type item.</param>
+    /// <returns><c>true</c> if the item should be added; otherwise, <c>false</c>.</returns>
     protected override bool AddToList(ContentType item)
     {
         var name = item.Name.RawString;
-        if (string.IsNullOrEmpty(name)) return false;
-        if (!name.All(char.IsAscii)) return false;
+        if (string.IsNullOrEmpty(name) || !name.All(char.IsAscii))
+        {
+            return false;
+        }
         return true;
     }
 
+    /// <summary>
+    /// Converts the specified item to code.
+    /// </summary>
+    /// <param name="item">The content type item.</param>
+    /// <returns>The generated code for the item.</returns>
     protected override string ToCode(ContentType item)
     {
         var name = item.Name.RawString.ToPascalCase();

--- a/RotationSolver.GameData/Getters/ExcelRowGetter.cs
+++ b/RotationSolver.GameData/Getters/ExcelRowGetter.cs
@@ -1,27 +1,54 @@
 ﻿using Lumina.Excel;
 
-namespace RotationSolver.GameData.Getters;
-internal abstract class ExcelRowGetter<T>(Lumina.GameData gameData) where T : ExcelRow
+namespace RotationSolver.GameData.Getters
 {
-    protected Lumina.GameData _gameData = gameData;
-    public int Count { get; private set; } = 0;
-
-    protected abstract bool AddToList(T item);
-    protected abstract string ToCode(T item);
-
-    protected virtual void BeforeCreating() { }
-
-
-    public string GetCode()
+    /// <summary>
+    /// Abstract base class for getting Excel rows.
+    /// </summary>
+    /// <typeparam name="T">Type of the Excel row.</typeparam>
+    internal abstract class ExcelRowGetter<T>(Lumina.GameData gameData) where T : ExcelRow
     {
-        var items = _gameData.GetExcelSheet<T>();
+        protected readonly Lumina.GameData _gameData = gameData ?? throw new ArgumentNullException(nameof(gameData));
 
-        if (items == null) return string.Empty;
-        BeforeCreating();
+        /// <summary>
+        /// Gets the count of filtered items.
+        /// </summary>
+        public int Count { get; private set; } = 0;
 
-        var filteredItems = items.Where(AddToList);
-        Count = filteredItems.Count();
+        /// <summary>
+        /// Determines whether the specified item should be added to the list.
+        /// </summary>
+        /// <param name="item">The item to check.</param>
+        /// <returns>True if the item should be added; otherwise, false.</returns>
+        protected abstract bool AddToList(T item);
 
-        return string.Join("\n", filteredItems.Select(ToCode));
+        /// <summary>
+        /// Converts the specified item to code.
+        /// </summary>
+        /// <param name="item">The item to convert.</param>
+        /// <returns>The code representation of the item.</returns>
+        protected abstract string ToCode(T item);
+
+        /// <summary>
+        /// Called before creating the list of items.
+        /// </summary>
+        protected virtual void BeforeCreating() { }
+
+        /// <summary>
+        /// Gets the code representation of the filtered items.
+        /// </summary>
+        /// <returns>The code representation of the filtered items.</returns>
+        public string GetCode()
+        {
+            var items = _gameData.GetExcelSheet<T>();
+
+            if (items == null) return string.Empty;
+            BeforeCreating();
+
+            var filteredItems = items.Where(AddToList);
+            Count = filteredItems.Count();
+
+            return string.Join("\n", filteredItems.Select(ToCode));
+        }
     }
 }

--- a/RotationSolver.GameData/Getters/ItemGetter.cs
+++ b/RotationSolver.GameData/Getters/ItemGetter.cs
@@ -2,17 +2,31 @@
 
 namespace RotationSolver.GameData.Getters;
 
+/// <summary>
+/// Class responsible for getting and processing items from the game data.
+/// </summary>
 internal class ItemGetter(Lumina.GameData gameData)
     : ExcelRowGetter<Item>(gameData)
 {
-    public List<string> AddedNames { get; } = [];
+    /// <summary>
+    /// Gets the list of added item names.
+    /// </summary>
+    public List<string> AddedNames { get; } = new List<string>();
 
+    /// <summary>
+    /// Clears the list of added item names before creating the list of items.
+    /// </summary>
     protected override void BeforeCreating()
     {
         AddedNames.Clear();
         base.BeforeCreating();
     }
 
+    /// <summary>
+    /// Determines whether the specified item should be added to the list.
+    /// </summary>
+    /// <param name="item">The item to check.</param>
+    /// <returns>True if the item should be added; otherwise, false.</returns>
     protected override bool AddToList(Item item)
     {
         if (item.ItemSearchCategory.Row != 43) return false;
@@ -21,12 +35,17 @@ internal class ItemGetter(Lumina.GameData gameData)
         return true;
     }
 
+    /// <summary>
+    /// Converts the specified item to its code representation.
+    /// </summary>
+    /// <param name="item">The item to convert.</param>
+    /// <returns>The code representation of the item.</returns>
     protected override string ToCode(Item item)
     {
         var name = item.Singular.RawString.ToPascalCase();
         if (AddedNames.Contains(name))
         {
-            name += "_" + item.RowId.ToString();
+            name += $"_{item.RowId}";
         }
         else
         {
@@ -34,7 +53,6 @@ internal class ItemGetter(Lumina.GameData gameData)
         }
 
         var desc = item.Description.RawString ?? string.Empty;
-
         desc = $"<para>{desc.Replace("\n", "</para>\n/// <para>")}</para>";
 
         var descName = $"<see href=\"https://garlandtools.org/db/#item/{item.RowId}\"><strong>{item.Name.RawString}</strong></see> [{item.RowId}]";

--- a/RotationSolver.GameData/Getters/RotationGetter.cs
+++ b/RotationSolver.GameData/Getters/RotationGetter.cs
@@ -3,25 +3,40 @@ using RotationSolver.GameData.Getters.Actions;
 
 namespace RotationSolver.GameData.Getters;
 
-internal class RotationGetter(Lumina.GameData gameData, ClassJob job)
+/// <summary>
+/// Provides methods to generate rotation code for a specific job.
+/// </summary>
+internal class RotationGetter
 {
-    public string GetName()
+    private readonly Lumina.GameData gameData;
+    private readonly ClassJob job;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RotationGetter"/> class.
+    /// </summary>
+    /// <param name="gameData">The game data.</param>
+    /// <param name="job">The job.</param>
+    public RotationGetter(Lumina.GameData gameData, ClassJob job)
     {
-        return (job.Name.ToString() + " Rotation").ToPascalCase();
+        this.gameData = gameData;
+        this.job = job;
     }
 
+    /// <summary>
+    /// Gets the name of the rotation.
+    /// </summary>
+    /// <returns>The name of the rotation.</returns>
+    public string GetName() => $"{job.Name} Rotation".ToPascalCase();
+
+    /// <summary>
+    /// Generates the rotation code.
+    /// </summary>
+    /// <returns>The generated rotation code.</returns>
     public string GetCode()
     {
         var jobName = job.Name.ToString();
-
-        var jobs = $"Job.{job.Abbreviation}";
-        if (job.RowId != 28 && job.RowId != job.ClassJobParent.Row)
-        {
-            jobs += $", Job.{job.ClassJobParent.Value?.Abbreviation ?? "ADV"}";
-        }
-
-        var jobGauge = job.Abbreviation == "BLU" ? string.Empty : $"static {job.Abbreviation}Gauge JobGauge => Svc.Gauges.Get<{job.Abbreviation}Gauge>();";
-
+        var jobs = GetJobs();
+        var jobGauge = GetJobGauge();
         var rotationsGetter = new ActionSingleRotationGetter(gameData, job);
         var traitsGetter = new TraitRotationGetter(gameData, job);
 
@@ -64,10 +79,35 @@ internal class RotationGetter(Lumina.GameData gameData, ClassJob job)
          """;
     }
 
+    /// <summary>
+    /// Gets the jobs associated with the current job.
+    /// </summary>
+    /// <returns>A string representing the jobs.</returns>
+    private string GetJobs()
+    {
+        var jobs = $"Job.{job.Abbreviation}";
+        if (job.RowId != 28 && job.RowId != job.ClassJobParent.Row)
+        {
+            jobs += $", Job.{job.ClassJobParent.Value?.Abbreviation ?? "ADV"}";
+        }
+        return jobs;
+    }
+
+    /// <summary>
+    /// Gets the job gauge code.
+    /// </summary>
+    /// <returns>The job gauge code.</returns>
+    private string GetJobGauge() => job.Abbreviation == "BLU" ? string.Empty : $"static {job.Abbreviation}Gauge JobGauge => Svc.Gauges.Get<{job.Abbreviation}Gauge>();";
+
+    /// <summary>
+    /// Gets the limit break code for a specific action.
+    /// </summary>
+    /// <param name="action">The action.</param>
+    /// <param name="index">The index of the limit break.</param>
+    /// <returns>The limit break code.</returns>
     private string GetLBInRotation(Lumina.Excel.GeneratedSheets.Action? action, int index)
     {
-        if (action == null) return string.Empty;
-        if (action.RowId == 0) return string.Empty;
+        if (action == null || action.RowId == 0) return string.Empty;
 
         var code = GetLBPvE(action, out var name);
 
@@ -79,17 +119,29 @@ internal class RotationGetter(Lumina.GameData gameData, ClassJob job)
             private sealed protected override IBaseAction LimitBreak{index} => {name};
             """;
     }
+
+    /// <summary>
+    /// Gets the PvE limit break code for a specific action.
+    /// </summary>
+    /// <param name="action">The action.</param>
+    /// <param name="name">The name of the limit break.</param>
+    /// <returns>The PvE limit break code.</returns>
     private string GetLBPvE(Lumina.Excel.GeneratedSheets.Action action, out string name)
     {
-        name = action.Name.RawString.ToPascalCase() + $"PvE";
+        name = $"{action.Name.RawString.ToPascalCase()}PvE";
         var descName = action.GetDescName();
 
         return action.ToCode(name, descName, GetDesc(action), false);
     }
+
+    /// <summary>
+    /// Gets the PvP limit break code for a specific action.
+    /// </summary>
+    /// <param name="action">The action.</param>
+    /// <returns>The PvP limit break code.</returns>
     private string GetLBInRotationPvP(Lumina.Excel.GeneratedSheets.Action? action)
     {
-        if (action == null) return string.Empty;
-        if (action.RowId == 0) return string.Empty;
+        if (action == null || action.RowId == 0) return string.Empty;
 
         var code = GetLBPvP(action, out var name);
 
@@ -102,18 +154,28 @@ internal class RotationGetter(Lumina.GameData gameData, ClassJob job)
             """;
     }
 
+    /// <summary>
+    /// Gets the PvP limit break code for a specific action.
+    /// </summary>
+    /// <param name="action">The action.</param>
+    /// <param name="name">The name of the limit break.</param>
+    /// <returns>The PvP limit break code.</returns>
     private string GetLBPvP(Lumina.Excel.GeneratedSheets.Action action, out string name)
     {
-        name = action.Name.RawString.ToPascalCase() + $"PvP";
+        name = $"{action.Name.RawString.ToPascalCase()}PvP";
         var descName = action.GetDescName();
 
         return action.ToCode(name, descName, GetDesc(action), false);
     }
 
+    /// <summary>
+    /// Gets the description of a specific action.
+    /// </summary>
+    /// <param name="item">The action.</param>
+    /// <returns>The description of the action.</returns>
     private string GetDesc(Lumina.Excel.GeneratedSheets.Action item)
     {
         var desc = gameData.GetExcelSheet<ActionTransient>()?.GetRow(item.RowId)?.Description.RawString ?? string.Empty;
-
         return $"<para>{desc.Replace("\n", "</para>\n/// <para>")}</para>";
     }
 }

--- a/RotationSolver.GameData/Getters/StatusGetter.cs
+++ b/RotationSolver.GameData/Getters/StatusGetter.cs
@@ -1,41 +1,68 @@
 ﻿using Lumina.Excel.GeneratedSheets;
+using System.Text;
 
 namespace RotationSolver.GameData.Getters;
+
+/// <summary>
+/// Class for getting and processing Status Excel rows.
+/// </summary>
 internal class StatusGetter(Lumina.GameData gameData)
     : ExcelRowGetter<Status>(gameData)
 {
-    private readonly List<string> _addedNames = [];
+    private readonly HashSet<string> _addedNames = new();
 
+    /// <summary>
+    /// Called before creating the list of items. Clears the added names set.
+    /// </summary>
     protected override void BeforeCreating()
     {
         _addedNames.Clear();
         base.BeforeCreating();
     }
 
+    /// <summary>
+    /// Determines whether the specified status should be added to the list.
+    /// </summary>
+    /// <param name="item">The status item to check.</param>
+    /// <returns>True if the status should be added; otherwise, false.</returns>
     protected override bool AddToList(Status item)
     {
-        if (item.ClassJobCategory.Row == 0) return false;
         var name = item.Name.RawString;
-        if (string.IsNullOrEmpty(name)) return false;
-        if (!name.All(char.IsAscii)) return false;
-        if (item.Icon == 0) return false;
-        return true;
+        if (string.IsNullOrEmpty(name))
+        {
+            // Allow statuses without a name
+            return true;
+        }
+
+        // Perform usual checks for statuses with a name
+        return item.ClassJobCategory.Row != 0 &&
+               name.All(char.IsAscii) &&
+               item.Icon != 0;
     }
 
+    /// <summary>
+    /// Converts the specified status to its code representation.
+    /// </summary>
+    /// <param name="item">The status item to convert.</param>
+    /// <returns>The code representation of the status.</returns>
     protected override string ToCode(Status item)
     {
-        var name = item.Name.RawString.ToPascalCase();
-        if (_addedNames.Contains(name))
+        var name = item.Name.RawString;
+        if (string.IsNullOrEmpty(name))
         {
-            name += "_" + item.RowId.ToString();
+            name = $"UnnamedStatus_{item.RowId}";
         }
         else
         {
-            _addedNames.Add(name);
+            name = name.ToPascalCase();
+        }
+
+        if (!_addedNames.Add(name))
+        {
+            name += "_" + item.RowId.ToString();
         }
 
         var desc = item.Description.RawString;
-
         var jobs = item.ClassJobCategory.Value?.Name.RawString;
         jobs = string.IsNullOrEmpty(jobs) ? string.Empty : $" ({jobs})";
 
@@ -46,12 +73,26 @@ internal class StatusGetter(Lumina.GameData gameData)
             _ => string.Empty,
         };
 
-        return $"""
+        var sb = new StringBuilder();
+        if (!name.StartsWith("UnnamedStatus"))
+        {
+            sb.AppendLine($"""
         /// <summary>
         /// <see href="https://garlandtools.org/db/#status/{item.RowId}"><strong>{item.Name.RawString.Replace("&", "and")}</strong></see>{cate}{jobs}
         /// <para>{desc.Replace("\n", "</para>\n/// <para>")}</para>
         /// </summary>
-        {name} = {item.RowId},
-        """;
+        """);
+        }
+        else
+        {
+            sb.AppendLine($"""
+        /// <summary>
+        /// <para>{desc.Replace("\n", "</para>\n/// <para>")}</para>
+        /// </summary>
+        """);
+        }
+        sb.AppendLine($"{name} = {item.RowId},");
+
+        return sb.ToString();
     }
 }

--- a/RotationSolver.GameData/Getters/TraitRotationGetter.cs
+++ b/RotationSolver.GameData/Getters/TraitRotationGetter.cs
@@ -1,17 +1,44 @@
 ﻿using Lumina.Excel.GeneratedSheets;
 
 namespace RotationSolver.GameData.Getters;
-internal class TraitRotationGetter(Lumina.GameData gameData, ClassJob job)
-    : ExcelRowGetter<Trait>(gameData)
-{
-    public List<string> AddedNames { get; } = [];
 
+/// <summary>
+/// Class responsible for getting trait rotations.
+/// </summary>
+internal class TraitRotationGetter : ExcelRowGetter<Trait>
+{
+    private readonly ClassJob _job;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TraitRotationGetter"/> class.
+    /// </summary>
+    /// <param name="gameData">The game data.</param>
+    /// <param name="job">The class job.</param>
+    public TraitRotationGetter(Lumina.GameData gameData, ClassJob job)
+        : base(gameData)
+    {
+        _job = job ?? throw new ArgumentNullException(nameof(job));
+    }
+
+    /// <summary>
+    /// Gets the list of added names.
+    /// </summary>
+    public List<string> AddedNames { get; } = new List<string>();
+
+    /// <summary>
+    /// Called before creating the list of items.
+    /// </summary>
     protected override void BeforeCreating()
     {
         AddedNames.Clear();
         base.BeforeCreating();
     }
 
+    /// <summary>
+    /// Determines whether the specified item should be added to the list.
+    /// </summary>
+    /// <param name="item">The item to check.</param>
+    /// <returns>True if the item should be added; otherwise, false.</returns>
     protected override bool AddToList(Trait item)
     {
         if (item.ClassJob.Row == 0) return false;
@@ -22,10 +49,15 @@ internal class TraitRotationGetter(Lumina.GameData gameData, ClassJob job)
 
         var category = item.ClassJob.Value;
         if (category == null) return false;
-        var jobName = job.Abbreviation.RawString;
+        var jobName = _job.Abbreviation.RawString;
         return category.Abbreviation == jobName;
     }
 
+    /// <summary>
+    /// Converts the specified item to code.
+    /// </summary>
+    /// <param name="item">The item to convert.</param>
+    /// <returns>The code representation of the item.</returns>
     protected override string ToCode(Trait item)
     {
         var name = item.Name.RawString.ToPascalCase() + "Trait";
@@ -48,6 +80,11 @@ internal class TraitRotationGetter(Lumina.GameData gameData, ClassJob job)
         """;
     }
 
+    /// <summary>
+    /// Gets the description name for the specified item.
+    /// </summary>
+    /// <param name="item">The item.</param>
+    /// <returns>The description name.</returns>
     private static string GetDescName(Trait item)
     {
         var jobs = item.ClassJobCategory.Value?.Name.RawString;
@@ -56,6 +93,11 @@ internal class TraitRotationGetter(Lumina.GameData gameData, ClassJob job)
         return $"<see href=\"https://garlandtools.org/db/#action/{50000 + item.RowId}\"><strong>{item.Name.RawString}</strong></see>{jobs} [{item.RowId}]";
     }
 
+    /// <summary>
+    /// Gets the description for the specified item.
+    /// </summary>
+    /// <param name="item">The item.</param>
+    /// <returns>The description.</returns>
     private string GetDesc(Trait item)
     {
         var desc = _gameData.GetExcelSheet<TraitTransient>()?.GetRow(item.RowId)?.Description.RawString ?? string.Empty;

--- a/RotationSolver.GameData/Program.cs
+++ b/RotationSolver.GameData/Program.cs
@@ -7,114 +7,133 @@ using RotationSolver.GameData.Getters;
 using RotationSolver.GameData.Getters.Actions;
 using System.Net;
 using System.Resources.NetStandard;
+using System.Xml.Linq;
 
-var gameData = new GameData(@"C:\FF14\game\sqpack", new LuminaOptions
+/// <summary>
+/// Entry point for the RotationSolver GameData program.
+/// </summary>
+public class Program
 {
-    LoadMultithreaded = true,
-    CacheFileResources = true,
-    PanicOnSheetChecksumMismatch = false,
-    DefaultExcelLanguage = Language.English,
-});
-
-var dirInfo = new DirectoryInfo(typeof(Program).Assembly.Location);
-dirInfo = dirInfo.Parent!.Parent!.Parent!.Parent!.Parent!.Parent!;
-
-using var res = new ResXResourceWriter(dirInfo.FullName + "\\RotationSolver.SourceGenerators\\Properties\\Resources.resx");
-
-res.AddResource("StatusId", new StatusGetter(gameData).GetCode());
-res.AddResource("ContentType", new ContentTypeGetter(gameData).GetCode());
-res.AddResource("ActionId", new ActionIdGetter(gameData).GetCode());
-res.AddResource("ActionCategory", new ActionCategoryGetter(gameData).GetCode());
-
-var rotationBase = new ActionRoleRotationGetter(gameData);
-var rotationCodes = rotationBase.GetCode();
-var rotationItems = new ItemGetter(gameData);
-var rotationItemCodes = rotationItems.GetCode();
-
-res.AddResource("Action", $$"""
-    using RotationSolver.Basic.Actions;
-    
-    namespace RotationSolver.Basic.Rotations;
-    
     /// <summary>
-    /// The Custom Rotation.
-    /// <br>Number of Actions: {{rotationBase.Count}}</br>
+    /// Main method to execute the program.
     /// </summary>
-    public abstract partial class CustomRotation
+    public static async Task Main()
     {
-    #region Actions
-    {{rotationCodes.Table()}}
+        try
+        {
+            var gameData = new GameData(@"C:\FF14\game\sqpack", new LuminaOptions
+            {
+                LoadMultithreaded = true,
+                CacheFileResources = true,
+                PanicOnSheetChecksumMismatch = false,
+                DefaultExcelLanguage = Language.English,
+            });
 
-    {{Util.ArrayNames("AllBaseActions", "IBaseAction",
-    "public virtual", [.. rotationBase.AddedNames]).Table()}}
-    #endregion
+            var dirInfo = new DirectoryInfo(typeof(Program).Assembly.Location);
+            dirInfo = dirInfo.Parent!.Parent!.Parent!.Parent!.Parent!.Parent!;
 
-    #region Items
-    {{rotationItemCodes.Table()}}
+            using var res = new ResXResourceWriter(Path.Combine(dirInfo.FullName, "RotationSolver.SourceGenerators\\Properties\\Resources.resx"));
 
-    {{Util.ArrayNames("AllItems", "IBaseItem",
-    "public ", [.. rotationItems.AddedNames]).Table()}}
-    #endregion
+            res.AddResource("StatusId", new StatusGetter(gameData).GetCode());
+            res.AddResource("ContentType", new ContentTypeGetter(gameData).GetCode());
+            res.AddResource("ActionId", new ActionIdGetter(gameData).GetCode());
+            res.AddResource("ActionCategory", new ActionCategoryGetter(gameData).GetCode());
+
+            var rotationBase = new ActionRoleRotationGetter(gameData);
+            var rotationCodes = rotationBase.GetCode();
+            var rotationItems = new ItemGetter(gameData);
+            var rotationItemCodes = rotationItems.GetCode();
+
+            res.AddResource("Action", $$"""
+                using RotationSolver.Basic.Actions;
+                
+                namespace RotationSolver.Basic.Rotations;
+                
+                /// <summary>
+                /// The Custom Rotation.
+                /// <br>Number of Actions: {{rotationBase.Count}}</br>
+                /// </summary>
+                public abstract partial class CustomRotation
+                {
+                #region Actions
+                {{rotationCodes.Table()}}
+
+                {{Util.ArrayNames("AllBaseActions", "IBaseAction",
+                "public virtual", [.. rotationBase.AddedNames]).Table()}}
+                #endregion
+
+                #region Items
+                {{rotationItemCodes.Table()}}
+
+                {{Util.ArrayNames("AllItems", "IBaseItem",
+                "public ", [.. rotationItems.AddedNames]).Table()}}
+                #endregion
+                }
+                """);
+
+            var dutyRotationBase = new ActionDutyRotationGetter(gameData);
+            rotationCodes = dutyRotationBase.GetCode();
+
+            res.AddResource("DutyAction", $$"""
+                using RotationSolver.Basic.Actions;
+                
+                namespace RotationSolver.Basic.Rotations.Duties;
+                
+                /// <summary>
+                /// The Custom Rotation.
+                /// <br>Number of Actions: {{dutyRotationBase.Count}}</br>
+                /// </summary>
+                public abstract partial class DutyRotation
+                {
+                {{rotationCodes.Table()}}
+                }
+                """);
+
+            var header = """
+            using ECommons.DalamudServices;
+            using ECommons.ExcelServices;
+            using RotationSolver.Basic.Actions;
+            using RotationSolver.Basic.Traits;
+
+            namespace RotationSolver.Basic.Rotations.Basic;
+
+            """;
+
+            var rotations = gameData.GetExcelSheet<ClassJob>()!
+                .Where(job => job.JobIndex > 0)
+                .Select(job => new RotationGetter(gameData, job).GetCode());
+            res.AddResource("Rotation", header + string.Join("\n\n", rotations));
+
+            using var client = new HttpClient { Timeout = TimeSpan.FromSeconds(30) };
+            var result = await client.GetAsync("https://raw.githubusercontent.com/karashiiro/FFXIVOpcodes/master/opcodes.json");
+
+            if (result.StatusCode != HttpStatusCode.OK) return;
+            var responseStream = await result.Content.ReadAsStringAsync();
+
+            var strs = JToken.Parse(responseStream)[0]!["lists"]!.Children()
+                .SelectMany(i => i.Children()).SelectMany(i => i.Children()).Cast<JObject>()
+                .Select(i =>
+                {
+                    var name = ((JValue)i["name"]!).Value as string;
+                    var description = name!.Space();
+
+                    return $$"""
+                    /// <summary>
+                    ///{{description}}
+                    /// </summary>
+                    [Description("{{description}}")]
+                    {{name}} = {{((JValue)i["opcode"]!).Value}},
+                    """;
+                });
+            res.AddResource("OpCode", string.Join("\n", strs));
+
+            res.Generate();
+
+            Console.WriteLine("Finished!");
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"An error occurred: {ex.Message}");
+        }
     }
-    """);
-
-var dutyRotationBase = new ActionDutyRotationGetter(gameData);
-rotationCodes = dutyRotationBase.GetCode();
-
-res.AddResource("DutyAction", $$"""
-    using RotationSolver.Basic.Actions;
-    
-    namespace RotationSolver.Basic.Rotations.Duties;
-    
-    /// <summary>
-    /// The Custom Rotation.
-    /// <br>Number of Actions: {{dutyRotationBase.Count}}</br>
-    /// </summary>
-    public abstract partial class DutyRotation
-    {
-    {{rotationCodes.Table()}}
-    }
-    """);
-
-var header = """
-using ECommons.DalamudServices;
-using ECommons.ExcelServices;
-using RotationSolver.Basic.Actions;
-using RotationSolver.Basic.Traits;
-
-namespace RotationSolver.Basic.Rotations.Basic;
-
-""";
-
-var rotations = gameData.GetExcelSheet<ClassJob>()!
-    .Where(job => job.JobIndex > 0)
-    .Select(job => new RotationGetter(gameData, job).GetCode());
-res.AddResource("Rotation", header + string.Join("\n\n", rotations));
-
-using var client = new HttpClient { Timeout = TimeSpan.FromSeconds(30) };
-using var result = await client.GetAsync("https://raw.githubusercontent.com/karashiiro/FFXIVOpcodes/master/opcodes.json");
-
-if (result.StatusCode != HttpStatusCode.OK) return;
-var responseStream = await result.Content.ReadAsStringAsync();
-
-
-var strs = JToken.Parse(responseStream)[0]!["lists"]!.Children()
-    .SelectMany(i => i.Children()).SelectMany(i => i.Children()).Cast<JObject>()
-    .Select(i =>
-    {
-        var name = ((JValue)i["name"]!).Value as string;
-        var description = name!.Space();
-
-        return $$"""
-        /// <summary>
-        ///{{description}}
-        /// </summary>
-        [Description("{{description}}")]
-        {{name}} = {{((JValue)i["opcode"]!).Value}},
-        """;
-    });
-res.AddResource("OpCode", string.Join("\n", strs));
-
-res.Generate();
-
-Console.WriteLine("Finished!");
+}

--- a/RotationSolver.GameData/Util.cs
+++ b/RotationSolver.GameData/Util.cs
@@ -1,9 +1,18 @@
 ﻿using Lumina.Excel.GeneratedSheets;
+using System.Text;
 using System.Text.RegularExpressions;
 
 namespace RotationSolver.GameData;
+/// <summary>
+/// Utility class for various helper methods.
+/// </summary>
 internal static partial class Util
 {
+    /// <summary>
+    /// Determines if the job category represents a single job for combat.
+    /// </summary>
+    /// <param name="jobCategory">The job category to check.</param>
+    /// <returns>True if the job category represents a single job for combat; otherwise, false.</returns>
     public static bool IsSingleJobForCombat(this ClassJobCategory jobCategory)
     {
         if (jobCategory.RowId == 68) return true; // ACN SMN SCH 
@@ -13,29 +22,49 @@ internal static partial class Util
         return true;
     }
 
+    /// <summary>
+    /// Indents each line of the string with four spaces.
+    /// </summary>
+    /// <param name="str">The string to indent.</param>
+    /// <returns>The indented string.</returns>
     public static string Table(this string str) => "    " + str.Replace("\n", "\n    ");
 
+    /// <summary>
+    /// Inserts spaces before each uppercase letter in the string.
+    /// </summary>
+    /// <param name="str">The string to modify.</param>
+    /// <returns>The modified string with spaces.</returns>
     public static string Space(this string str)
     {
-        string result = string.Empty;
-
+        var result = new StringBuilder();
         bool lower = false;
+
         foreach (var c in str)
         {
             var isLower = char.IsLower(c);
             if (lower && !isLower)
             {
-                result += ' ';
+                result.Append(' ');
             }
             lower = isLower;
-            result += c;
+            result.Append(c);
         }
 
-        return result;
+        return result.ToString();
     }
 
+    /// <summary>
+    /// Removes non-ASCII characters from the string.
+    /// </summary>
+    /// <param name="input">The input string.</param>
+    /// <returns>The string containing only ASCII characters.</returns>
     public static string OnlyAscii(this string input) => new(input.Where(char.IsAscii).ToArray());
 
+    /// <summary>
+    /// Converts the string to PascalCase.
+    /// </summary>
+    /// <param name="input">The input string.</param>
+    /// <returns>The PascalCase string.</returns>
     public static string ToPascalCase(this string input)
     {
         var pascalCase = InvalidCharsRgx().Replace(WhiteSpace().Replace(input, "_"), string.Empty)
@@ -67,6 +96,14 @@ internal static partial class Util
     [GeneratedRegex("(?<=[A-Z])[A-Z]+?((?=[A-Z][a-z])|(?=[0-9]))")]
     private static partial Regex UpperCaseInside();
 
+    /// <summary>
+    /// Generates a property with an array of names.
+    /// </summary>
+    /// <param name="propertyName">The name of the property.</param>
+    /// <param name="propertyType">The type of the property.</param>
+    /// <param name="modifier">The modifier for the property.</param>
+    /// <param name="items">The items to include in the array.</param>
+    /// <returns>The generated property code.</returns>
     public static string ArrayNames(string propertyName, string propertyType, string modifier, params string[] items)
     {
         var thisItems = $"""
@@ -83,6 +120,15 @@ internal static partial class Util
         """;
     }
 
+    /// <summary>
+    /// Generates code for an action.
+    /// </summary>
+    /// <param name="item">The action item.</param>
+    /// <param name="actionName">The name of the action.</param>
+    /// <param name="actionDescName">The description name of the action.</param>
+    /// <param name="desc">The description of the action.</param>
+    /// <param name="isDuty">Indicates if the action is a duty action.</param>
+    /// <returns>The generated action code.</returns>
     public static string ToCode(this Lumina.Excel.GeneratedSheets.Action item,
         string actionName, string actionDescName, string desc, bool isDuty)
     {
@@ -118,6 +164,11 @@ internal static partial class Util
         """;
     }
 
+    /// <summary>
+    /// Gets the description name for an action.
+    /// </summary>
+    /// <param name="action">The action.</param>
+    /// <returns>The description name of the action.</returns>
     public static string GetDescName(this Lumina.Excel.GeneratedSheets.Action action)
     {
         var jobs = action.ClassJobCategory.Value?.Name.RawString;

--- a/RotationSolver.SourceGenerators/ConditionBoolGenerator.cs
+++ b/RotationSolver.SourceGenerators/ConditionBoolGenerator.cs
@@ -1,109 +1,156 @@
 ﻿using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using System.Collections.Immutable;
+using System.Text;
 
 namespace RotationSolver.SourceGenerators;
 
+/// <summary>
+/// Source generator for creating properties from fields marked with the ConditionBoolAttribute.
+/// </summary>
 [Generator(LanguageNames.CSharp)]
-
 public class ConditionBoolGenerator : IIncrementalGenerator
 {
+    /// <summary>
+    /// Initializes the incremental generator.
+    /// </summary>
+    /// <param name="context">The initialization context.</param>
     public void Initialize(IncrementalGeneratorInitializationContext context)
     {
-        var provider = context.SyntaxProvider.ForAttributeWithMetadataName
-            ("RotationSolver.Basic.Attributes.ConditionBoolAttribute",
+        var provider = context.SyntaxProvider.ForAttributeWithMetadataName(
+            "RotationSolver.Basic.Attributes.ConditionBoolAttribute",
             static (node, _) => node is VariableDeclaratorSyntax { Parent: VariableDeclarationSyntax { Parent: FieldDeclarationSyntax { Parent: ClassDeclarationSyntax or StructDeclarationSyntax } } },
             static (n, ct) => ((VariableDeclaratorSyntax)n.TargetNode, n.SemanticModel))
             .Where(m => m.Item1 != null);
+
         context.RegisterSourceOutput(provider.Collect(), Execute);
     }
 
+    /// <summary>
+    /// Executes the source generation.
+    /// </summary>
+    /// <param name="context">The source production context.</param>
+    /// <param name="array">The array of variable declarators and semantic models.</param>
     private void Execute(SourceProductionContext context, ImmutableArray<(VariableDeclaratorSyntax, SemanticModel SemanticModel)> array)
     {
-        var typeGrps = array.GroupBy(variable => variable.Item1.Parent!.Parent!.Parent!);
+        var typeGroups = array.GroupBy(variable => variable.Item1.Parent!.Parent!.Parent!);
 
-        foreach (var grp in typeGrps)
+        foreach (var group in typeGroups)
         {
-            var type = (TypeDeclarationSyntax)grp.Key;
-
+            var type = (TypeDeclarationSyntax)group.Key;
             var nameSpace = type.GetParent<BaseNamespaceDeclarationSyntax>()?.Name.ToString() ?? "Null";
-
             var classType = type is ClassDeclarationSyntax ? "class" : "struct";
-
             var className = type.Identifier.Text;
 
-            var propertyCodes = new List<string>();
-            foreach (var (variableInfo, model) in grp)
-            {
-                var typeSymbol = model.GetDeclaredSymbol(type) as ITypeSymbol;
-
-                var field = (FieldDeclarationSyntax)variableInfo.Parent!.Parent!;
-
-                var variableName = variableInfo.Identifier.ToString();
-                var propertyName = variableName.ToPascalCase();
-
-                if (variableName == propertyName)
-                {
-                    //context.DiagnosticWarning(variableInfo.Identifier.GetLocation(),
-                    //    "Please don't use Pascal Case to name your field!");
-                    continue;
-                }
-
-                var key = string.Join(".", nameSpace, className, propertyName);
-
-                var fieldTypeStr = field.Declaration.Type;
-                var fieldType = model.GetTypeInfo(fieldTypeStr).Type!;
-
-                if (fieldType.GetFullMetadataName() != "System.Boolean")
-                {
-                    var diag = new DiagnosticDescriptor("a", "aa", "aaa", "1", DiagnosticSeverity.Warning, true);
-                    context.ReportDiagnostic(Diagnostic.Create(diag, variableInfo.GetLocation()));
-                    continue;
-                }
-
-                var names = new List<string>();
-                foreach (var attrSet in field.AttributeLists)
-                {
-                    if (attrSet == null) continue;
-                    foreach (var attr in attrSet.Attributes)
-                    {
-                        if (model.GetSymbolInfo(attr).Symbol?.GetFullMetadataName()
-                            is "RotationSolver.Basic.Attributes.UIAttribute"
-                            or "RotationSolver.Basic.Attributes.UnitAttribute"
-                            or "RotationSolver.Basic.Attributes.RangeAttribute"
-                            or "RotationSolver.Basic.Attributes.LinkDescriptionAttribute")
-                        {
-                            names.Add(attr.ToString());
-                        }
-                    }
-                }
-
-                var attributeStr = names.Count == 0 ? "" : $"[{string.Join(", ", names)}]";
-                var propertyCode = $$"""
-                        {{attributeStr}}
-                        public ConditionBoolean {{propertyName}} { get; private set; } = new({{variableName}}, "{{propertyName}}");
-                """;
-
-                propertyCodes.Add(propertyCode);
-            }
+            var propertyCodes = GeneratePropertyCodes(group, context, nameSpace, className);
 
             if (propertyCodes.Count == 0) continue;
 
-            var code = $$"""
-             using RotationSolver.Basic.Data;
-
-             namespace {{nameSpace}}
-             {
-                 partial {{classType}} {{className}}
-                 {
-
-             {{string.Join("\n \n", propertyCodes)}}
-
-                 }
-             }
-             """;
-
+            var code = GenerateClassCode(nameSpace, classType, className, propertyCodes);
             context.AddSource($"{nameSpace}_{className}.g.cs", code);
         }
+    }
+
+    /// <summary>
+    /// Generates the property codes for the given group of variables.
+    /// </summary>
+    /// <param name="group">The group of variables.</param>
+    /// <param name="context">The source production context.</param>
+    /// <param name="nameSpace">The namespace of the class.</param>
+    /// <param name="className">The name of the class.</param>
+    /// <returns>A list of property code strings.</returns>
+    private List<string> GeneratePropertyCodes(IGrouping<SyntaxNode, (VariableDeclaratorSyntax, SemanticModel)> group, SourceProductionContext context, string nameSpace, string className)
+    {
+        var propertyCodes = new List<string>();
+
+        foreach (var (variableInfo, model) in group)
+        {
+            var field = (FieldDeclarationSyntax)variableInfo.Parent!.Parent!;
+            var variableName = variableInfo.Identifier.ToString();
+            var propertyName = variableName.ToPascalCase();
+
+            if (variableName == propertyName)
+            {
+                context.ReportDiagnostic(Diagnostic.Create(new DiagnosticDescriptor("RS001", "Naming Warning", "Please don't use Pascal Case to name your field!", "Naming", DiagnosticSeverity.Warning, true), variableInfo.Identifier.GetLocation()));
+                continue;
+            }
+
+            var fieldType = model.GetTypeInfo(field.Declaration.Type).Type!;
+            if (fieldType.GetFullMetadataName() != "System.Boolean")
+            {
+                context.ReportDiagnostic(Diagnostic.Create(new DiagnosticDescriptor("RS002", "Type Warning", "Field type must be System.Boolean", "Type", DiagnosticSeverity.Warning, true), variableInfo.GetLocation()));
+                continue;
+            }
+
+            var attributeStr = GetFieldAttributes(field, model);
+            var propertyCode = $$"""
+                {{attributeStr}}
+                public ConditionBoolean {{propertyName}} { get; private set; } = new({{variableName}}, "{{propertyName}}");
+            """;
+
+            propertyCodes.Add(propertyCode);
+        }
+
+        return propertyCodes;
+    }
+
+    /// <summary>
+    /// Generates the class code with the given properties.
+    /// </summary>
+    /// <param name="nameSpace">The namespace of the class.</param>
+    /// <param name="classType">The type of the class (class or struct).</param>
+    /// <param name="className">The name of the class.</param>
+    /// <param name="propertyCodes">The list of property code strings.</param>
+    /// <returns>The generated class code.</returns>
+    private string GenerateClassCode(string nameSpace, string classType, string className, List<string> propertyCodes)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine("using RotationSolver.Basic.Data;");
+        sb.AppendLine();
+        sb.AppendLine($"namespace {nameSpace}");
+        sb.AppendLine("{");
+        sb.AppendLine($"    partial {classType} {className}");
+        sb.AppendLine("    {");
+
+        foreach (var propertyCode in propertyCodes)
+        {
+            sb.AppendLine("        " + propertyCode);
+            sb.AppendLine();
+        }
+
+        sb.AppendLine("    }");
+        sb.AppendLine("}");
+
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// Gets the attributes of the field as a string.
+    /// </summary>
+    /// <param name="field">The field declaration syntax.</param>
+    /// <param name="model">The semantic model.</param>
+    /// <returns>The attributes as a string.</returns>
+    private string GetFieldAttributes(FieldDeclarationSyntax field, SemanticModel model)
+    {
+        var names = new List<string>();
+
+        foreach (var attrSet in field.AttributeLists)
+        {
+            if (attrSet == null) continue;
+
+            foreach (var attr in attrSet.Attributes)
+            {
+                if (model.GetSymbolInfo(attr).Symbol?.GetFullMetadataName()
+                    is "RotationSolver.Basic.Attributes.UIAttribute"
+                    or "RotationSolver.Basic.Attributes.UnitAttribute"
+                    or "RotationSolver.Basic.Attributes.RangeAttribute"
+                    or "RotationSolver.Basic.Attributes.LinkDescriptionAttribute")
+                {
+                    names.Add(attr.ToString());
+                }
+            }
+        }
+
+        return names.Count == 0 ? "" : $"[{string.Join(", ", names)}]";
     }
 }

--- a/RotationSolver.SourceGenerators/JobChoiceConfigGenerator.cs
+++ b/RotationSolver.SourceGenerators/JobChoiceConfigGenerator.cs
@@ -5,78 +5,63 @@ using System.Collections.Immutable;
 namespace RotationSolver.SourceGenerators;
 
 [Generator(LanguageNames.CSharp)]
-
 public class JobChoiceConfigGenerator : IIncrementalGenerator
 {
     public void Initialize(IncrementalGeneratorInitializationContext context)
     {
-        var provider = context.SyntaxProvider.ForAttributeWithMetadataName
-            ("RotationSolver.Basic.Attributes.JobChoiceConfigAttribute",
+        var provider = context.SyntaxProvider.ForAttributeWithMetadataName(
+            "RotationSolver.Basic.Attributes.JobChoiceConfigAttribute",
             static (node, _) => node is VariableDeclaratorSyntax { Parent: VariableDeclarationSyntax { Parent: FieldDeclarationSyntax { Parent: ClassDeclarationSyntax or StructDeclarationSyntax } } },
             static (n, ct) => ((VariableDeclaratorSyntax)n.TargetNode, n.SemanticModel))
             .Where(m => m.Item1 != null);
+
         context.RegisterSourceOutput(provider.Collect(), Execute);
     }
 
     private void Execute(SourceProductionContext context, ImmutableArray<(VariableDeclaratorSyntax, SemanticModel SemanticModel)> array)
     {
-        var typeGrps = array.GroupBy(variable => variable.Item1.Parent!.Parent!.Parent!);
+        var typeGroups = array.GroupBy(variable => variable.Item1.Parent!.Parent!.Parent!);
 
-        foreach (var grp in typeGrps)
+        foreach (var group in typeGroups)
         {
-            var type = (TypeDeclarationSyntax)grp.Key;
-
-            var nameSpace = type.GetParent<BaseNamespaceDeclarationSyntax>()?.Name.ToString() ?? "Null";
-
+            var type = (TypeDeclarationSyntax)group.Key;
+            var namespaceName = type.GetParent<BaseNamespaceDeclarationSyntax>()?.Name.ToString() ?? "Null";
             var classType = type is ClassDeclarationSyntax ? "class" : "struct";
-
             var className = type.Identifier.Text;
 
             var propertyCodes = new List<string>();
-            foreach (var (variableInfo, model) in grp)
+            foreach (var (variableInfo, model) in group)
             {
-                var typeSymbol = model.GetDeclaredSymbol(type) as ITypeSymbol;
-
-                var field = (FieldDeclarationSyntax)variableInfo.Parent!.Parent!;
-
-                var variableName = variableInfo.Identifier.ToString();
-                var propertyName = variableName.ToPascalCase();
-
-                if (variableName == propertyName)
+                try
                 {
-                    //context.DiagnosticWarning(variableInfo.Identifier.GetLocation(),
-                    //    "Please don't use Pascal Case to name your field!");
-                    continue;
-                }
+                    var field = (FieldDeclarationSyntax)variableInfo.Parent!.Parent!;
+                    var variableName = variableInfo.Identifier.ToString();
+                    var propertyName = variableName.ToPascalCase();
 
-                var key = string.Join(".", nameSpace, className, propertyName);
-
-                var fieldTypeStr = field.Declaration.Type;
-                var fieldType = model.GetTypeInfo(fieldTypeStr).Type!;
-                var fieldStr = fieldType.GetFullMetadataName();
-
-                var names = new List<string>();
-                foreach (var attrSet in field.AttributeLists)
-                {
-                    if (attrSet == null) continue;
-                    foreach (var attr in attrSet.Attributes)
+                    if (variableName == propertyName)
                     {
-                        if (model.GetSymbolInfo(attr).Symbol?.GetFullMetadataName()
-                            is "RotationSolver.Basic.Attributes.UIAttribute"
+                        // Skip fields with PascalCase names
+                        continue;
+                    }
+
+                    var fieldTypeStr = field.Declaration.Type;
+                    var fieldType = model.GetTypeInfo(fieldTypeStr).Type!;
+                    var fieldStr = fieldType.GetFullMetadataName();
+
+                    var attributeNames = field.AttributeLists
+                        .SelectMany(attrSet => attrSet.Attributes)
+                        .Select(attr => model.GetSymbolInfo(attr).Symbol?.GetFullMetadataName())
+                        .Where(name => name is "RotationSolver.Basic.Attributes.UIAttribute"
                             or "RotationSolver.Basic.Attributes.UnitAttribute"
                             or "RotationSolver.Basic.Attributes.RangeAttribute"
                             or "RotationSolver.Basic.Attributes.JobChoiceConfigAttribute"
                             or "RotationSolver.Basic.Attributes.LinkDescriptionAttribute")
-                        {
-                            names.Add(attr.ToString());
-                        }
-                    }
-                }
+                        .ToList();
 
-                var attributeStr = names.Count == 0 ? "" : $"[{string.Join(", ", names)}]";
-                var propertyCode = $$"""
+                    var attributeStr = attributeNames.Count == 0 ? "" : $"[{string.Join(", ", attributeNames)}]";
+                    var propertyCode = $$"""
                         [JsonProperty]
-                        private Dictionary<Job, Dictionary<string, {{fieldStr}}>> {{variableName}}Dict = [];
+                        private Dictionary<Job, Dictionary<string, {{fieldStr}}>> {{variableName}}Dict = new();
 
                         [JsonIgnore]
                         {{attributeStr}}
@@ -88,7 +73,7 @@ public class JobChoiceConfigGenerator : IIncrementalGenerator
                                 {
                                     dict = {{variableName}}Dict[DataCenter.Job] = new();
                                 }
-                                
+
                                 if (!dict.TryGetValue(RotationChoice, out var value))
                                 {
                                     value = dict[RotationChoice] = {{variableName}};
@@ -101,29 +86,37 @@ public class JobChoiceConfigGenerator : IIncrementalGenerator
                                 {{variableName}}Dict[DataCenter.Job][RotationChoice] = value;
                             }
                         }
-                """;
+                    """;
 
-                propertyCodes.Add(propertyCode);
+                    propertyCodes.Add(propertyCode);
+                }
+                catch (Exception ex)
+                {
+                    context.ReportDiagnostic(Diagnostic.Create(new DiagnosticDescriptor(
+                        "JCCG001",
+                        "Error generating property",
+                        $"An error occurred while generating property for {variableInfo.Identifier}: {ex.Message}",
+                        "JobChoiceConfigGenerator",
+                        DiagnosticSeverity.Error,
+                        isEnabledByDefault: true), variableInfo.GetLocation()));
+                }
             }
 
             if (propertyCodes.Count == 0) continue;
 
             var code = $$"""
-             using ECommons.ExcelServices;
+                using ECommons.ExcelServices;
 
-             namespace {{nameSpace}}
-             {
-                 partial {{classType}} {{className}}
-                 {
+                namespace {{namespaceName}}
+                {
+                    partial {{classType}} {{className}}
+                    {
+                        {{string.Join("\n\n", propertyCodes)}}
+                    }
+                }
+            """;
 
-             {{string.Join("\n \n", propertyCodes)}}
-
-                 }
-             }
-             """;
-
-            context.AddSource($"{nameSpace}_{className}.g.cs", code);
+            context.AddSource($"{namespaceName}_{className}.g.cs", code);
         }
     }
-
 }

--- a/RotationSolver.SourceGenerators/StaticCodeGenerator.cs
+++ b/RotationSolver.SourceGenerators/StaticCodeGenerator.cs
@@ -1,11 +1,19 @@
 ﻿using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using System;
 
 namespace RotationSolver.SourceGenerators;
 
+/// <summary>
+/// A source generator that generates static code for various enums and classes.
+/// </summary>
 [Generator(LanguageNames.CSharp)]
 public class StaticCodeGenerator : IIncrementalGenerator
 {
+    /// <summary>
+    /// Initializes the generator with the provided context.
+    /// </summary>
+    /// <param name="context">The initialization context.</param>
     public void Initialize(IncrementalGeneratorInitializationContext context)
     {
         var provider = context.SyntaxProvider.CreateSyntaxProvider(
@@ -17,17 +25,38 @@ public class StaticCodeGenerator : IIncrementalGenerator
         context.RegisterSourceOutput(compilation, (spc, source) => Execute(spc));
     }
 
+    /// <summary>
+    /// Executes the source generation process.
+    /// </summary>
+    /// <param name="context">The source production context.</param>
     private static void Execute(SourceProductionContext context)
     {
-        GenerateStatus(context);
-        GenerateActionID(context);
-        GenerateContentType(context);
-        GenerateActionCate(context);
-        GenerateBaseRotation(context);
-        GenerateRotations(context);
-        GenerateOpCode(context);
+        try
+        {
+            GenerateStatus(context);
+            GenerateActionID(context);
+            GenerateContentType(context);
+            GenerateActionCate(context);
+            GenerateBaseRotation(context);
+            GenerateRotations(context);
+            GenerateOpCode(context);
+        }
+        catch (Exception ex)
+        {
+            context.ReportDiagnostic(Diagnostic.Create(new DiagnosticDescriptor(
+                "SG0001",
+                "Source Generation Error",
+                $"An error occurred during source generation: {ex.Message}",
+                "SourceGenerator",
+                DiagnosticSeverity.Error,
+                isEnabledByDefault: true), Location.None));
+        }
     }
 
+    /// <summary>
+    /// Generates the OpCode enum source code.
+    /// </summary>
+    /// <param name="context">The source production context.</param>
     private static void GenerateOpCode(SourceProductionContext context)
     {
         var code = $$"""
@@ -49,6 +78,10 @@ public class StaticCodeGenerator : IIncrementalGenerator
         context.AddSource("OpCode.g.cs", code);
     }
 
+    /// <summary>
+    /// Generates the StatusID enum source code.
+    /// </summary>
+    /// <param name="context">The source production context.</param>
     private static void GenerateStatus(SourceProductionContext context)
     {
         var code = $$"""
@@ -70,6 +103,10 @@ public class StaticCodeGenerator : IIncrementalGenerator
         context.AddSource("StatusID.g.cs", code);
     }
 
+    /// <summary>
+    /// Generates the TerritoryContentType enum source code.
+    /// </summary>
+    /// <param name="context">The source production context.</param>
     private static void GenerateContentType(SourceProductionContext context)
     {
         var code = $$"""
@@ -91,6 +128,10 @@ public class StaticCodeGenerator : IIncrementalGenerator
         context.AddSource("TerritoryContentType.g.cs", code);
     }
 
+    /// <summary>
+    /// Generates the ActionCate enum source code.
+    /// </summary>
+    /// <param="context">The source production context.</param>
     private static void GenerateActionCate(SourceProductionContext context)
     {
         var code = $$"""
@@ -112,6 +153,10 @@ public class StaticCodeGenerator : IIncrementalGenerator
         context.AddSource("ActionCate.g.cs", code);
     }
 
+    /// <summary>
+    /// Generates the ActionID enum source code.
+    /// </summary>
+    /// <param="context">The source production context.</param>
     private static void GenerateActionID(SourceProductionContext context)
     {
         var code = $$"""
@@ -133,14 +178,22 @@ public class StaticCodeGenerator : IIncrementalGenerator
         context.AddSource("ActionID.g.cs", code);
     }
 
+    /// <summary>
+    /// Generates the base rotation source code.
+    /// </summary>
+    /// <param="context">The source production context.</param>
     private static void GenerateBaseRotation(SourceProductionContext context)
     {
         context.AddSource("CustomRotation.g.cs", Properties.Resources.Action);
         context.AddSource("DutyRotation.g.cs", Properties.Resources.DutyAction);
     }
 
+    /// <summary>
+    /// Generates the rotations source code.
+    /// </summary>
+    /// <param="context">The source production context.</param>
     private static void GenerateRotations(SourceProductionContext context)
     {
-        context.AddSource($"BaseRotations.g.cs", Properties.Resources.Rotation);
+        context.AddSource("BaseRotations.g.cs", Properties.Resources.Rotation);
     }
 }

--- a/RotationSolver.SourceGenerators/Util.cs
+++ b/RotationSolver.SourceGenerators/Util.cs
@@ -2,100 +2,131 @@
 using System.Text;
 using System.Text.RegularExpressions;
 
-namespace RotationSolver.SourceGenerators;
-internal static class Util
+namespace RotationSolver.SourceGenerators
 {
-    public static TS? GetParent<TS>(this SyntaxNode? node) where TS : SyntaxNode
+    /// <summary>
+    /// Utility class for various helper methods.
+    /// </summary>
+    internal static class Util
     {
-        if (node == null) return null;
-        if (node is TS result) return result;
-        return GetParent<TS>(node.Parent);
-    }
-
-    public static string GetFullMetadataName(this ISymbol s)
-    {
-        if (s == null || s is INamespaceSymbol)
+        /// <summary>
+        /// Gets the parent node of the specified type.
+        /// </summary>
+        /// <typeparam name="TS">The type of the parent node.</typeparam>
+        /// <param name="node">The starting syntax node.</param>
+        /// <returns>The parent node of the specified type, or null if not found.</returns>
+        public static TS? GetParent<TS>(this SyntaxNode? node) where TS : SyntaxNode
         {
-            return string.Empty;
+            if (node == null) return null;
+            if (node is TS result) return result;
+            return GetParent<TS>(node.Parent);
         }
 
-        while (s != null && s is not ITypeSymbol)
+        /// <summary>
+        /// Gets the full metadata name of the specified symbol.
+        /// </summary>
+        /// <param name="s">The symbol.</param>
+        /// <returns>The full metadata name of the symbol.</returns>
+        public static string GetFullMetadataName(this ISymbol s)
         {
-            s = s.ContainingSymbol;
-        }
-
-        if (s == null)
-        {
-            return string.Empty;
-        }
-
-        var sb = new StringBuilder(s.GetTypeSymbolName());
-
-        s = s.ContainingSymbol;
-        while (!IsRootNamespace(s))
-        {
-            try
+            if (s == null || s is INamespaceSymbol)
             {
-                sb.Insert(0, s.OriginalDefinition.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat) + '.');
-            }
-            catch
-            {
-                break;
+                return string.Empty;
             }
 
+            while (s is not ITypeSymbol)
+            {
+                s = s.ContainingSymbol;
+            }
+
+            if (s == null)
+            {
+                return string.Empty;
+            }
+
+            var sb = new StringBuilder(s.GetTypeSymbolName());
+
             s = s.ContainingSymbol;
+            while (!IsRootNamespace(s))
+            {
+                try
+                {
+                    sb.Insert(0, s.OriginalDefinition.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat) + '.');
+                }
+                catch
+                {
+                    break;
+                }
+
+                s = s.ContainingSymbol;
+            }
+
+            return sb.ToString();
+
+            static bool IsRootNamespace(ISymbol symbol)
+            {
+                return symbol is INamespaceSymbol s && s.IsGlobalNamespace;
+            }
         }
 
-        return sb.ToString();
-
-        static bool IsRootNamespace(ISymbol symbol)
+        /// <summary>
+        /// Gets the type symbol name of the specified symbol.
+        /// </summary>
+        /// <param name="symbol">The symbol.</param>
+        /// <returns>The type symbol name.</returns>
+        private static string GetTypeSymbolName(this ISymbol symbol)
         {
-            return symbol is INamespaceSymbol s && s.IsGlobalNamespace;
+            if (symbol is IArrayTypeSymbol arrayTypeSymbol) // Array
+            {
+                return arrayTypeSymbol.ElementType.GetFullMetadataName() + "[]";
+            }
+
+            var str = symbol.MetadataName;
+            if (symbol is INamedTypeSymbol symbolType) // Generic
+            {
+                var strs = str.Split('`');
+                if (strs.Length < 2) return str;
+                str = strs[0];
+
+                str += "<" + string.Join(", ", symbolType.TypeArguments.Select(p => p.GetFullMetadataName())) + ">";
+            }
+            return str;
         }
-    }
 
-    private static string GetTypeSymbolName(this ISymbol symbol)
-    {
-        if (symbol is IArrayTypeSymbol arrayTypeSymbol) //Array
+        /// <summary>
+        /// Indents each line of the string with four spaces.
+        /// </summary>
+        /// <param name="str">The input string.</param>
+        /// <returns>The indented string.</returns>
+        public static string Table(this string str) => "    " + str.Replace("\n", "\n    ");
+
+        /// <summary>
+        /// Converts the input string to PascalCase.
+        /// </summary>
+        /// <param name="input">The input string.</param>
+        /// <returns>The PascalCase string.</returns>
+        public static string ToPascalCase(this string input)
         {
-            return arrayTypeSymbol.ElementType.GetFullMetadataName() + "[]";
-        }
+            return string.Join(".", input.Split('.').Select(ConvertToPascalCase));
 
-        var str = symbol.MetadataName;
-        if (symbol is INamedTypeSymbol symbolType)//Generic
-        {
-            var strs = str.Split('`');
-            if (strs.Length < 2) return str;
-            str = strs[0];
+            static string ConvertToPascalCase(string input)
+            {
+                Regex invalidCharsRgx = new(@"[^_a-zA-Z0-9]");
+                Regex whiteSpace = new(@"(?<=\s)");
+                Regex startsWithLowerCaseChar = new("^[a-z]");
+                Regex firstCharFollowedByUpperCasesOnly = new("(?<=[A-Z])[A-Z0-9]+$");
+                Regex lowerCaseNextToNumber = new("(?<=[0-9])[a-z]");
+                Regex upperCaseInside = new("(?<=[A-Z])[A-Z]+?((?=[A-Z][a-z])|(?=[0-9]))");
 
-            str += "<" + string.Join(", ", symbolType.TypeArguments.Select(p => p.GetFullMetadataName())) + ">";
-        }
-        return str;
-    }
+                var pascalCase = invalidCharsRgx.Replace(whiteSpace.Replace(input, "_"), string.Empty)
+                    .Split(new char[] { '_' }, StringSplitOptions.RemoveEmptyEntries)
+                    .Select(w => startsWithLowerCaseChar.Replace(w, m => m.Value.ToUpper()))
+                    .Select(w => firstCharFollowedByUpperCasesOnly.Replace(w, m => m.Value.ToLower()))
+                    .Select(w => lowerCaseNextToNumber.Replace(w, m => m.Value.ToUpper()))
+                    .Select(w => upperCaseInside.Replace(w, m => m.Value.ToLower()));
 
-    public static string Table(this string str) => "    " + str.Replace("\n", "\n    ");
-
-    public static string ToPascalCase(this string input)
-    {
-        return string.Join(".", input.Split('.').Select(ConvertToPascalCase));
-
-        static string ConvertToPascalCase(string input)
-        {
-            Regex invalidCharsRgx = new(@"[^_a-zA-Z0-9]");
-            Regex whiteSpace = new(@"(?<=\s)");
-            Regex startsWithLowerCaseChar = new("^[a-z]");
-            Regex firstCharFollowedByUpperCasesOnly = new("(?<=[A-Z])[A-Z0-9]+$");
-            Regex lowerCaseNextToNumber = new("(?<=[0-9])[a-z]");
-            Regex upperCaseInside = new("(?<=[A-Z])[A-Z]+?((?=[A-Z][a-z])|(?=[0-9]))");
-
-            var pascalCase = invalidCharsRgx.Replace(whiteSpace.Replace(input, "_"), string.Empty)
-                .Split(new char[] { '_' }, StringSplitOptions.RemoveEmptyEntries)
-                .Select(w => startsWithLowerCaseChar.Replace(w, m => m.Value.ToUpper()))
-                .Select(w => firstCharFollowedByUpperCasesOnly.Replace(w, m => m.Value.ToLower()))
-                .Select(w => lowerCaseNextToNumber.Replace(w, m => m.Value.ToUpper()))
-                .Select(w => upperCaseInside.Replace(w, m => m.Value.ToLower()));
-
-            return string.Concat(pascalCase);
+                return string.Concat(pascalCase);
+            }
         }
     }
 }

--- a/RotationSolver/Commands/RSCommands_Actions.cs
+++ b/RotationSolver/Commands/RSCommands_Actions.cs
@@ -184,7 +184,7 @@ namespace RotationSolver.Commands
                 }
 
                 var target = DataCenter.AllHostileTargets
-                    .FirstOrDefault(t => t != null && t.TargetObjectId == playerObject.GameObjectId);
+                    .FirstOrDefault(t => t != null && t is IBattleChara battleChara && battleChara.TargetObjectId == playerObject.GameObjectId);
 
                 if (Svc.Condition[ConditionFlag.LoggingOut] ||
                     (Service.Config.AutoOffWhenDead && DataCenter.Territory?.IsPvP == false && Player.Available && playerObject.CurrentHp == 0) ||
@@ -255,6 +255,7 @@ namespace RotationSolver.Commands
                 Svc.Log.Error(ex, "Exception in UpdateRotationState");
             }
         }
+
 
     }
 }

--- a/RotationSolver/Updaters/TargetUpdater.cs
+++ b/RotationSolver/Updaters/TargetUpdater.cs
@@ -142,8 +142,6 @@ internal static partial class TargetUpdater
     private static List<IBattleChara> GetAllHostileTargets()
     {
         var hostileTargets = new List<IBattleChara>();
-        var strongOfShieldPositional = EnemyPositional.Front;
-
         try
         {
             foreach (var target in DataCenter.AllTargets)
@@ -152,7 +150,6 @@ internal static partial class TargetUpdater
                 if (!target.IsEnemy() || !target.IsTargetable) continue;
                 if (target.StatusList != null && target.StatusList.Any(StatusHelper.IsInvincible) &&
                     (DataCenter.IsPvP && !Service.Config.IgnorePvPInvincibility || !DataCenter.IsPvP)) continue;
-                if (target.HasStatus(true, StatusID.StrongOfShield) && strongOfShieldPositional != target.FindEnemyPositional()) continue;
 
                 hostileTargets.Add(target);
             }


### PR DESCRIPTION
This pull request introduces several changes to the `RotationSolver` project, focusing on adding new configurations, improving the handling of certain targets, and enhancing the documentation for various classes and methods. The most significant changes include adding new configuration options, updating helper methods to account for new conditions, and adding detailed documentation comments to various classes and methods.

### New Configuration Options:
* Added new configuration options to ignore specific immune targets in different scenarios, such as Ark Angels in Jeuno, targets in Cloud of Darkness Chaotic, and Strong of Shield targets in The Tower at Paradigm's Breach (`RotationSolver.Basic/Configuration/Configs.cs`).

### Helper Method Enhancements:
* Updated `IsAttackable` method to include checks for the new configuration options (`RotationSolver.Basic/Helpers/ObjectHelper.cs`).
* Added new methods `IsCODBossImmune` and `IsHanselorGretelSheilded` to check for specific immunities (`RotationSolver.Basic/Helpers/ObjectHelper.cs`).

### Status Tracking System:
* Improved source gen system to allow for tracking of unnamed statuses

### Documentation Improvements:
* Added comprehensive documentation comments to various classes and methods across multiple files to improve code readability and maintainability. This includes classes such as `ActionCategoryGetter`, `ActionGetterBase`, `ActionIdGetter`, `ActionRotationGetterBase`, `ContentTypeGetter`, `ExcelRowGetter`, and `ItemGetter`. [[1]](diffhunk://#diff-dbd2d55eda7eb8f5ab66c7c1a95348a337832ba88d43d23463e419449d3ad355R4-R26) [[2]](diffhunk://#diff-c5763cf14e83db17feea3d05f830fe95f2cf52502c5ada0564e2eb1649af0b89L6-R78) [[3]](diffhunk://#diff-8289b45890cf8d7f0e7a94f42b54200a1aca620727fe8203e9e729b2a6cd2a9fL5-R23) [[4]](diffhunk://#diff-abedbeb5eb6b57459d6be7f10e109e6d6c28ae3326885f6e921688d90031e001L2-R21) [[5]](diffhunk://#diff-3452deacc9c486dd34d2ca7e80fbc8f31b2e280a7dce2835db990352dec7d7c3R4-R30) [[6]](diffhunk://#diff-8104c750c900a45c6317a3bac71a0f0ce9dc1c0b316d8c8c94cb2a9f960c3213L3-R40) [[7]](diffhunk://#diff-cf5a7180e5bc6b7bbc39453ead657c039bfd988fa1e93123c845cbaef8d2a48bR5-R29)