### PR TITLE
Add BioMove option, update logic, and enhance debug UI

### DIFF
--- a/BasicRotations/Ranged/MCH_Default.cs
+++ b/BasicRotations/Ranged/MCH_Default.cs
@@ -26,6 +26,9 @@ public sealed class MCH_Default : MachinistRotation
 
     [RotationConfig(CombatType.PvE, Name = "Prevent the use of defense abilties during hypercharge burst")]
     private bool BurstDefense { get; set; } = false;
+
+    [RotationConfig(CombatType.PvE, Name = "Use Bioblaster while moving")]
+    private bool BioMove { get; set; } = true;
     #endregion
 
     #region Countdown logic
@@ -131,7 +134,7 @@ public sealed class MCH_Default : MachinistRotation
         if (HeatBlastPvE.CanUse(out act)) return true;
 
         // drill's aoe version
-        if (BioblasterPvE.CanUse(out act, usedUp: true)) return true;
+        if ((BioMove || (!IsMoving && !BioMove)) && BioblasterPvE.CanUse(out act, usedUp: true)) return true;
 
         // single target --- need to update this strange condition writing!!!
         if (!SpreadShotPvE.CanUse(out _))

--- a/BasicRotations/Ranged/MCH_HighEnd.cs
+++ b/BasicRotations/Ranged/MCH_HighEnd.cs
@@ -14,6 +14,9 @@ public sealed class MCH_HighEnd : MachinistRotation
 
     [RotationConfig(CombatType.PvE, Name = "Use burst medicine midfight when Air Anchor, Barrel Stabilizer, and Wildfire are about to come off cooldown")]
     private bool MidfightBurstMeds { get; set; } = false;
+
+    [RotationConfig(CombatType.PvE, Name = "Use Bioblaster while moving")]
+    private bool BioMove { get; set; } = true;
     #endregion
 
     private const float HYPERCHARGE_DURATION = 8f;
@@ -147,7 +150,7 @@ public sealed class MCH_HighEnd : MachinistRotation
         if (HeatBlastPvE.CanUse(out act)) return true;
 
         // drill's aoe version
-        if (BioblasterPvE.CanUse(out act, usedUp: true)) return true;
+        if ((BioMove || (!IsMoving && !BioMove)) && BioblasterPvE.CanUse(out act, usedUp: true)) return true;
 
         // single target --- need to update this strange condition writing!!!
         if (!SpreadShotPvE.CanUse(out _))

--- a/RotationSolver/UI/RotationConfigWindow.cs
+++ b/RotationSolver/UI/RotationConfigWindow.cs
@@ -2814,7 +2814,9 @@ public partial class RotationConfigWindow : Window
         foreach (var status in Player.Object.StatusList)
         {
             var source = status.SourceId == Player.Object.GameObjectId ? "You" : Svc.Objects.SearchById(status.SourceId) == null ? "None" : "Others";
-            ImGui.Text($"{status.GameData.Value.Name}: {status.StatusId} From: {source}");
+            byte stacks = Player.Object.StatusStack(true, (StatusID)status.StatusId);
+            string stackDisplay = stacks == byte.MaxValue ? "N/A" : stacks.ToString(); // Convert 255 to "N/A"
+            ImGui.Text($"{status.GameData.Value.Name}: {status.StatusId} From: {source} Stacks: {stackDisplay}");
         }
     }
 


### PR DESCRIPTION
This pull request includes several changes to the `BasicRotations` and `RotationSolver` modules to enhance functionality and improve the user interface. The most important changes are summarized below:

### Enhancements to `BasicRotations`:

* Added a new configuration option `BioMove` to `MCH_Default` and `MCH_HighEnd` classes to allow the use of `Bioblaster` while moving. (`BasicRotations/Ranged/MCH_Default.cs`, [[1]](diffhunk://#diff-18a4bcb56b9f9757c8f7433cbf7c0bdf8595591724f92e6e0376e81115ace381R29-R31); `BasicRotations/Ranged/MCH_HighEnd.cs`, [[2]](diffhunk://#diff-09ace0e58dc4b356a6f82de953c04dbb6517b79b3a6c15f5311e1bfcb6289e35R17-R19)
* Updated the `GeneralGCD` method in both `MCH_Default` and `MCH_HighEnd` classes to respect the new `BioMove` configuration option. (`BasicRotations/Ranged/MCH_Default.cs`, [[1]](diffhunk://#diff-18a4bcb56b9f9757c8f7433cbf7c0bdf8595591724f92e6e0376e81115ace381L134-R137); `BasicRotations/Ranged/MCH_HighEnd.cs`, [[2]](diffhunk://#diff-09ace0e58dc4b356a6f82de953c04dbb6517b79b3a6c15f5311e1bfcb6289e35L150-R153)

### Improvements to `RotationSolver` UI:

* Enhanced the `DrawStatus` method in `RotationConfigWindow.cs` to display the stack count of status effects, converting a stack value of 255 to "N/A" for better readability. (`RotationSolver/UI/RotationConfigWindow.cs`, [RotationSolver/UI/RotationConfigWindow.csL2817-R2819](diffhunk://#diff-44969e3ee4b8d522e4eb8b1ff7712a14af282526ae777e1bbe2ec561a1e9ef0eL2817-R2819))

### Submodule Update:

* Updated the `ECommons` submodule to a new commit. (`ECommons`, [ECommonsL1-R1](diffhunk://#diff-e347001520b30beb27d6d2af61f0ac96655dea8d449d396616012d03575182d9L1-R1))