### PR TITLE
Stop attempting auto open chest when 'InCombat'

### DIFF
--- a/RotationSolver/Updaters/MajorUpdater.cs
+++ b/RotationSolver/Updaters/MajorUpdater.cs
@@ -286,6 +286,7 @@ internal static class MajorUpdater
     private unsafe static void OpenChest()
     {
         if (!Service.Config.AutoOpenChest) return;
+        if (DataCenter.InCombat) return;
         var player = Player.Object;
 
         var treasure = Svc.Objects.FirstOrDefault(o =>


### PR DESCRIPTION
Added an early return in the OpenChest method if player is 'InCombat'.
Intended for while killing the treasure chest mobs that appear in the over-world.