### PR TITLE
BLU Base3.0 mostly filled out

### DIFF
--- a/BasicRotations/Limited Jobs/BLU_Default.cs
+++ b/BasicRotations/Limited Jobs/BLU_Default.cs
@@ -19,7 +19,8 @@ public sealed class Blue_Default : BlueMageRotation
     protected override bool EmergencyAbility(IAction nextGCD, out IAction? act)
     {
         act = null;
-
+        if (nextGCD.IsTheSameTo(true, AngelWhisperPvE) && SwiftcastPvE.CanUse(out act)) return true;
+        if (nextGCD.IsTheSameTo(true, TheRoseOfDestructionPvE) && OffguardPvE.CanUse(out act)) return true;
         return base.EmergencyAbility(nextGCD, out act);
     }
     #endregion
@@ -80,9 +81,11 @@ public sealed class Blue_Default : BlueMageRotation
     protected override bool AttackAbility(IAction nextGCD, out IAction? act)
     {
         act = null;
+        if (SurpanakhaPvE.CanUse(out act)) return true;
+        if (PhantomFlurryPvE.CanUse(out act)) return true;
         if (JKickPvE.CanUse(out act)) return true;
         if (BeingMortalPvE.CanUse(out act)) return true;
-        if (NightbloomPvE.CanUse(out act)) return true;
+        if (NightbloomPvE.CanUse(out act, skipStatusProvideCheck: true)) return true;
         if (FeatherRainPvE.CanUse(out act)) return true;
         if (ShockStrikePvE.CanUse(out act)) return true;
 
@@ -103,7 +106,7 @@ public sealed class Blue_Default : BlueMageRotation
     protected override bool EmergencyGCD(out IAction? act)
     {
         act = null;
-
+        
         return base.EmergencyGCD(out act);
     }
 
@@ -116,6 +119,7 @@ public sealed class Blue_Default : BlueMageRotation
     protected override bool DefenseAreaGCD(out IAction? act)
     {
         if (ColdFogPvE.CanUse(out act)) return true;
+        if (GobskinPvE.CanUse(out act)) return true;
         return base.DefenseAreaGCD(out act);
     }
 
@@ -128,13 +132,14 @@ public sealed class Blue_Default : BlueMageRotation
 
     protected override bool HealAreaGCD(out IAction? act)
     {
-        if (WhiteWindPvE.CanUse(out act)) return true;
+        if (Player.GetHealthRatio() > 0.5 && WhiteWindPvE.CanUse(out act)) return true;
+        if (StotramPvE.CanUse(out act)) return true;
         return base.HealAreaGCD(out act);
     }
 
     protected override bool HealSingleGCD(out IAction? act)
     {
-        if (WhiteWindPvE.CanUse(out act)) return true;
+        if (PomCurePvE.CanUse(out act)) return true;
         return base.HealSingleGCD(out act);
     }
 
@@ -160,6 +165,8 @@ public sealed class Blue_Default : BlueMageRotation
 
     protected override bool GeneralGCD(out IAction? act)
     {
+        if (MightyGuardPvE.CanUse(out act)) return true;
+        if (BasicInstinctPvE.CanUse(out act)) return true;
         if (WhiteDeathPvE.CanUse(out act)) return true;
 
         if (BreathOfMagicPvE.CanUse(out act) && (BreathOfMagicPvE.Target.Target?.WillStatusEnd(2, true, BreathOfMagicPvE.Setting.TargetStatusProvide ?? []) ?? false)) return true;
@@ -167,10 +174,6 @@ public sealed class Blue_Default : BlueMageRotation
 
         if (MatraMagicPvE.CanUse(out act)) return true;
         if (TheRoseOfDestructionPvE.CanUse(out act)) return true;
-
-        if (TinglePvE.CanUse(out act) && TripleTridentPvE.Cooldown.WillHaveOneChargeGCD(2) && !Player.HasStatus(true, StatusID.Tingling) && !IsLastGCD(ActionID.TinglePvE)) return true;
-        if (WhistlePvE.CanUse(out act) && Player.HasStatus(true, StatusID.Tingling)) return true;
-        if (TripleTridentPvE.CanUse(out act) && IsLastGCD(ActionID.WhistlePvE) && Player.HasStatus(true, StatusID.Tingling)) return true;
 
         if (SonicBoomPvE.CanUse(out act)) return true;
         if (FlyingSardinePvE.CanUse(out act)) return true;

--- a/RotationSolver.Basic/Rotations/Basic/BlueMageRotation.cs
+++ b/RotationSolver.Basic/Rotations/Basic/BlueMageRotation.cs
@@ -144,6 +144,7 @@ partial class BlueMageRotation
     public override MedicineType MedicineType => MedicineType.Intelligence;
 
     private protected sealed override IBaseAction Raise => AngelWhisperPvE;
+    private protected sealed override IBaseAction TankStance => MightyGuardPvE;
 
     /// <summary>
     /// Tye ID card for Blu.
@@ -172,12 +173,40 @@ partial class BlueMageRotation
     [RotationConfig(CombatType.PvE, Name = "Aetheric Mimicry Role")]
     public static BLUID BlueId { get; set; } = BLUID.DPS;
 
-    static partial void ModifySharpenedKnifePvE(ref ActionSetting setting)
+    static partial void ModifyWaterCannonPvE(ref ActionSetting setting)
     {
 
     }
 
-    static partial void ModifyChocoMeteorPvE(ref ActionSetting setting)
+    static partial void ModifyFlameThrowerPvE(ref ActionSetting setting)
+    {
+        setting.IsFriendly = false;
+        setting.CreateConfig = () => new ActionConfig()
+        {
+            AoeCount = 3,
+        };
+    }
+
+    static partial void ModifyAquaBreathPvE(ref ActionSetting setting)
+    {
+        setting.TargetStatusProvide = [StatusID.Dropsy_1736];
+        setting.IsFriendly = false;
+        setting.CreateConfig = () => new ActionConfig()
+        {
+            AoeCount = 3,
+        };
+    }
+
+    static partial void ModifyFlyingFrenzyPvE(ref ActionSetting setting)
+    {
+        setting.SpecialType = SpecialActionType.MovingForward;
+        setting.CreateConfig = () => new ActionConfig()
+        {
+            AoeCount = 3,
+        };
+    }
+
+    static partial void ModifyDrillCannonsPvE(ref ActionSetting setting)
     {
         setting.CreateConfig = () => new ActionConfig()
         {
@@ -185,9 +214,33 @@ partial class BlueMageRotation
         };
     }
 
-    static partial void ModifyPomCurePvE(ref ActionSetting setting)
+    static partial void ModifyHighVoltagePvE(ref ActionSetting setting)
     {
+        setting.TargetStatusProvide = [StatusID.Paralysis];
+        setting.IsFriendly = false;
+        setting.CreateConfig = () => new ActionConfig()
+        {
+            AoeCount = 3,
+        };
+    }
+
+    static partial void ModifyLoomPvE(ref ActionSetting setting)
+    {
+        setting.SpecialType = SpecialActionType.MovingForward;
         setting.IsFriendly = true;
+        setting.CreateConfig = () => new ActionConfig()
+        {
+            AoeCount = 1,
+        };
+    }
+
+    static partial void ModifyFinalStingPvE(ref ActionSetting setting)
+    {
+        setting.ActionCheck = () => !Player.HasStatus(true, StatusID.BrushWithDeath);
+        setting.CreateConfig = () => new ActionConfig()
+        {
+            AoeCount = 1,
+        };
     }
 
     static partial void ModifySongOfTormentPvE(ref ActionSetting setting)
@@ -195,19 +248,286 @@ partial class BlueMageRotation
         setting.TargetStatusProvide = [StatusID.Bleeding_1714];
     }
 
+    static partial void ModifyGlowerPvE(ref ActionSetting setting)
+    {
+        setting.TargetStatusProvide = [StatusID.Paralysis];
+        setting.CreateConfig = () => new ActionConfig()
+        {
+            AoeCount = 1,
+        };
+    }
+
+    static partial void ModifyPlaincrackerPvE(ref ActionSetting setting)
+    {
+        setting.IsFriendly = false;
+        setting.CreateConfig = () => new ActionConfig()
+        {
+            AoeCount = 1,
+        };
+    }
+
     static partial void ModifyBristlePvE(ref ActionSetting setting)
     {
-        setting.StatusProvide = [StatusID.Boost_1716];
+        setting.IsFriendly = true;
+        setting.StatusProvide = [StatusID.Boost_1716, StatusID.Harmonized];
+        setting.CreateConfig = () => new ActionConfig()
+        {
+            AoeCount = 1,
+        };
+    }
+
+    static partial void ModifyWhiteWindPvE(ref ActionSetting setting)
+    {
+        setting.CreateConfig = () => new ActionConfig()
+        {
+            AoeCount = 1,
+        };
+    }
+
+    static partial void ModifyLevel5PetrifyPvE(ref ActionSetting setting)
+    {
+        setting.TargetStatusProvide = [StatusID.Petrification];
+        setting.IsFriendly = false;
+        setting.CreateConfig = () => new ActionConfig()
+        {
+            AoeCount = 1,
+        };
+    }
+
+    static partial void ModifySharpenedKnifePvE(ref ActionSetting setting)
+    {
+
+    }
+
+    static partial void ModifyIceSpikesPvE(ref ActionSetting setting)
+    {
+        setting.StatusProvide = [StatusID.IceSpikes_1720, StatusID.VeilOfTheWhorl_1724, StatusID.Schiltron];
+        setting.IsFriendly = false;
+    }
+
+    static partial void ModifyBloodDrainPvE(ref ActionSetting setting)
+    {
+
+    }
+
+    static partial void ModifyAcornBombPvE(ref ActionSetting setting)
+    {
+        setting.TargetStatusProvide = [StatusID.Sleep];
+        setting.CreateConfig = () => new ActionConfig()
+        {
+            AoeCount = 1,
+        };
+    }
+
+    static partial void ModifyBombTossPvE(ref ActionSetting setting)
+    {
+        setting.TargetStatusProvide = [StatusID.Stun];
+        setting.CreateConfig = () => new ActionConfig()
+        {
+            AoeCount = 1,
+        };
+    }
+
+    static partial void ModifyOffguardPvE(ref ActionSetting setting)
+    {
+        setting.TargetStatusProvide = [StatusID.Offguard];
+    }
+
+    static partial void ModifySelfdestructPvE(ref ActionSetting setting)
+    {
+        setting.ActionCheck = () => !Player.HasStatus(true, StatusID.BrushWithDeath);
+        setting.CreateConfig = () => new ActionConfig()
+        {
+            AoeCount = 1,
+        };
+    }
+
+    static partial void ModifyTransfusionPvE(ref ActionSetting setting)
+    {
+        setting.ActionCheck = () => !Player.HasStatus(true, StatusID.BrushWithDeath);
+    }
+
+    static partial void ModifyFazePvE(ref ActionSetting setting)
+    {
+        setting.TargetStatusProvide = [StatusID.Stun];
+        setting.CreateConfig = () => new ActionConfig()
+        {
+            AoeCount = 1,
+        };
+    }
+
+    static partial void ModifyFlyingSardinePvE(ref ActionSetting setting)
+    {
+        //setting.TargetType = TargetType.Interrupt;
+    }
+
+    static partial void ModifySnortPvE(ref ActionSetting setting)
+    {
+        setting.IsFriendly = false;
+    }
+
+    static partial void Modify_4TonzeWeightPvE(ref ActionSetting setting)
+    {
+        setting.TargetStatusProvide = [StatusID.Heavy];
+        setting.CreateConfig = () => new ActionConfig()
+        {
+            AoeCount = 1,
+        };
+    }
+
+    static partial void ModifyTheLookPvE(ref ActionSetting setting)
+    {
+        setting.IsFriendly = false;
+        //setting.TargetType = TargetType.Provoke;
+        setting.CreateConfig = () => new ActionConfig()
+        {
+            AoeCount = 1,
+        };
+    }
+
+    static partial void ModifyBadBreathPvE(ref ActionSetting setting)
+    {
+        setting.IsFriendly = false;
+        setting.TargetStatusProvide = [StatusID.Slow, StatusID.Heavy, StatusID.Blind, StatusID.Paralysis, StatusID.Poison, StatusID.Malodorous];
+        setting.CreateConfig = () => new ActionConfig()
+        {
+            AoeCount = 1,
+        };
+    }
+
+    static partial void ModifyDiamondbackPvE(ref ActionSetting setting)
+    {
+        setting.StatusProvide = [StatusID.Diamondback];
+        setting.IsFriendly = true;
+        setting.CreateConfig = () => new ActionConfig()
+        {
+            AoeCount = 1,
+        };
+    }
+
+    static partial void ModifyMightyGuardPvE(ref ActionSetting setting)
+    {
+        setting.StatusProvide = [StatusID.MightyGuard];
+    }
+
+    static partial void ModifyStickyTonguePvE(ref ActionSetting setting)
+    {
+        setting.TargetStatusProvide = [StatusID.Stun];
+    }
+
+    static partial void ModifyToadOilPvE(ref ActionSetting setting)
+    {
+        setting.StatusProvide = [StatusID.ToadOil];
+        setting.IsFriendly = true;
+    }
+
+    static partial void ModifyTheRamsVoicePvE(ref ActionSetting setting)
+    {
+        setting.TargetStatusProvide = [StatusID.DeepFreeze_1731];
+        setting.IsFriendly = false;
+        setting.CreateConfig = () => new ActionConfig()
+        {
+            AoeCount = 1,
+        };
+    }
+
+    static partial void ModifyTheDragonsVoicePvE(ref ActionSetting setting)
+    {
+        setting.TargetStatusProvide = [StatusID.Paralysis];
+        setting.IsFriendly = false;
+        setting.CreateConfig = () => new ActionConfig()
+        {
+            AoeCount = 1,
+        };
+    }
+
+    static partial void ModifyMissilePvE(ref ActionSetting setting)
+    {
+
+    }
+
+    static partial void Modify_1000NeedlesPvE(ref ActionSetting setting)
+    {
+        setting.CreateConfig = () => new ActionConfig()
+        {
+            AoeCount = 1,
+        };
+    }
+
+    static partial void ModifyInkJetPvE(ref ActionSetting setting)
+    {
+        setting.TargetStatusProvide = [StatusID.Blind];
+        setting.IsFriendly = false;
+        setting.CreateConfig = () => new ActionConfig()
+        {
+            AoeCount = 1,
+        };
+    }
+
+    static partial void ModifyFireAngonPvE(ref ActionSetting setting)
+    {
+        setting.CreateConfig = () => new ActionConfig()
+        {
+            AoeCount = 1,
+        };
     }
 
     static partial void ModifyMoonFlutePvE(ref ActionSetting setting)
     {
         setting.StatusProvide = [StatusID.WaxingNocturne];
+        setting.IsFriendly = true;
+    }
+
+    static partial void ModifyTailScrewPvE(ref ActionSetting setting)
+    {
+
+    }
+
+    static partial void ModifyMindBlastPvE(ref ActionSetting setting)
+    {
+        setting.TargetStatusProvide = [StatusID.Paralysis];
+        setting.IsFriendly = false;
+        setting.CreateConfig = () => new ActionConfig()
+        {
+            AoeCount = 1,
+        };
+    }
+
+    static partial void ModifyDoomPvE(ref ActionSetting setting)
+    {
+        setting.TargetStatusProvide = [StatusID.Doom_1738];
+    }
+
+    static partial void ModifyPeculiarLightPvE(ref ActionSetting setting)
+    {
+        setting.TargetStatusProvide = [StatusID.PeculiarLight];
+        setting.IsFriendly = false;
+        setting.CreateConfig = () => new ActionConfig()
+        {
+            AoeCount = 3,
+        };
     }
 
     static partial void ModifyFeatherRainPvE(ref ActionSetting setting)
     {
         setting.TargetStatusProvide = [StatusID.Windburn_1723];
+        setting.CreateConfig = () => new ActionConfig()
+        {
+            AoeCount = 1,
+        };
+    }
+
+    static partial void ModifyEruptionPvE(ref ActionSetting setting)
+    {
+        setting.CreateConfig = () => new ActionConfig()
+        {
+            AoeCount = 1,
+        };
+    }
+
+    static partial void ModifyMountainBusterPvE(ref ActionSetting setting)
+    {
+        setting.IsFriendly = false;
         setting.CreateConfig = () => new ActionConfig()
         {
             AoeCount = 1,
@@ -222,6 +542,118 @@ partial class BlueMageRotation
         };
     }
 
+    static partial void ModifyGlassDancePvE(ref ActionSetting setting)
+    {
+        setting.IsFriendly = false;
+        setting.CreateConfig = () => new ActionConfig()
+        {
+            AoeCount = 1,
+        };
+    }
+
+    static partial void ModifyVeilOfTheWhorlPvE(ref ActionSetting setting)
+    {
+        setting.StatusProvide = [StatusID.IceSpikes_1720, StatusID.VeilOfTheWhorl_1724, StatusID.Schiltron];
+        setting.CreateConfig = () => new ActionConfig()
+        {
+            AoeCount = 1,
+        };
+    }
+
+    static partial void ModifyAlpineDraftPvE(ref ActionSetting setting)
+    {
+        setting.CreateConfig = () => new ActionConfig()
+        {
+            AoeCount = 1,
+        };
+    }
+
+    static partial void ModifyProteanWavePvE(ref ActionSetting setting)
+    {
+        setting.IsFriendly = false;
+        setting.CreateConfig = () => new ActionConfig()
+        {
+            AoeCount = 1,
+        };
+    }
+
+    static partial void ModifyNortherliesPvE(ref ActionSetting setting)
+    {
+        setting.IsFriendly = false;
+        setting.CreateConfig = () => new ActionConfig()
+        {
+            AoeCount = 1,
+        };
+    }
+
+    static partial void ModifyKaltstrahlPvE(ref ActionSetting setting)
+    {
+        setting.CreateConfig = () => new ActionConfig()
+        {
+            AoeCount = 1,
+        };
+    }
+
+    static partial void ModifyAbyssalTransfixionPvE(ref ActionSetting setting)
+    {
+        setting.TargetStatusProvide = [StatusID.Paralysis];
+    }
+
+    static partial void ModifyChirpPvE(ref ActionSetting setting)
+    {
+        setting.TargetStatusProvide = [StatusID.Sleep];
+        setting.CreateConfig = () => new ActionConfig()
+        {
+            AoeCount = 1,
+        };
+    }
+
+    static partial void ModifyEerieSoundwavePvE(ref ActionSetting setting)
+    {
+        setting.IsFriendly = false;
+        setting.CreateConfig = () => new ActionConfig()
+        {
+            AoeCount = 1,
+        };
+    }
+
+    static partial void ModifyPomCurePvE(ref ActionSetting setting)
+    {
+        setting.IsFriendly = true;
+    }
+
+    static partial void ModifyGobskinPvE(ref ActionSetting setting)
+    {
+        setting.StatusProvide = [StatusID.Gobskin];
+        setting.CreateConfig = () => new ActionConfig()
+        {
+            AoeCount = 1,
+        };
+    }
+
+    static partial void ModifyMagicHammerPvE(ref ActionSetting setting)
+    {
+        setting.StatusProvide = [StatusID.Conked];
+        setting.CreateConfig = () => new ActionConfig()
+        {
+            AoeCount = 1,
+        };
+    }
+
+    static partial void ModifyAvailPvE(ref ActionSetting setting)
+    {
+        //setting.StatusProvide = [StatusID.Avail];
+    }
+
+    static partial void ModifyFrogLegsPvE(ref ActionSetting setting)
+    {
+        setting.TargetType = TargetType.Provoke;
+        setting.CreateConfig = () => new ActionConfig()
+        {
+            AoeCount = 1,
+        };
+    }
+
     static partial void ModifySonicBoomPvE(ref ActionSetting setting)
     {
 
@@ -229,13 +661,90 @@ partial class BlueMageRotation
 
     static partial void ModifyWhistlePvE(ref ActionSetting setting)
     {
-        setting.StatusProvide = [StatusID.Harmonized];
+        setting.StatusProvide = [StatusID.Boost_1716, StatusID.Harmonized];
+        setting.IsFriendly = true;
     }
 
+    static partial void ModifyWhiteKnightsTourPvE(ref ActionSetting setting)
+    {
+        setting.TargetStatusProvide = [StatusID.Blind];
+        setting.CreateConfig = () => new ActionConfig()
+        {
+            AoeCount = 1,
+        };
+    }
+
+    static partial void ModifyBlackKnightsTourPvE(ref ActionSetting setting)
+    {
+        setting.TargetStatusProvide = [StatusID.Slow];
+        setting.CreateConfig = () => new ActionConfig()
+        {
+            AoeCount = 1,
+        };
+    }
+
+    static partial void ModifyLevel5DeathPvE(ref ActionSetting setting)
+    {
+        setting.IsFriendly = false;
+        setting.CreateConfig = () => new ActionConfig()
+        {
+            AoeCount = 1,
+        };
+    }
+
+    static partial void ModifyLauncherPvE(ref ActionSetting setting)
+    {
+        setting.IsFriendly = false;
+        setting.CreateConfig = () => new ActionConfig()
+        {
+            AoeCount = 1,
+        };
+    }
+
+    static partial void ModifyPerpetualRayPvE(ref ActionSetting setting)
+    {
+        setting.TargetStatusProvide = [StatusID.Stun];
+
+    }
+
+    static partial void ModifyCactguardPvE(ref ActionSetting setting)
+    {
+        setting.TargetStatusProvide = [StatusID.Cactguard];
+        setting.TargetType = TargetType.BeAttacked;
+    }
+
+    static partial void ModifyRevengeBlastPvE(ref ActionSetting setting)
+    {
+        setting.ActionCheck = () => Player.GetHealthRatio() > 0.2;
+    }
 
     static partial void ModifyAngelWhisperPvE(ref ActionSetting setting)
     {
 
+    }
+
+    static partial void ModifyExuviationPvE(ref ActionSetting setting)
+    {
+        setting.TargetType = TargetType.Dispel;
+        setting.CreateConfig = () => new ActionConfig()
+        {
+            AoeCount = 1,
+        };
+    }
+
+    static partial void ModifyRefluxPvE(ref ActionSetting setting)
+    {
+        setting.TargetStatusProvide = [StatusID.Heavy];
+    }
+
+    static partial void ModifyDevourPvE(ref ActionSetting setting)
+    {
+
+    }
+
+    static partial void ModifyCondensedLibraPvE(ref ActionSetting setting)
+    {
+        setting.TargetStatusProvide = [StatusID.PhysicalAttenuation, StatusID.AstralAttenuation, StatusID.UmbralAttenuation];
     }
 
     static partial void ModifyAethericMimicryPvE(ref ActionSetting setting)
@@ -279,8 +788,18 @@ partial class BlueMageRotation
         };
     }
 
+    static partial void ModifyQuasarPvE(ref ActionSetting setting)
+    {
+        setting.IsFriendly = false;
+        setting.CreateConfig = () => new ActionConfig()
+        {
+            AoeCount = 3,
+        };
+    }
+
     static partial void ModifyJKickPvE(ref ActionSetting setting)
     {
+        setting.ActionCheck = () => !Player.HasStatus(false, StatusID.Bind);
         setting.CreateConfig = () => new ActionConfig()
         {
             AoeCount = 1,
@@ -301,6 +820,15 @@ partial class BlueMageRotation
         };
     }
 
+    static partial void ModifyTatamigaeshiPvE(ref ActionSetting setting)
+    {
+        setting.TargetStatusProvide = [StatusID.Tingling];
+        setting.CreateConfig = () => new ActionConfig()
+        {
+            AoeCount = 1,
+        };
+    }
+
     static partial void ModifyColdFogPvE(ref ActionSetting setting)
     {
         setting.StatusProvide = [StatusID.ColdFog];
@@ -314,14 +842,150 @@ partial class BlueMageRotation
         setting.TargetStatusProvide = [StatusID.DeepFreeze_1731];
     }
 
+    static partial void ModifyStotramPvE(ref ActionSetting setting)
+    {
+        setting.CreateConfig = () => new ActionConfig()
+        {
+            AoeCount = 1,
+        };
+    }
+
+    static partial void ModifySaintlyBeamPvE(ref ActionSetting setting)
+    {
+        setting.CreateConfig = () => new ActionConfig()
+        {
+            AoeCount = 3,
+        };
+    }
+
+    static partial void ModifyFeculentFloodPvE(ref ActionSetting setting)
+    {
+        setting.CreateConfig = () => new ActionConfig()
+        {
+            AoeCount = 1,
+        };
+    }
+
+    static partial void ModifyAngelsSnackPvE(ref ActionSetting setting)
+    {
+        setting.CreateConfig = () => new ActionConfig()
+        {
+            AoeCount = 1,
+        };
+    }
+
+    static partial void ModifyChelonianGatePvE(ref ActionSetting setting)
+    {
+        setting.IsFriendly = true;
+        setting.StatusProvide = [StatusID.ChelonianGate];
+        setting.CreateConfig = () => new ActionConfig()
+        {
+            AoeCount = 1,
+        };
+    }
+
+    static partial void ModifyDivineCataractPvE(ref ActionSetting setting)
+    {
+        setting.StatusProvide = [StatusID.AuspiciousTrance];
+        setting.IsFriendly = false;
+        setting.CreateConfig = () => new ActionConfig()
+        {
+            AoeCount = 1,
+        };
+    }
+
     static partial void ModifyTheRoseOfDestructionPvE(ref ActionSetting setting)
     {
 
     }
 
+    static partial void ModifyBasicInstinctPvE(ref ActionSetting setting)
+    {
+        setting.IsFriendly = true;
+        setting.StatusProvide = [StatusID.BasicInstinct];
+        setting.ActionCheck = () => IsInDuty && PartyMembers.Count() <= 1 && DataCenter.Territory?.ContentType != TerritoryContentType.TheMaskedCarnivale;
+    }
+
+    static partial void ModifyUltravibrationPvE(ref ActionSetting setting)
+    {
+        setting.TargetStatusNeed = [StatusID.DeepFreeze_1731, StatusID.Petrification];
+        setting.IsFriendly = false;
+        setting.CreateConfig = () => new ActionConfig()
+        {
+            AoeCount = 1,
+        };
+    }
+
+    static partial void ModifyBlazePvE(ref ActionSetting setting)
+    {
+        setting.CreateConfig = () => new ActionConfig()
+        {
+            AoeCount = 1,
+        };
+    }
+
+    static partial void ModifyMustardBombPvE(ref ActionSetting setting)
+    {
+        setting.CreateConfig = () => new ActionConfig()
+        {
+            AoeCount = 1,
+        };
+    }
+
+    static partial void ModifyDragonForcePvE(ref ActionSetting setting)
+    {
+        setting.StatusProvide = [StatusID.DragonForce];
+        setting.IsFriendly = false;
+    }
+
+    static partial void ModifyAetherialSparkPvE(ref ActionSetting setting)
+    {
+        setting.StatusProvide = [StatusID.Bleeding_1714];
+    }
+
+    static partial void ModifyHydroPullPvE(ref ActionSetting setting)
+    {
+        setting.IsFriendly = false;
+        setting.CreateConfig = () => new ActionConfig()
+        {
+            AoeCount = 1,
+        };
+    }
+
+    static partial void ModifyMaledictionOfWaterPvE(ref ActionSetting setting)
+    {
+        setting.IsFriendly = false;
+        setting.CreateConfig = () => new ActionConfig()
+        {
+            AoeCount = 1,
+        };
+    }
+
+    static partial void ModifyChocoMeteorPvE(ref ActionSetting setting)
+    {
+        setting.CreateConfig = () => new ActionConfig()
+        {
+            AoeCount = 1,
+        };
+    }
+
     static partial void ModifyMatraMagicPvE(ref ActionSetting setting)
     {
 
+    }
+
+    static partial void ModifyPeripheralSynthesisPvE(ref ActionSetting setting)
+    {
+
+    }
+
+    static partial void ModifyBothEndsPvE(ref ActionSetting setting)
+    {
+        setting.IsFriendly = false;
+        setting.CreateConfig = () => new ActionConfig()
+        {
+            AoeCount = 3,
+        };
     }
 
     static partial void ModifyPhantomFlurryPvE(ref ActionSetting setting)
@@ -345,6 +1009,26 @@ partial class BlueMageRotation
         };
     }
 
+    static partial void ModifyGoblinPunchPvE(ref ActionSetting setting)
+    {
+
+    }
+
+    static partial void ModifyRightRoundPvE(ref ActionSetting setting)
+    {
+        //Need data
+    }
+
+    static partial void ModifySchiltronPvE(ref ActionSetting setting)
+    {
+        setting.StatusProvide = [StatusID.IceSpikes_1720, StatusID.VeilOfTheWhorl_1724, StatusID.Schiltron];
+    }
+
+    static partial void ModifyRehydrationPvE(ref ActionSetting setting)
+    {
+        setting.IsFriendly = true;
+    }
+
     static partial void ModifyBreathOfMagicPvE(ref ActionSetting setting)
     {
         setting.TargetStatusProvide = [StatusID.BreathOfMagic];
@@ -353,6 +1037,49 @@ partial class BlueMageRotation
         {
             AoeCount = 1,
         };
+    }
+
+    static partial void ModifyWildRagePvE(ref ActionSetting setting)
+    {
+        //Need data
+    }
+
+    static partial void ModifyPeatPeltPvE(ref ActionSetting setting)
+    {
+        //Need data
+    }
+
+    static partial void ModifyDeepCleanPvE(ref ActionSetting setting)
+    {
+        //Need data
+    }
+
+    static partial void ModifyRubyDynamicsPvE(ref ActionSetting setting)
+    {
+        //Need data
+    }
+
+    static partial void ModifyDivinationRunePvE(ref ActionSetting setting)
+    {
+        setting.CreateConfig = () => new ActionConfig()
+        {
+            AoeCount = 1,
+        };
+    }
+
+    static partial void ModifyDimensionalShiftPvE(ref ActionSetting setting)
+    {
+        //Need data
+    }
+
+    static partial void ModifyConvictionMarcatoPvE(ref ActionSetting setting)
+    {
+        //Need data
+    }
+
+    static partial void ModifyForceFieldPvE(ref ActionSetting setting)
+    {
+        //Need data
     }
 
     static partial void ModifyWingedReprobationPvE(ref ActionSetting setting)
@@ -364,15 +1091,33 @@ partial class BlueMageRotation
         };
     }
 
-    static partial void ModifySeaShantyPvE(ref ActionSetting setting)
+    static partial void ModifyLaserEyePvE(ref ActionSetting setting)
     {
-
+        //Need data
     }
 
-    static partial void ModifyMightyGuardPvE(ref ActionSetting setting)
+    static partial void ModifyCandyCanePvE(ref ActionSetting setting)
     {
-        setting.IsFriendly = true;
-        setting.StatusProvide = [StatusID.MightyGuard];
+        setting.TargetStatusProvide = [StatusID.CandyCane];
+        setting.CreateConfig = () => new ActionConfig()
+        {
+            AoeCount = 1,
+        };
+    }
+
+    static partial void ModifyMortalFlamePvE(ref ActionSetting setting)
+    {
+        //Need data
+    }
+
+    static partial void ModifySeaShantyPvE(ref ActionSetting setting)
+    {
+        //Need data
+    }
+
+    static partial void ModifyApokalypsisPvE(ref ActionSetting setting)
+    {
+        //Need data
     }
 
     static partial void ModifyBeingMortalPvE(ref ActionSetting setting)
@@ -382,43 +1127,6 @@ partial class BlueMageRotation
         {
             AoeCount = 1,
         };
-    }
-
-    static partial void ModifyGlowerPvE(ref ActionSetting setting)
-    {
-        setting.IsFriendly = false;
-        setting.CreateConfig = () => new ActionConfig()
-        {
-            AoeCount = 1,
-        };
-    }
-
-
-    //Optional
-    static partial void ModifyFlyingSardinePvE(ref ActionSetting setting)
-    {
-
-    }
-
-    static partial void ModifyMindBlastPvE(ref ActionSetting setting)
-    {
-        setting.CreateConfig = () => new ActionConfig()
-        {
-            AoeCount = 3,
-        };
-        setting.IsFriendly = false;
-    }
-
-    static partial void ModifyWhiteWindPvE(ref ActionSetting setting)
-    {
-        setting.IsFriendly = true;
-    }
-
-    static partial void ModifyBasicInstinctPvE(ref ActionSetting setting)
-    {
-        setting.IsFriendly = true;
-        setting.StatusProvide = [StatusID.BasicInstinct];
-        setting.ActionCheck = () => IsInDuty && PartyMembers.Count() <= 1 && DataCenter.Territory?.ContentType != TerritoryContentType.TheMaskedCarnivale;
     }
 
     /// <summary>


### PR DESCRIPTION
This pull request includes several updates to the `Blue_Default` class in the `BasicRotations/Limited Jobs/BLU_Default.cs` file. The changes focus on enhancing the emergency abilities, attack abilities, defense abilities, healing abilities, and general abilities of the Blue Mage rotation.

Enhancements to emergency abilities:

* Added checks for `AngelWhisperPvE` and `TheRoseOfDestructionPvE` in `EmergencyAbility` method.

Improvements to attack abilities:

* Added checks for `SurpanakhaPvE` and `PhantomFlurryPvE` in `AttackAbility` method.
* Modified `NightbloomPvE` check to skip status provide check in `AttackAbility` method.

Updates to defense abilities:

* Added check for `GobskinPvE` in `DefenseAreaGCD` method.

Enhancements to healing abilities:

* Added health ratio check for `WhiteWindPvE` and added `StotramPvE` check in `HealAreaGCD` method.
* Added check for `PomCurePvE` in `HealSingleGCD` method.

Updates to general abilities:

* Added checks for `MightyGuardPvE` and `BasicInstinctPvE` in `GeneralGCD` method.
* Removed checks for `TinglePvE`, `WhistlePvE`, and `TripleTridentPvE` in `GeneralGCD` method.