### PR TITLE
Internal language, UI/error display, ShowToggledSettingsInChat

### DIFF
--- a/RotationSolver.Basic/Configuration/ConditionBoolean.cs
+++ b/RotationSolver.Basic/Configuration/ConditionBoolean.cs
@@ -56,7 +56,7 @@ internal class ConditionBoolean
     {
         if (!Service.Config.UseAdditionalConditions) return condition.Value;
         var rotation = DataCenter.CurrentRotation;
-        var set = DataCenter.RightSet;
+        var set = DataCenter.CurrentConditionValue;
         if (rotation != null)
         {
             if (condition.Enable && set.GetEnableCondition(condition.Key).IsTrue(rotation)) return true;

--- a/RotationSolver.Basic/Configuration/Conditions/MajorConditionSet.cs
+++ b/RotationSolver.Basic/Configuration/Conditions/MajorConditionSet.cs
@@ -3,7 +3,7 @@ using ECommons.ExcelServices;
 
 namespace RotationSolver.Basic.Configuration.Conditions;
 
-internal class MajorConditionSet(string name = MajorConditionSet.conditionName)
+internal class MajorConditionValue(string name = MajorConditionValue.conditionName)
 {
     const string conditionName = "Unnamed";
 
@@ -114,7 +114,7 @@ internal class MajorConditionSet(string name = MajorConditionSet.conditionName)
         File.WriteAllText(path, str);
     }
 
-    public static MajorConditionSet[] Read(string folder)
+    public static MajorConditionValue[] Read(string folder)
     {
         if (!Directory.Exists(folder)) return [];
 
@@ -124,7 +124,7 @@ internal class MajorConditionSet(string name = MajorConditionSet.conditionName)
 
             try
             {
-                return JsonConvert.DeserializeObject<MajorConditionSet>(str, new IConditionConverter());
+                return JsonConvert.DeserializeObject<MajorConditionValue>(str, new IConditionConverter());
             }
             catch (Exception ex)
             {
@@ -132,6 +132,6 @@ internal class MajorConditionSet(string name = MajorConditionSet.conditionName)
                 Svc.Chat.Print($"Failed to load the ConditionSet from {p}");
                 return null;
             }
-        }).OfType<MajorConditionSet>().Where(set => !string.IsNullOrEmpty(set.Name)).ToArray();
+        }).OfType<MajorConditionValue>().Where(set => !string.IsNullOrEmpty(set.Name)).ToArray();
     }
 }

--- a/RotationSolver.Basic/Configuration/Conditions/NamedCondition.cs
+++ b/RotationSolver.Basic/Configuration/Conditions/NamedCondition.cs
@@ -6,7 +6,7 @@ internal class NamedCondition : DelayCondition
     public string ConditionName = "Not Chosen";
     protected override bool IsTrueInside(ICustomRotation rotation)
     {
-        foreach (var pair in DataCenter.RightSet.NamedConditions)
+        foreach (var pair in DataCenter.CurrentConditionValue.NamedConditions)
         {
             if (pair.Name != ConditionName) continue;
 

--- a/RotationSolver.Basic/Configuration/Configs.cs
+++ b/RotationSolver.Basic/Configuration/Configs.cs
@@ -500,7 +500,7 @@ internal partial class Configs : IPluginConfiguration
         Filter = HealingActionCondition, Section = 3)]
     private static readonly bool _healWhenNothingTodo = true;
 
-    [UI("The duration of special windows set by commands",
+    [UI("The duration of special windows opened by /macro commands by default.",
         Filter = BasicTimer, Section = 1)]
     [Range(1, 20, ConfigUnitType.Seconds, 1f)]
     public float SpecialDuration { get; set; } = 3;

--- a/RotationSolver.Basic/Configuration/Configs.cs
+++ b/RotationSolver.Basic/Configuration/Configs.cs
@@ -376,9 +376,9 @@ internal partial class Configs : IPluginConfiguration
         PvPFilter = JobFilterType.NoHealer, PvEFilter = JobFilterType.NoHealer)]
     private static readonly bool _onlyHealSelfWhenNoHealer = false;
 
-    [ConditionBool, UI("Show action toggled action and state feedback in chat.",
+    [ConditionBool, UI("Show toggled setting and new value in chat.",
         Filter = UiInformation)]
-    private static readonly bool _showToggledActionInChat = false;
+    private static readonly bool _ShowToggledSettingInChat = false;
 
     [ConditionBool, UI("Record knockback actions", Filter = List2)]
     private static readonly bool _recordKnockbackies = false;

--- a/RotationSolver.Basic/DataCenter.cs
+++ b/RotationSolver.Basic/DataCenter.cs
@@ -37,13 +37,13 @@ internal static class DataCenter
     /// <summary>
     /// This one never be null.
     /// </summary>
-    public static MajorConditionSet RightSet
+    public static MajorConditionValue CurrentConditionValue
     {
         get
         {
             if (ConditionSets == null || ConditionSets.Length == 0)
             {
-                ConditionSets = new[] { new MajorConditionSet() };
+                ConditionSets = new[] { new MajorConditionValue() };
             }
 
             var index = Service.Config.ActionSequencerIndex;
@@ -56,7 +56,7 @@ internal static class DataCenter
         }
     }
 
-    internal static MajorConditionSet[] ConditionSets { get; set; } = Array.Empty<MajorConditionSet>();
+    internal static MajorConditionValue[] ConditionSets { get; set; } = Array.Empty<MajorConditionValue>();
 
     /// <summary>
     /// Only recorded 15s hps.

--- a/RotationSolver/Commands/RSCommands_Actions.cs
+++ b/RotationSolver/Commands/RSCommands_Actions.cs
@@ -195,7 +195,7 @@ namespace RotationSolver.Commands
                     (Service.Config.AutoOffBetweenArea && (Svc.Condition[ConditionFlag.BetweenAreas] || Svc.Condition[ConditionFlag.BetweenAreas51])) ||
                     (Service.Config.CancelStateOnCombatBeforeCountdown && Service.CountDownTime > 0.2f && DataCenter.InCombat) ||
                     (ActionUpdater.AutoCancelTime != DateTime.MinValue && DateTime.Now > ActionUpdater.AutoCancelTime) ||
-                    (DataCenter.RightSet.SwitchCancelConditionSet?.IsTrue(DataCenter.CurrentRotation) ?? false))
+                    (DataCenter.CurrentConditionValue.SwitchCancelConditionSet?.IsTrue(DataCenter.CurrentRotation) ?? false))
                 {
                     CancelState();
 #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
@@ -235,14 +235,14 @@ namespace RotationSolver.Commands
                     _lastCountdownTime = 0;
                     CancelState();
                 }
-                else if (DataCenter.RightSet.SwitchManualConditionSet?.IsTrue(DataCenter.CurrentRotation) ?? false)
+                else if (DataCenter.CurrentConditionValue.SwitchManualConditionSet?.IsTrue(DataCenter.CurrentRotation) ?? false)
                 {
                     if (!DataCenter.State)
                     {
                         DoStateCommandType(StateCommandType.Manual);
                     }
                 }
-                else if (DataCenter.RightSet.SwitchAutoConditionSet?.IsTrue(DataCenter.CurrentRotation) ?? false)
+                else if (DataCenter.CurrentConditionValue.SwitchAutoConditionSet?.IsTrue(DataCenter.CurrentRotation) ?? false)
                 {
                     if (!DataCenter.State)
                     {

--- a/RotationSolver/Commands/RSCommands_OtherCommand.cs
+++ b/RotationSolver/Commands/RSCommands_OtherCommand.cs
@@ -106,7 +106,7 @@ public static partial class RSCommands
             property.SetValue(Service.Config, convertedValue);
             command = convertedValue?.ToString();
 
-            if (Service.Config.ShowToggledActionInChat)
+            if (Service.Config.ShowToggledSettingInChat)
             {
                 Svc.Chat.Print($"Changed setting {property.Name} to {command}");
             }
@@ -227,14 +227,14 @@ public static partial class RSCommands
 
     private static void ToggleActionCommand(string str)
     {
-        foreach (var act in RotationUpdater.RightRotationActions)
+        foreach (var act in RotationUpdater.CurrentRotationActions)
         {
             if (str.StartsWith(act.Name))
             {
                 var flag = str[act.Name.Length..].Trim();
                 act.IsEnabled = bool.TryParse(flag, out var parse) ? parse : !act.IsEnabled;
 
-                if (Service.Config.ShowToggledActionInChat)
+                if (Service.Config.ShowToggledSettingInChat)
                 {
                     Svc.Chat.Print($"Toggled {act.Name} : {act.IsEnabled}");
                 }
@@ -258,7 +258,7 @@ public static partial class RSCommands
 
         if (double.TryParse(timeStr, out var time))
         {
-            foreach (var iAct in RotationUpdater.RightRotationActions)
+            foreach (var iAct in RotationUpdater.CurrentRotationActions)
             {
                 if (actName.Equals(iAct.Name, StringComparison.OrdinalIgnoreCase))
                 {
@@ -288,7 +288,7 @@ public static partial class RSCommands
         {
             if (config.DoCommand(configs, str))
             {
-                if (Service.Config.ShowToggledActionInChat)
+                if (Service.Config.ShowToggledSettingInChat)
                 {
                     Svc.Chat.Print($"Changed setting {config.DisplayName} to {config.Value}");
                     return;

--- a/RotationSolver/Commands/RSCommands_StateSpecialCommand.cs
+++ b/RotationSolver/Commands/RSCommands_StateSpecialCommand.cs
@@ -35,7 +35,6 @@ namespace RotationSolver.Commands
             {
                 stateType = AdjustStateType(stateType, ref index);
             }
-
             UpdateState(stateType, role);
             return stateType;
         });
@@ -78,18 +77,23 @@ namespace RotationSolver.Commands
                     DataCenter.State = false;
                     DataCenter.IsManual = false;
                     ActionUpdater.NextAction = ActionUpdater.NextGCDAction = null;
+                    if (Service.Config.ShowToggledSettingInChat) {Svc.Chat.Print($"Targeting : Off");}
                     break;
+
 
                 case StateCommandType.Auto:
                     DataCenter.IsManual = false;
                     DataCenter.State = true;
                     ActionUpdater.AutoCancelTime = DateTime.MinValue;
+                    if (Service.Config.ShowToggledSettingInChat) {Svc.Chat.Print($"Auto Targeting : {Service.Config.TargetingTypes[Service.Config.TargetingIndex]}");}
                     break;
+
 
                 case StateCommandType.Manual:
                     DataCenter.IsManual = true;
                     DataCenter.State = true;
                     ActionUpdater.AutoCancelTime = DateTime.MinValue;
+                    if (Service.Config.ShowToggledSettingInChat) {Svc.Chat.Print($"Targeting : Manual");}
                     break;
             }
 

--- a/RotationSolver/Data/UiString.cs
+++ b/RotationSolver/Data/UiString.cs
@@ -4,10 +4,10 @@ namespace RotationSolver.Data
 {
     internal enum UiString
     {
-        [Description("The condition set you chose. Click to modify.")]
+        [Description("The condition value you chose. Click to modify.")]
         ConfigWindow_ConditionSetDesc,
 
-        [Description("Condition Set")]
+        [Description("Condition Value")]
         ConfigWindow_ConditionSet,
 
         [Description("Action Condition")]

--- a/RotationSolver/Data/UiString.cs
+++ b/RotationSolver/Data/UiString.cs
@@ -43,9 +43,6 @@ namespace RotationSolver.Data
         [Description("Analyzes PvE combat information in every frame and finds the best action.")]
         ConfigWindow_About_Punchline,
 
-        [Description("Game")]
-        ConfigWindow_Helper_GameVersion,
-
         [Description("Invalid Rotation! \nPlease update to the latest version or contact {0}!")]
         ConfigWindow_Rotation_InvalidRotation,
 
@@ -343,7 +340,7 @@ namespace RotationSolver.Data
         [Description("Move")]
         InfoWindowMove,
 
-        [Description("Search...")]
+        [Description("Setting Search")]
         ConfigWindow_Searching,
 
         [Description("Timer")]

--- a/RotationSolver/UI/ConditionDrawer.cs
+++ b/RotationSolver/UI/ConditionDrawer.cs
@@ -324,7 +324,7 @@ internal static class ConditionDrawer
     private static void DrawAfter(this NamedCondition namedCondition, ICustomRotation _)
     {
         ImGuiHelper.SearchCombo($"##Comparation{namedCondition.GetHashCode()}", namedCondition.ConditionName, ref searchTxt,
-            DataCenter.RightSet.NamedConditions.Select(p => p.Name).ToArray(), i => i.ToString(), i =>
+            DataCenter.CurrentConditionValue.NamedConditions.Select(p => p.Name).ToArray(), i => i.ToString(), i =>
             {
                 namedCondition.ConditionName = i;
             }, UiString.ConfigWindow_Condition_ConditionName.GetDescription());

--- a/RotationSolver/UI/RotationConfigWindow.cs
+++ b/RotationSolver/UI/RotationConfigWindow.cs
@@ -1739,7 +1739,7 @@ public partial class RotationConfigWindow : Window
             ImGui.TextWrapped(UiString.ConfigWindow_Actions_ForcedConditionSet_Description.GetDescription());
 
             var rotation = DataCenter.CurrentRotation;
-            var set = DataCenter.RightSet;
+            var set = DataCenter.CurrentConditionValue;
 
             if (set == null || _activeAction == null || rotation == null) return;
             set.GetCondition(_activeAction.ID)?.DrawMain(rotation);
@@ -1750,7 +1750,7 @@ public partial class RotationConfigWindow : Window
             ImGui.TextWrapped(UiString.ConfigWindow_Actions_DisabledConditionSet_Description.GetDescription());
 
             var rotation = DataCenter.CurrentRotation;
-            var set = DataCenter.RightSet;
+            var set = DataCenter.CurrentConditionValue;
 
             if (set == null || _activeAction == null || rotation == null) return;
             set.GetDisabledCondition(_activeAction.ID)?.DrawMain(rotation);

--- a/RotationSolver/UI/RotationConfigWindow_Config.cs
+++ b/RotationSolver/UI/RotationConfigWindow_Config.cs
@@ -113,15 +113,15 @@ public partial class RotationConfigWindow
     {
         {
             UiString.ConfigWindow_Basic_SwitchCancelConditionSet.GetDescription,
-            () => DataCenter.RightSet.SwitchCancelConditionSet?.DrawMain(DataCenter.CurrentRotation)
+            () => DataCenter.CurrentConditionValue.SwitchCancelConditionSet?.DrawMain(DataCenter.CurrentRotation)
         },
         {
             UiString.ConfigWindow_Basic_SwitchManualConditionSet.GetDescription,
-            () => DataCenter.RightSet.SwitchManualConditionSet?.DrawMain(DataCenter.CurrentRotation)
+            () => DataCenter.CurrentConditionValue.SwitchManualConditionSet?.DrawMain(DataCenter.CurrentRotation)
         },
         {
             UiString.ConfigWindow_Basic_SwitchAutoConditionSet.GetDescription,
-            () => DataCenter.RightSet.SwitchAutoConditionSet?.DrawMain(DataCenter.CurrentRotation)
+            () => DataCenter.CurrentConditionValue.SwitchAutoConditionSet?.DrawMain(DataCenter.CurrentRotation)
         },
     })
     {
@@ -133,15 +133,15 @@ public partial class RotationConfigWindow
     private static void DrawBasicNamedConditions()
     {
         // Ensure there is always an empty named condition at the end
-        if (!DataCenter.RightSet.NamedConditions.Any(c => string.IsNullOrEmpty(c.Name)))
+        if (!DataCenter.CurrentConditionValue.NamedConditions.Any(c => string.IsNullOrEmpty(c.Name)))
         {
-            DataCenter.RightSet.NamedConditions = DataCenter.RightSet.NamedConditions.Append((string.Empty, new ConditionSet())).ToArray();
+            DataCenter.CurrentConditionValue.NamedConditions = DataCenter.CurrentConditionValue.NamedConditions.Append((string.Empty, new ConditionSet())).ToArray();
         }
 
         ImGui.Spacing();
 
         int removeIndex = -1;
-        for (int i = 0; i < DataCenter.RightSet.NamedConditions.Length; i++)
+        for (int i = 0; i < DataCenter.CurrentConditionValue.NamedConditions.Length; i++)
         {
             var value = _isOpen.TryGetValue(i, out var open) && open;
 
@@ -152,7 +152,7 @@ public partial class RotationConfigWindow
 
             ImGui.SetNextItemWidth(width);
             ImGui.InputTextWithHint($"##Rotation Solver Named Condition{i}", UiString.ConfigWindow_Condition_ConditionName.GetDescription(),
-                ref DataCenter.RightSet.NamedConditions[i].Name, 1024);
+                ref DataCenter.CurrentConditionValue.NamedConditions[i].Name, 1024);
 
             ImGui.SameLine();
 
@@ -170,22 +170,22 @@ public partial class RotationConfigWindow
 
             if (value && DataCenter.CurrentRotation != null)
             {
-                DataCenter.RightSet.NamedConditions[i].Condition?.DrawMain(DataCenter.CurrentRotation);
+                DataCenter.CurrentConditionValue.NamedConditions[i].Condition?.DrawMain(DataCenter.CurrentRotation);
             }
         }
 
         // Remove the named condition if needed
         if (removeIndex > -1)
         {
-            var list = DataCenter.RightSet.NamedConditions.ToList();
+            var list = DataCenter.CurrentConditionValue.NamedConditions.ToList();
             list.RemoveAt(removeIndex);
-            DataCenter.RightSet.NamedConditions = list.ToArray();
+            DataCenter.CurrentConditionValue.NamedConditions = list.ToArray();
         }
     }
 
     private static void DrawBasicOthers()
     {
-        var set = DataCenter.RightSet;
+        var set = DataCenter.CurrentConditionValue;
 
         const string popUpId = "Right Set Popup";
         if (ImGui.Selectable(set.Name, false, ImGuiSelectableFlags.None, new Vector2(0, 20)))
@@ -208,7 +208,7 @@ public partial class RotationConfigWindow
                 if (combos[i].Name == set.Name)
                 {
                     ImGuiHelper.SetNextWidthWithName(set.Name);
-                    ImGui.InputText("##MajorConditionSet", ref set.Name, 100);
+                    ImGui.InputText("##MajorConditionValue", ref set.Name, 100);
                 }
                 else
                 {
@@ -328,47 +328,47 @@ public partial class RotationConfigWindow
     {
         {
             UiString.ConfigWindow_Auto_HealAreaConditionSet.GetDescription,
-            () => DataCenter.RightSet.HealAreaConditionSet?.DrawMain(DataCenter.CurrentRotation)
+            () => DataCenter.CurrentConditionValue.HealAreaConditionSet?.DrawMain(DataCenter.CurrentRotation)
         },
         {
             UiString.ConfigWindow_Auto_HealSingleConditionSet.GetDescription,
-            () => DataCenter.RightSet.HealSingleConditionSet?.DrawMain(DataCenter.CurrentRotation)
+            () => DataCenter.CurrentConditionValue.HealSingleConditionSet?.DrawMain(DataCenter.CurrentRotation)
         },
         {
             UiString.ConfigWindow_Auto_DefenseAreaConditionSet.GetDescription,
-            () => DataCenter.RightSet.DefenseAreaConditionSet?.DrawMain(DataCenter.CurrentRotation)
+            () => DataCenter.CurrentConditionValue.DefenseAreaConditionSet?.DrawMain(DataCenter.CurrentRotation)
         },
         {
             UiString.ConfigWindow_Auto_DefenseSingleConditionSet.GetDescription,
-            () => DataCenter.RightSet.DefenseSingleConditionSet?.DrawMain(DataCenter.CurrentRotation)
+            () => DataCenter.CurrentConditionValue.DefenseSingleConditionSet?.DrawMain(DataCenter.CurrentRotation)
         },
         {
             UiString.ConfigWindow_Auto_DispelStancePositionalConditionSet.GetDescription,
-            () => DataCenter.RightSet.DispelStancePositionalConditionSet?.DrawMain(DataCenter.CurrentRotation)
+            () => DataCenter.CurrentConditionValue.DispelStancePositionalConditionSet?.DrawMain(DataCenter.CurrentRotation)
         },
         {
             UiString.ConfigWindow_Auto_RaiseShirkConditionSet.GetDescription,
-            () => DataCenter.RightSet.RaiseShirkConditionSet?.DrawMain(DataCenter.CurrentRotation)
+            () => DataCenter.CurrentConditionValue.RaiseShirkConditionSet?.DrawMain(DataCenter.CurrentRotation)
         },
         {
             UiString.ConfigWindow_Auto_MoveForwardConditionSet.GetDescription,
-            () => DataCenter.RightSet.MoveForwardConditionSet?.DrawMain(DataCenter.CurrentRotation)
+            () => DataCenter.CurrentConditionValue.MoveForwardConditionSet?.DrawMain(DataCenter.CurrentRotation)
         },
         {
             UiString.ConfigWindow_Auto_MoveBackConditionSet.GetDescription,
-            () => DataCenter.RightSet.MoveBackConditionSet?.DrawMain(DataCenter.CurrentRotation)
+            () => DataCenter.CurrentConditionValue.MoveBackConditionSet?.DrawMain(DataCenter.CurrentRotation)
         },
         {
             UiString.ConfigWindow_Auto_AntiKnockbackConditionSet.GetDescription,
-            () => DataCenter.RightSet.AntiKnockbackConditionSet?.DrawMain(DataCenter.CurrentRotation)
+            () => DataCenter.CurrentConditionValue.AntiKnockbackConditionSet?.DrawMain(DataCenter.CurrentRotation)
         },
         {
             UiString.ConfigWindow_Auto_SpeedConditionSet.GetDescription,
-            () => DataCenter.RightSet.SpeedConditionSet?.DrawMain(DataCenter.CurrentRotation)
+            () => DataCenter.CurrentConditionValue.SpeedConditionSet?.DrawMain(DataCenter.CurrentRotation)
         },
         {
             UiString.ConfigWindow_Auto_NoCastingConditionSet.GetDescription,
-            () => DataCenter.RightSet.NoCastingConditionSet?.DrawMain(DataCenter.CurrentRotation)
+            () => DataCenter.CurrentConditionValue.NoCastingConditionSet?.DrawMain(DataCenter.CurrentRotation)
         },
     })
     {

--- a/RotationSolver/UI/SearchableConfigs/CheckBoxSearch.cs
+++ b/RotationSolver/UI/SearchableConfigs/CheckBoxSearch.cs
@@ -60,7 +60,7 @@ internal class CheckBoxSearchCondition(PropertyInfo property, params ISearchable
 
         protected override ConditionSet GetCondition()
         {
-            return DataCenter.RightSet.GetDisableCondition(_condition.Key);
+            return DataCenter.CurrentConditionValue.GetDisableCondition(_condition.Key);
         }
     }
 
@@ -78,7 +78,7 @@ internal class CheckBoxSearchCondition(PropertyInfo property, params ISearchable
 
         protected override ConditionSet GetCondition()
         {
-            return DataCenter.RightSet.GetEnableCondition(_condition.Key);
+            return DataCenter.CurrentConditionValue.GetEnableCondition(_condition.Key);
         }
     }
 

--- a/RotationSolver/Updaters/ActionSequencerUpdater.cs
+++ b/RotationSolver/Updaters/ActionSequencerUpdater.cs
@@ -12,9 +12,9 @@ internal class ActionSequencerUpdater
         var customRotation = DataCenter.CurrentRotation;
         if (customRotation == null) return;
 
-        var allActions = RotationUpdater.RightRotationActions;
+        var allActions = RotationUpdater.CurrentRotationActions;
 
-        var set = DataCenter.RightSet;
+        var set = DataCenter.CurrentConditionValue;
         if (set == null) return;
 
         var disabledActions = new HashSet<uint>();
@@ -75,7 +75,7 @@ internal class ActionSequencerUpdater
     {
         if (_actionSequencerFolder == null) return;
 
-        DataCenter.ConditionSets = MajorConditionSet.Read(_actionSequencerFolder);
+        DataCenter.ConditionSets = MajorConditionValue.Read(_actionSequencerFolder);
     }
 
     public static void AddNew()
@@ -92,9 +92,9 @@ internal class ActionSequencerUpdater
 
         if (!hasUnnamed)
         {
-            var newConditionSets = new List<MajorConditionSet>(DataCenter.ConditionSets)
+            var newConditionSets = new List<MajorConditionValue>(DataCenter.ConditionSets)
             {
-                new MajorConditionSet()
+                new MajorConditionValue()
             };
             DataCenter.ConditionSets = newConditionSets.ToArray();
         }
@@ -102,7 +102,7 @@ internal class ActionSequencerUpdater
 
     public static void Delete(string name)
     {
-        var newConditionSets = new List<MajorConditionSet>();
+        var newConditionSets = new List<MajorConditionValue>();
         foreach (var conditionSet in DataCenter.ConditionSets)
         {
             if (conditionSet.Name != name)

--- a/RotationSolver/Updaters/RotationUpdater.cs
+++ b/RotationSolver/Updaters/RotationUpdater.cs
@@ -17,7 +17,7 @@ internal static class RotationUpdater
     internal static CustomRotationGroup[] CustomRotations { get; set; } = [];
     internal static SortedList<uint, Type[]> DutyRotations { get; set; } = [];
 
-    public static IAction[] RightRotationActions { get; private set; } = [];
+    public static IAction[] CurrentRotationActions { get; private set; } = [];
 
     private static DateTime LastRunTime;
 
@@ -553,13 +553,13 @@ internal static class RotationUpdater
                 DataCenter.CurrentRotation = instance;
             }
 
-            RightRotationActions = DataCenter.CurrentRotation?.AllActions ?? Array.Empty<IAction>();
+            CurrentRotationActions = DataCenter.CurrentRotation?.AllActions ?? Array.Empty<IAction>();
             return;
         }
 
         CustomRotation.MoveTarget = null;
         DataCenter.CurrentRotation = null;
-        RightRotationActions = Array.Empty<IAction>();
+        CurrentRotationActions = Array.Empty<IAction>();
 
         static ICustomRotation? GetRotation(Type? t)
         {

--- a/RotationSolver/Updaters/StateUpdater.cs
+++ b/RotationSolver/Updaters/StateUpdater.cs
@@ -432,24 +432,24 @@ internal static class StateUpdater
             _ => AutoStatus.None,
         };
 
-        AddStatus(ref status, AutoStatus.HealAreaSpell | AutoStatus.HealAreaAbility, DataCenter.RightSet.HealAreaConditionSet);
-        AddStatus(ref status, AutoStatus.HealSingleSpell | AutoStatus.HealSingleAbility, DataCenter.RightSet.HealSingleConditionSet);
-        AddStatus(ref status, AutoStatus.DefenseArea, DataCenter.RightSet.DefenseAreaConditionSet);
-        AddStatus(ref status, AutoStatus.DefenseSingle, DataCenter.RightSet.DefenseSingleConditionSet);
+        AddStatus(ref status, AutoStatus.HealAreaSpell | AutoStatus.HealAreaAbility, DataCenter.CurrentConditionValue.HealAreaConditionSet);
+        AddStatus(ref status, AutoStatus.HealSingleSpell | AutoStatus.HealSingleAbility, DataCenter.CurrentConditionValue.HealSingleConditionSet);
+        AddStatus(ref status, AutoStatus.DefenseArea, DataCenter.CurrentConditionValue.DefenseAreaConditionSet);
+        AddStatus(ref status, AutoStatus.DefenseSingle, DataCenter.CurrentConditionValue.DefenseSingleConditionSet);
 
         AddStatus(ref status, AutoStatus.Dispel | AutoStatus.TankStance | AutoStatus.Positional,
-            DataCenter.RightSet.DispelStancePositionalConditionSet);
-        AddStatus(ref status, AutoStatus.Raise | AutoStatus.Shirk, DataCenter.RightSet.RaiseShirkConditionSet);
-        AddStatus(ref status, AutoStatus.MoveForward, DataCenter.RightSet.MoveForwardConditionSet);
-        AddStatus(ref status, AutoStatus.MoveBack, DataCenter.RightSet.MoveBackConditionSet);
-        AddStatus(ref status, AutoStatus.AntiKnockback, DataCenter.RightSet.AntiKnockbackConditionSet);
+            DataCenter.CurrentConditionValue.DispelStancePositionalConditionSet);
+        AddStatus(ref status, AutoStatus.Raise | AutoStatus.Shirk, DataCenter.CurrentConditionValue.RaiseShirkConditionSet);
+        AddStatus(ref status, AutoStatus.MoveForward, DataCenter.CurrentConditionValue.MoveForwardConditionSet);
+        AddStatus(ref status, AutoStatus.MoveBack, DataCenter.CurrentConditionValue.MoveBackConditionSet);
+        AddStatus(ref status, AutoStatus.AntiKnockback, DataCenter.CurrentConditionValue.AntiKnockbackConditionSet);
 
         if (!status.HasFlag(AutoStatus.Burst) && Service.Config.AutoBurst)
         {
             status |= AutoStatus.Burst;
         }
-        AddStatus(ref status, AutoStatus.Speed, DataCenter.RightSet.SpeedConditionSet);
-        AddStatus(ref status, AutoStatus.NoCasting, DataCenter.RightSet.NoCastingConditionSet);
+        AddStatus(ref status, AutoStatus.Speed, DataCenter.CurrentConditionValue.SpeedConditionSet);
+        AddStatus(ref status, AutoStatus.NoCasting, DataCenter.CurrentConditionValue.NoCastingConditionSet);
 
         return status;
     }


### PR DESCRIPTION
1. Variable language correction throughout. Changing Right and Set to Current and Value where appropriate.
2. Morphed ShowToggledActionInChat to ShowToggledSettingInChat, and added/restored chat based read outs of changed values.
3. Changed LTS' beloved error/warning panel. It now only displays when there is an error instead of no error, in a reactive way. Further, tightened up the UI's twitchiness when minimizing and expanding window.