### PR TITLE
Low level Hypercharge fix, engagement style removal

### DIFF
--- a/BasicRotations/Ranged/MCH_Default.cs
+++ b/BasicRotations/Ranged/MCH_Default.cs
@@ -85,6 +85,9 @@ public sealed class MCH_Default : MachinistRotation
         // If Wildfire is active, use Hypercharge.....Period
         if (Player.HasStatus(true, StatusID.Wildfire_1946) && HyperchargePvE.CanUse(out act)) return true;
 
+        // If you cant use Wildfire, use Hypercharge freely
+        if (!WildfirePvE.EnoughLevel && HyperchargePvE.CanUse(out act)) return true;
+
         // Start Ricochet/Gauss cooldowns rolling
         if (!RicochetPvE.Cooldown.IsCoolingDown && RicochetPvE.CanUse(out act)) return true;
         if (!GaussRoundPvE.Cooldown.IsCoolingDown && GaussRoundPvE.CanUse(out act)) return true;

--- a/BasicRotations/Ranged/MCH_HighEnd.cs
+++ b/BasicRotations/Ranged/MCH_HighEnd.cs
@@ -88,6 +88,9 @@ public sealed class MCH_HighEnd : MachinistRotation
         // If Wildfire is active, use Hypercharge.....Period
         if (Player.HasStatus(true, StatusID.Wildfire_1946) && HyperchargePvE.CanUse(out act)) return true;
 
+        // If you cant use Wildfire, use Hypercharge freely
+        if (!WildfirePvE.EnoughLevel && HyperchargePvE.CanUse(out act)) return true;
+
         // don't do anything that might fuck with burst timings at 100
         if (nextGCD.IsTheSameTo(true, FullMetalFieldPvE) || IsLastGCD(true, FullMetalFieldPvE))
         {

--- a/RotationSolver.Basic/Helpers/ObjectHelper.cs
+++ b/RotationSolver.Basic/Helpers/ObjectHelper.cs
@@ -141,9 +141,10 @@ public static class ObjectHelper
             TargetHostileType.AllTargetsWhenSolo => DataCenter.PartyMembers.Count == 1 || battleChara.TargetObject is IBattleChara,
             TargetHostileType.AllTargetsWhenSoloInDuty => (DataCenter.PartyMembers.Count == 1 && (Svc.Condition[ConditionFlag.BoundByDuty] || Svc.Condition[ConditionFlag.BoundByDuty56]))
                                 || battleChara.TargetObject is IBattleChara,
-            TargetHostileType.TargetIsInEnemiesList => battleChara.TargetObject is IBattleChara target && target.IsInEnemiesList(),
-            TargetHostileType.AllTargetsWhenSoloTargetIsInEnemiesList => (DataCenter.PartyMembers.Count == 1 && (Svc.Condition[ConditionFlag.BoundByDuty] || Svc.Condition[ConditionFlag.BoundByDuty56])) || battleChara.TargetObject is IBattleChara target && target.IsInEnemiesList(),
-            TargetHostileType.AllTargetsWhenSoloInDutyTargetIsInEnemiesList => DataCenter.PartyMembers.Count == 1 || battleChara.TargetObject is IBattleChara target && target.IsInEnemiesList(),
+            //Below options do not work while in party, isAttackable will always return false
+            //TargetHostileType.TargetIsInEnemiesList => battleChara.TargetObject is IBattleChara target && target.IsInEnemiesList(),
+            //TargetHostileType.AllTargetsWhenSoloTargetIsInEnemiesList => (DataCenter.PartyMembers.Count == 1 && (Svc.Condition[ConditionFlag.BoundByDuty] || Svc.Condition[ConditionFlag.BoundByDuty56])) || battleChara.TargetObject is IBattleChara target && target.IsInEnemiesList(),
+            //TargetHostileType.AllTargetsWhenSoloInDutyTargetIsInEnemiesList => DataCenter.PartyMembers.Count == 1 || battleChara.TargetObject is IBattleChara target && target.IsInEnemiesList(),
             _ => true,
         };
     }
@@ -166,7 +167,6 @@ public static class ObjectHelper
         return output.ToString();
     }
 
-    //Below never returns true
     internal static unsafe bool IsInEnemiesList(this IBattleChara battleChara)
     {
         var addons = Service.GetAddons<AddonEnemyList>();

--- a/RotationSolver/Updaters/TargetUpdater.cs
+++ b/RotationSolver/Updaters/TargetUpdater.cs
@@ -13,7 +13,7 @@ internal static partial class TargetUpdater
         _raiseAllTargets = new(() => Service.Config.RaiseDelay);
 
     private static DateTime _lastUpdateTimeToKill = DateTime.MinValue;
-    private static readonly TimeSpan TimeToKillUpdateInterval = TimeSpan.FromSeconds(0.5);
+    private static readonly TimeSpan TimeToKillUpdateInterval = TimeSpan.FromSeconds(0.1);
 
     internal static void UpdateTargets()
     {
@@ -187,10 +187,10 @@ internal static partial class TargetUpdater
         {
             try
             {
-                var deathParty = DataCenter.PartyMembers?.GetDeath().ToList() ?? new List<IBattleChara>();
-                var deathAll = DataCenter.AllTargets?.GetDeath().ToList() ?? new List<IBattleChara>();
-                var deathNPC = DataCenter.FriendlyNPCMembers?.GetDeath().ToList() ?? new List<IBattleChara>();
-                var deathAllianceMembers = DataCenter.AllianceMembers?.GetDeath().ToList() ?? new List<IBattleChara>();
+                var deathParty = DataCenter.PartyMembers?.GetDeath().ToList() ?? [];
+                var deathAll = DataCenter.AllTargets?.GetDeath().ToList() ?? [];
+                var deathNPC = DataCenter.FriendlyNPCMembers?.GetDeath().ToList() ?? [];
+                var deathAllianceMembers = DataCenter.AllianceMembers?.GetDeath().ToList() ?? [];
                 var deathAllianceHealers = new List<IBattleChara>(deathParty);
                 var deathAllianceSupports = new List<IBattleChara>(deathParty);
 


### PR DESCRIPTION
This pull request includes several changes to the `BasicRotations` and `RotationSolver` directories, as well as an update to the `ECommons` submodule. The most important changes involve adjustments to the attack abilities and target handling logic.

### Attack Ability Adjustments:
* [`BasicRotations/Ranged/MCH_Default.cs`](diffhunk://#diff-18a4bcb56b9f9757c8f7433cbf7c0bdf8595591724f92e6e0376e81115ace381R88-R90): Added a condition to use Hypercharge freely if Wildfire cannot be used.
* [`BasicRotations/Ranged/MCH_HighEnd.cs`](diffhunk://#diff-09ace0e58dc4b356a6f82de953c04dbb6517b79b3a6c15f5311e1bfcb6289e35R91-R93): Added a similar condition to use Hypercharge freely if Wildfire cannot be used.

### Target Handling Logic:
* [`RotationSolver.Basic/Helpers/ObjectHelper.cs`](diffhunk://#diff-44cc6e98dcd8c3d2aa47210ec76d800058560df9bbff9ce225b3116c47ddc1fcL144-R147): Commented out several `TargetHostileType` options that do not work while in a party, ensuring `isAttackable` does not return false incorrectly.
* [`RotationSolver.Basic/Helpers/ObjectHelper.cs`](diffhunk://#diff-44cc6e98dcd8c3d2aa47210ec76d800058560df9bbff9ce225b3116c47ddc1fcL169): Removed an outdated comment that indicated a method never returns true.

### Performance Improvement:
* [`RotationSolver/Updaters/TargetUpdater.cs`](diffhunk://#diff-622e3c74c4a92d384d06fbf22795624a905d57cffab7cb988c7fe789a2d0cefcL16-R16): Reduced the `TimeToKillUpdateInterval` from 0.5 seconds to 0.1 seconds to improve the responsiveness of target updates.

### Submodule Update:
* [`ECommons`](diffhunk://#diff-e347001520b30beb27d6d2af61f0ac96655dea8d449d396616012d03575182d9L1-R1): Updated the submodule commit to the latest version.