### PR TITLE
Update various classes with new properties and logic

### DIFF
--- a/BasicRotations/Magical/SMN_Default.cs
+++ b/BasicRotations/Magical/SMN_Default.cs
@@ -21,10 +21,14 @@ public sealed class SMN_Default : SummonerRotation
         [Description("Ruby-Emerald-Topaz")] RubyEmeraldTopaz,
     }
 
-    [RotationConfig(CombatType.PvE, Name = "Use Crimson Cyclone. Will use at any range, regardless of saftey use with caution.")]
+    [RotationConfig(CombatType.PvE, Name = "Use Crimson Cyclone at any range, regardless of saftey use with caution (Enabling this ignores the below distance setting).")]
     public bool AddCrimsonCyclone { get; set; } = true;
 
-    [RotationConfig(CombatType.PvE, Name = "Use Crimson Cyclone. Even When MOVING")]
+    [Range(1, 20, ConfigUnitType.Yalms)]
+    [RotationConfig(CombatType.PvE, Name = "Max distance you can be from the target for Crimson Cyclone use")]
+    public float CrimsonCycloneDistance { get; set; } = 3.0f;
+
+    [RotationConfig(CombatType.PvE, Name = "Use Crimson Cyclone when moving")]
     public bool AddCrimsonCycloneMoving { get; set; } = false;
 
     [RotationConfig(CombatType.PvE, Name = "Use Swiftcast on Garuda")]
@@ -190,7 +194,7 @@ public sealed class SMN_Default : SummonerRotation
 
         if (GemshinePvE.CanUse(out act)) return true;
 
-        if ((!IsMoving || AddCrimsonCycloneMoving) && AddCrimsonCyclone && CrimsonCyclonePvE.CanUse(out act, skipAoeCheck: true)) return true;
+        if ((!IsMoving || AddCrimsonCycloneMoving) && (AddCrimsonCyclone || CrimsonCyclonePvE.Target.Target?.DistanceToPlayer() <= CrimsonCycloneDistance) && CrimsonCyclonePvE.CanUse(out act, skipAoeCheck: true)) return true;
 
         if (!SummonBahamutPvE.EnoughLevel && HasHostilesInRange && AetherchargePvE.CanUse(out act)) return true;
 

--- a/BasicRotations/Tank/PLD_Default.cs
+++ b/BasicRotations/Tank/PLD_Default.cs
@@ -83,7 +83,8 @@ public sealed class PLD_Default : PaladinRotation
         if (!RageOfHalonePvE.EnoughLevel && nextGCD.IsTheSameTo(true, RiotBladePvE, TotalEclipsePvE) && FightOrFlightPvE.CanUse(out act)) return true;
         if (!ProminencePvE.EnoughLevel && nextGCD.IsTheSameTo(true, RageOfHalonePvE, TotalEclipsePvE) && FightOrFlightPvE.CanUse(out act)) return true;
         if (!AtonementPvE.EnoughLevel && nextGCD.IsTheSameTo(true, RoyalAuthorityPvE, ProminencePvE) && FightOrFlightPvE.CanUse(out act)) return true;
-        if (AtonementPvE.EnoughLevel && (Player.HasStatus(true, StatusID.AtonementReady) || IsLastAction(true, RoyalAuthorityPvE)) && FightOrFlightPvE.CanUse(out act)) return true;
+        if (AtonementPvE.EnoughLevel && (Player.HasStatus(true, StatusID.AtonementReady, StatusID.SepulchreReady, StatusID.SupplicationReady, StatusID.DivineMight) || IsLastAction(true, RoyalAuthorityPvE)) && FightOrFlightPvE.CanUse(out act)) return true;
+
 
         // if requiscat is able to proc confiteor, use it immediately after Fight or Flight
         if (RequiescatMasteryTrait.EnoughLevel)
@@ -215,9 +216,16 @@ public sealed class PLD_Default : PaladinRotation
         if (GoringBladePvE.CanUse(out act)) return true;
 
         // Atonement Combo
-        if (SepulchrePvE.CanUse(out act)) return true;
-        if (SupplicationPvE.CanUse(out act)) return true;
-        if (AtonementPvE.CanUse(out act)) return true;
+        if ((!FightOrFlightPvE.Cooldown.WillHaveOneCharge(1) || HasFightOrFlight || Player.WillStatusEndGCD(1, 0, true, StatusID.AtonementReady)) && AtonementPvE.CanUse(out act)) return true;
+        if (((!HasAtonementReady && (SepulchreReady || SupplicationReady || HasDivineMight)) ||
+             (HasAtonementReady && !HasDivineMight)) &&
+            !Player.HasStatus(true, StatusID.Medicated) && !HasFightOrFlight && !RageOfHalonePvE.CanUse(out act, skipComboCheck: false))
+        {
+            if (RiotBladePvE.CanUse(out act) || FastBladePvE.CanUse(out act)) return true;
+        }
+        if ((RageOfHalonePvE.CanUse(out _, skipComboCheck: false) || HasFightOrFlight || Player.WillStatusEndGCD(1, 0, true, StatusID.SupplicationReady)) && SupplicationPvE.CanUse(out act)) return true;
+        if (RequiescatStacks > 0 && IsLastGCD(true, SupplicationPvE) && !HasFightOrFlight && HolySpiritPvE.CanUse(out act, skipCastingCheck: true)) return true;
+        if ((RageOfHalonePvE.CanUse(out _, skipComboCheck: false) || HasFightOrFlight || Player.WillStatusEndGCD(1, 0, true, StatusID.SepulchreReady)) && SepulchrePvE.CanUse(out act)) return true;
 
         //AoE
         if ((HasDivineMight || RequiescatStacks > 0) && HolyCirclePvE.CanUse(out act, skipCastingCheck: true)) return true;
@@ -227,7 +235,7 @@ public sealed class PLD_Default : PaladinRotation
         //Single Target
         if ((HasDivineMight || RequiescatStacks > 0) && HolySpiritPvE.CanUse(out act, skipCastingCheck: true)) return true;
 
-        if (RoyalAuthorityPvE.CanUse(out act)) return true;
+        if (!SupplicationReady && !SepulchreReady && !HasAtonementReady && !HasDivineMight && RoyalAuthorityPvE.CanUse(out act)) return true;
         if (RageOfHalonePvE.CanUse(out act)) return true;
         if (RiotBladePvE.CanUse(out act)) return true;
         if (FastBladePvE.CanUse(out act)) return true;

--- a/RotationSolver.Basic/Helpers/IActionHelper.cs
+++ b/RotationSolver.Basic/Helpers/IActionHelper.cs
@@ -154,4 +154,34 @@ public static class IActionHelper
         }
         return result;
     }
+
+    /// <summary>
+    /// Determines if the last combo action matches any of the provided actions.
+    /// </summary>
+    /// <param name="isAdjust">Whether to use the adjusted ID.</param>
+    /// <param name="actions">The actions to check against.</param>
+    /// <returns>True if the last combo action matches any of the provided actions, otherwise false.</returns>
+    internal static bool IsLastComboAction(bool isAdjust, params IAction[] actions)
+    {
+        return actions != null && IsLastComboAction(GetIDFromActions(isAdjust, actions));
+    }
+
+    /// <summary>
+    /// Determines if the last combo action matches any of the provided action IDs.
+    /// </summary>
+    /// <param name="ids">The action IDs to check against.</param>
+    /// <returns>True if the last combo action matches any of the provided action IDs, otherwise false.</returns>
+    internal static bool IsLastComboAction(params ActionID[] ids)
+    {
+        return IsActionID(DataCenter.LastComboAction, ids);
+    }
+
+    /// <summary>
+    /// Determines if the last action was a combo action.
+    /// </summary>
+    /// <returns>True if the last action was a combo action, otherwise false.</returns>
+    public static bool IsLastActionCombo()
+    {
+        return DataCenter.LastAction == DataCenter.LastComboAction;
+    }
 }

--- a/RotationSolver.Basic/Rotations/Basic/PaladinRotation.cs
+++ b/RotationSolver.Basic/Rotations/Basic/PaladinRotation.cs
@@ -34,7 +34,6 @@ partial class PaladinRotation
     public static byte OathGauge => JobGauge.OathGauge;
     #endregion
 
-
     #region Status Tracking
 
     /// <summary>

--- a/RotationSolver.Basic/Rotations/CustomRotation_OtherInfo.cs
+++ b/RotationSolver.Basic/Rotations/CustomRotation_OtherInfo.cs
@@ -183,6 +183,11 @@ partial class CustomRotation
     protected static IEnumerable<IBattleChara> AllHostileTargets => DataCenter.AllHostileTargets;
 
     /// <summary>
+    /// All targets. This includes both hostile and friendly targets.
+    /// </summary>
+    protected static IEnumerable<IBattleChara> AllTargets => DataCenter.AllTargets;
+
+    /// <summary>
     /// Average time to kill for all targets.
     /// </summary>
     [Description("Average time to kill")]
@@ -499,6 +504,32 @@ partial class CustomRotation
     {
         CountingOfLastUsing++;
         return IActionHelper.IsLastAction(ids);
+    }
+
+    /// <summary>
+    /// Last used Combo Action.
+    /// <br>WARNING: Do Not make this method the main of your rotation.</br>
+    /// </summary>
+    /// <param name="isAdjust">Check for adjust id not raw id.</param>
+    /// <param name="actions">True if any of this is matched.</param>
+    /// <returns></returns>
+    [Description("Just used Combo Action")]
+    public static bool IsLastComboAction(bool isAdjust, params IAction[] actions)
+    {
+        CountingOfLastUsing++;
+        return IActionHelper.IsLastComboAction(isAdjust, actions);
+    }
+
+    /// <summary>
+    /// Last used Combo Action.
+    /// <br>WARNING: Do Not make this method the main of your rotation.</br>
+    /// </summary>
+    /// <param name="ids">True if any of this is matched.</param>
+    /// <returns></returns>
+    public static bool IsLastComboAction(params ActionID[] ids)
+    {
+        CountingOfLastUsing++;
+        return IActionHelper.IsLastComboAction(ids);
     }
 
     /// <summary>


### PR DESCRIPTION
- SMN_Default.cs: Add CrimsonCycloneDistance property (1-20 yalms), update AddCrimsonCyclone description, and adjust CrimsonCyclone logic.
- PLD_Default.cs: Add status checks for AtonementPvE, refine conditions for SepulchrePvE, SupplicationPvE, and RoyalAuthorityPvE.
- IActionHelper.cs: Add methods to check last combo action and if the last action was a combo action.
- PaladinRotation.cs: Minor formatting change for #region Status Tracking comment.
- CustomRotation_OtherInfo.cs: Add AllTargets property, and methods to check last combo action with warnings.