### PR TITLE
Refactor TTK methods and update conditions

### DIFF
--- a/BasicRotations/Tank/PLD_Default.cs
+++ b/BasicRotations/Tank/PLD_Default.cs
@@ -226,7 +226,7 @@ public sealed class PLD_Default : PaladinRotation
              (HasAtonementReady && !HasDivineMight)) &&
             !Player.HasStatus(true, StatusID.Medicated) && !HasFightOrFlight && !RageOfHalonePvE.CanUse(out act, skipComboCheck: false))
         {
-            if (RiotBladePvE.CanUse(out act) || FastBladePvE.CanUse(out act)) return true;
+            if (!TotalEclipsePvE.CanUse(out _) && (RiotBladePvE.CanUse(out act) || FastBladePvE.CanUse(out act))) return true;
         }
         if ((RageOfHalonePvE.CanUse(out _, skipComboCheck: false) || HasFightOrFlight || Player.WillStatusEndGCD(1, 0, true, StatusID.SupplicationReady)) && SupplicationPvE.CanUse(out act)) return true;
         if (RequiescatStacks > 0 && IsLastGCD(true, SupplicationPvE) && !HasFightOrFlight && HolySpiritPvE.CanUse(out act, skipCastingCheck: true)) return true;

--- a/RotationSolver.Basic/Actions/ActionTargetInfo.cs
+++ b/RotationSolver.Basic/Actions/ActionTargetInfo.cs
@@ -316,7 +316,7 @@ public struct ActionTargetInfo(IBaseAction action)
     private bool CheckTimeToKill(IGameObject gameObject)
     {
         if (gameObject is not IBattleChara b) return false;
-        var time = b.GetTimeToKill();
+        var time = b.GetTTK();
         return float.IsNaN(time) || time >= action.Config.TimeToKill;
     }
 

--- a/RotationSolver.Basic/Actions/BaseAction.cs
+++ b/RotationSolver.Basic/Actions/BaseAction.cs
@@ -172,7 +172,7 @@ public class BaseAction : IBaseAction
 
     private bool IsTimeToKillValid()
     {
-        return DataCenter.AverageTimeToKill >= Config.TimeToKill && DataCenter.AverageTimeToKill >= Config.TimeToUntargetable;
+        return DataCenter.AverageTTK >= Config.TimeToKill && DataCenter.AverageTTK >= Config.TimeToUntargetable;
     }
 
 

--- a/RotationSolver.Basic/Configuration/Conditions/TargetCondition.cs
+++ b/RotationSolver.Basic/Configuration/Conditions/TargetCondition.cs
@@ -86,9 +86,9 @@ internal class TargetCondition : DelayCondition
     {
         return Param2 switch
         {
-            0 => tar.GetTimeToKill() > DistanceOrTime,
-            1 => tar.GetTimeToKill() < DistanceOrTime,
-            2 => tar.GetTimeToKill() == DistanceOrTime,
+            0 => tar.GetTTK() > DistanceOrTime,
+            1 => tar.GetTTK() < DistanceOrTime,
+            2 => tar.GetTTK() == DistanceOrTime,
             _ => false,
         };
     }

--- a/RotationSolver.Basic/DataCenter.cs
+++ b/RotationSolver.Basic/DataCenter.cs
@@ -467,7 +467,7 @@ internal static class DataCenter
         }
     }
 
-    public static float AverageTimeToKill
+    public static float AverageTTK
     {
         get
         {
@@ -475,10 +475,10 @@ internal static class DataCenter
             int count = 0;
             foreach (var b in AllHostileTargets)
             {
-                var timeToKill = b.GetTimeToKill();
-                if (!float.IsNaN(timeToKill))
+                var tTK = b.GetTTK();
+                if (!float.IsNaN(tTK))
                 {
-                    total += timeToKill;
+                    total += tTK;
                     count++;
                 }
             }
@@ -841,14 +841,17 @@ internal static class DataCenter
 
     public static bool IsCastingVfx(List<VfxNewData> vfxDataQueueCopy, Func<VfxNewData, bool> isVfx)
     {
+        // Create a copy of the list to avoid modification during enumeration
+        var vfxDataQueueSnapshot = new List<VfxNewData>(vfxDataQueueCopy);
+
         // Ensure the list is not empty
-        if (vfxDataQueueCopy.Count == 0)
+        if (vfxDataQueueSnapshot.Count == 0)
         {
             return false;
         }
 
         // Iterate over the copied list
-        foreach (var vfx in vfxDataQueueCopy)
+        foreach (var vfx in vfxDataQueueSnapshot)
         {
             if (isVfx(vfx))
             {

--- a/RotationSolver.Basic/Helpers/ObjectHelper.cs
+++ b/RotationSolver.Basic/Helpers/ObjectHelper.cs
@@ -592,7 +592,7 @@ public static class ObjectHelper
         if (obj.IsDummy()) return true;
 
         //Fate
-        return obj.GetTimeToKill(true) >= Service.Config.BossTimeToKill;
+        return obj.GetTTK(true) >= Service.Config.BossTimeToKill;
     }
 
     /// <summary>
@@ -619,7 +619,7 @@ public static class ObjectHelper
     public static bool IsDying(this IBattleChara b)
     {
         if (b == null || b.IsDummy()) return false;
-        return b.GetTimeToKill() <= Service.Config.DyingTimeToKill || b.GetHealthRatio() < Service.Config.IsDyingConfig;
+        return b.GetTTK() <= Service.Config.DyingTimeToKill || b.GetHealthRatio() < Service.Config.IsDyingConfig;
     }
 
     /// <summary>
@@ -645,7 +645,7 @@ public static class ObjectHelper
     /// <returns>
     /// The estimated time to kill the battle character in seconds, or <see cref="float.NaN"/> if the calculation cannot be performed.
     /// </returns>
-    internal static float GetTimeToKill(this IBattleChara b, bool wholeTime = false)
+    internal static float GetTTK(this IBattleChara b, bool wholeTime = false)
     {
         if (b == null) return float.NaN;
         if (b.IsDummy()) return 999.99f;

--- a/RotationSolver.Basic/Rotations/CustomRotation_OtherInfo.cs
+++ b/RotationSolver.Basic/Rotations/CustomRotation_OtherInfo.cs
@@ -191,7 +191,7 @@ partial class CustomRotation
     /// Average time to kill for all targets.
     /// </summary>
     [Description("Average time to kill")]
-    public static float AverageTimeToKill => DataCenter.AverageTimeToKill;
+    public static float AverageTTK => DataCenter.AverageTTK;
 
     /// <summary>
     /// The level of the LB.
@@ -209,14 +209,14 @@ partial class CustomRotation
     }
 
     /// <summary>
-    /// Is the <see cref="AverageTimeToKill"/> larger than <paramref name="time"/>.
+    /// Is the <see cref="AverageTTK"/> larger than <paramref name="time"/>.
     /// </summary>
     /// <param name="time">Time</param>
     /// <returns>Is Longer.</returns>
     public static bool IsLongerThan(float time)
     {
         if (IsInHighEndDuty) return true;
-        return AverageTimeToKill > time;
+        return AverageTTK > time;
     }
 
     /// <summary>

--- a/RotationSolver/UI/RotationConfigWindow.cs
+++ b/RotationSolver/UI/RotationConfigWindow.cs
@@ -2855,7 +2855,7 @@ public partial class RotationConfigWindow : Window
         {
             ImGui.Text($"HP: {battleChara.CurrentHp} / {battleChara.MaxHp}");
             ImGui.Text($"Is Current Focus Target: {battleChara.IsFocusTarget()}");
-            ImGui.Text($"TTK: {battleChara.GetTimeToKill()}");
+            ImGui.Text($"TTK: {battleChara.GetTTK()}");
             ImGui.Text($"Is Boss TTK: {battleChara.IsBossFromTTK()}");
             ImGui.Text($"Is Boss Icon: {battleChara.IsBossFromIcon()}");
             ImGui.Text($"Rank: {battleChara.GetObjectNPC()?.Rank.ToString() ?? string.Empty}");


### PR DESCRIPTION
This pull request includes several updates to the `RotationSolver` and `BasicRotations` modules, primarily focusing on renaming methods and variables for consistency and clarity. Additionally, there are some logic improvements in specific methods.

Renaming methods and variables:

* [`RotationSolver.Basic/Actions/ActionTargetInfo.cs`](diffhunk://#diff-c48c5d8b4fd41fe622aa573e5ca583106eb40f1fc24db44fcc12935cd35c1774L319-R319): Renamed `GetTimeToKill` to `GetTTK` for consistency.
* [`RotationSolver.Basic/Configuration/Conditions/TargetCondition.cs`](diffhunk://#diff-efc8744039d5ea138a6da7abe0f72154141796576a0ebca041d3dfa0446b1202L89-R91): Updated calls to `GetTimeToKill` to use the new `GetTTK` method.
* [`RotationSolver.Basic/DataCenter.cs`](diffhunk://#diff-2c3e758beb8d040501567ca05ffcedd46534840df24596c1119e971896e8eb42L470-R481): Changed `AverageTimeToKill` to `AverageTTK` and updated related method calls. [[1]](diffhunk://#diff-2c3e758beb8d040501567ca05ffcedd46534840df24596c1119e971896e8eb42L470-R481) [[2]](diffhunk://#diff-2c3e758beb8d040501567ca05ffcedd46534840df24596c1119e971896e8eb42R844-R854)
* [`RotationSolver.Basic/Helpers/ObjectHelper.cs`](diffhunk://#diff-44cc6e98dcd8c3d2aa47210ec76d800058560df9bbff9ce225b3116c47ddc1fcL595-R595): Renamed `GetTimeToKill` to `GetTTK` in various helper methods. [[1]](diffhunk://#diff-44cc6e98dcd8c3d2aa47210ec76d800058560df9bbff9ce225b3116c47ddc1fcL595-R595) [[2]](diffhunk://#diff-44cc6e98dcd8c3d2aa47210ec76d800058560df9bbff9ce225b3116c47ddc1fcL622-R622) [[3]](diffhunk://#diff-44cc6e98dcd8c3d2aa47210ec76d800058560df9bbff9ce225b3116c47ddc1fcL648-R648)
* [`RotationSolver.Basic/Rotations/CustomRotation_OtherInfo.cs`](diffhunk://#diff-dcfd2506d1ce54221fa2d12787392346547585e896b48e48de6d5fa8be631af4L194-R194): Updated references to `AverageTimeToKill` to use `AverageTTK`. [[1]](diffhunk://#diff-dcfd2506d1ce54221fa2d12787392346547585e896b48e48de6d5fa8be631af4L194-R194) [[2]](diffhunk://#diff-dcfd2506d1ce54221fa2d12787392346547585e896b48e48de6d5fa8be631af4L212-R219)
* [`RotationSolver/UI/RotationConfigWindow.cs`](diffhunk://#diff-44969e3ee4b8d522e4eb8b1ff7712a14af282526ae777e1bbe2ec561a1e9ef0eL2858-R2858): Updated UI display to use `GetTTK` instead of `GetTimeToKill`.

Logic improvements:

* [`BasicRotations/Tank/PLD_Default.cs`](diffhunk://#diff-4ba9729b1336b6ded178be4a01c32a04577b05d25ad4d1c6e762f098342953b6L229-R229): Added a check for `TotalEclipsePvE` before using `RiotBladePvE` or `FastBladePvE`.
* [`RotationSolver.Basic/DataCenter.cs`](diffhunk://#diff-2c3e758beb8d040501567ca05ffcedd46534840df24596c1119e971896e8eb42R844-R854): Added a snapshot of the list to avoid modification during enumeration in `IsCastingVfx`.