### PR TITLE
Update NPC Heal/Raise config and add new status entries

### DIFF
--- a/RotationSolver.Basic/Configuration/Configs.cs
+++ b/RotationSolver.Basic/Configuration/Configs.cs
@@ -496,7 +496,7 @@ internal partial class Configs : IPluginConfiguration
 
     [ConditionBool, UI("Heal and raise Party NPCs.",
         Filter = HealingActionCondition, Section = 3)]
-    private static readonly bool _friendlyPartyNPCHealRaise2 = true;
+    private static readonly bool _friendlyPartyNPCHealRaise3 = true;
 
     [ConditionBool, UI("Heal/Dance partner your chocobo", Description = "Experimental.",
         Filter = HealingActionCondition, Section = 3)]

--- a/RotationSolver.Basic/DataCenter.cs
+++ b/RotationSolver.Basic/DataCenter.cs
@@ -818,15 +818,18 @@ internal static class DataCenter
             if (!s.Path.StartsWith("vfx/lockon/eff/tank_lockon")) return false;
             if (!Player.Available) return false;
             if (Player.Object.IsJobCategory(JobRole.Tank) && s.ObjectId != Player.Object.GameObjectId) return false;
-
             return true;
         });
     }
 
     public static bool IsCastingAreaVfx()
     {
-        var vfxDataQueueCopy = VfxDataQueue.ToArray();
-        return IsCastingVfx([.. vfxDataQueueCopy], s => s.Path.StartsWith("vfx/lockon/eff/coshare"));
+        return IsCastingVfx(VfxDataQueue, s =>
+        {
+            if (!s.Path.StartsWith("vfx/lockon/eff/coshare")) return false;
+            if (!Player.Available) return false;
+            return true;
+        });
     }
 
     public static bool IsCastingVfx(List<VfxNewData> vfxDataQueueCopy, Func<VfxNewData, bool> isVfx)

--- a/RotationSolver.Basic/Helpers/ObjectHelper.cs
+++ b/RotationSolver.Basic/Helpers/ObjectHelper.cs
@@ -268,7 +268,7 @@ public static class ObjectHelper
                     if (p?.GameObject?.GameObjectId == gameObject.GameObjectId) return true;
                 }
 
-                if (Service.Config.FriendlyPartyNpcHealRaise2 && gameObject.IsNpcPartyMember()) return true;
+                if (Service.Config.FriendlyPartyNpcHealRaise3 && gameObject.IsNpcPartyMember()) return true;
                 if (Service.Config.ChocoboPartyMember && gameObject.IsPlayerCharacterChocobo()) return true;
                 if (Service.Config.FriendlyBattleNpcHeal && gameObject.IsFriendlyBattleNPC()) return true;
                 if (Service.Config.FocusTargetIsParty && gameObject.IsFocusTarget() && gameObject.IsAllianceMember()) return true;

--- a/RotationSolver.GameData/Getters/StatusGetter.cs
+++ b/RotationSolver.GameData/Getters/StatusGetter.cs
@@ -35,8 +35,7 @@ internal class StatusGetter(Lumina.GameData gameData)
         }
 
         // Perform usual checks for statuses with a name
-        return item.ClassJobCategory.Row != 0 &&
-               name.All(char.IsAscii) &&
+        return name.All(char.IsAscii) &&
                item.Icon != 0;
     }
 
@@ -62,6 +61,12 @@ internal class StatusGetter(Lumina.GameData gameData)
             name += "_" + item.RowId.ToString();
         }
 
+        // Ensure the name does not start with an underscore
+        if (name.StartsWith("_"))
+        {
+            name = "Status" + name;
+        }
+
         var desc = item.Description.RawString;
         var jobs = item.ClassJobCategory.Value?.Name.RawString;
         jobs = string.IsNullOrEmpty(jobs) ? string.Empty : $" ({jobs})";
@@ -77,19 +82,19 @@ internal class StatusGetter(Lumina.GameData gameData)
         if (!name.StartsWith("UnnamedStatus"))
         {
             sb.AppendLine($"""
-        /// <summary>
-        /// <see href="https://garlandtools.org/db/#status/{item.RowId}"><strong>{item.Name.RawString.Replace("&", "and")}</strong></see>{cate}{jobs}
-        /// <para>{desc.Replace("\n", "</para>\n/// <para>")}</para>
-        /// </summary>
-        """);
+    /// <summary>
+    /// <see href="https://garlandtools.org/db/#status/{item.RowId}"><strong>{item.Name.RawString.Replace("&", "and")}</strong></see>{cate}{jobs}
+    /// <para>{desc.Replace("\n", "</para>\n/// <para>")}</para>
+    /// </summary>
+    """);
         }
         else
         {
             sb.AppendLine($"""
-        /// <summary>
-        /// <para>{desc.Replace("\n", "</para>\n/// <para>")}</para>
-        /// </summary>
-        """);
+    /// <summary>
+    /// <para>{desc.Replace("\n", "</para>\n/// <para>")}</para>
+    /// </summary>
+    """);
         }
         sb.AppendLine($"{name} = {item.RowId},");
 

--- a/RotationSolver/UI/RotationConfigWindow.cs
+++ b/RotationSolver/UI/RotationConfigWindow.cs
@@ -1073,10 +1073,10 @@ public partial class RotationConfigWindow : Window
         }
 
         // Display the current NPC Heal/Raise Support status
-        ImGui.TextWrapped($"NPC Heal/Raise Support Enabled: {Service.Config.FriendlyPartyNpcHealRaise2}");
+        ImGui.TextWrapped($"NPC Heal/Raise Support Enabled: {Service.Config.FriendlyPartyNpcHealRaise3}");
         if (ImGui.Button("Enable NPC Heal/Raise Support"))
         {
-            Service.Config.FriendlyPartyNpcHealRaise2.Value = true;
+            Service.Config.FriendlyPartyNpcHealRaise3.Value = true;
         }
         ImGui.Spacing();
         // Display the Auto Load Rotations status

--- a/RotationSolver/Updaters/TargetUpdater.cs
+++ b/RotationSolver/Updaters/TargetUpdater.cs
@@ -100,7 +100,7 @@ internal static partial class TargetUpdater
     private static List<IBattleChara> GetFriendlyNPCs()
     {
         var friendlyNpcs = new List<IBattleChara>();
-        if (!Service.Config.FriendlyBattleNpcHeal && !Service.Config.FriendlyPartyNpcHealRaise2)
+        if (!Service.Config.FriendlyBattleNpcHeal && !Service.Config.FriendlyPartyNpcHealRaise3)
         {
             return friendlyNpcs;
         }
@@ -236,7 +236,7 @@ internal static partial class TargetUpdater
                     validRaiseTargets.AddRange(deathAll);
                 }
 
-                if (Service.Config.FriendlyPartyNpcHealRaise2 || Service.Config.FocusTargetIsParty)
+                if (Service.Config.FriendlyPartyNpcHealRaise3 || Service.Config.FocusTargetIsParty)
                 {
                     validRaiseTargets.AddRange(deathNPC);
                 }


### PR DESCRIPTION
Renamed `_friendlyPartyNPCHealRaise2` to `_friendlyPartyNPCHealRaise3` in `Configs` class and updated references in `ObjectHelper`, `RotationConfigWindow`, and `TargetUpdater` to reset default config for all users to true. Refactored `IsCastingAreaVfx` in `DataCenter` to include additional checks. Reformatted XML comments in `StatusGetter` and added new status entries to `Resources.resx` with summaries and links to garlandtools.org to allow for tracking of all statuses.