### PR TITLE
Action category polishes

### DIFF
--- a/RotationSolver.Basic/Rotations/Basic/BardRotation.cs
+++ b/RotationSolver.Basic/Rotations/Basic/BardRotation.cs
@@ -95,6 +95,7 @@ partial class BardRotation
 
     static partial void ModifyRagingStrikesPvE(ref ActionSetting setting)
     {
+        setting.IsFriendly = true;
         setting.StatusProvide = [StatusID.RagingStrikes];
         setting.CreateConfig = () => new()
         {
@@ -168,6 +169,7 @@ partial class BardRotation
 
     static partial void ModifyBarragePvE(ref ActionSetting setting)
     {
+        setting.IsFriendly = true;
         setting.StatusProvide = [StatusID.Barrage, StatusID.ResonantArrowReady];
     }
 

--- a/RotationSolver.Basic/Rotations/Basic/BlackMageRotation.cs
+++ b/RotationSolver.Basic/Rotations/Basic/BlackMageRotation.cs
@@ -192,6 +192,7 @@ partial class BlackMageRotation
     static partial void ModifyTransposePvE(ref ActionSetting setting)
     {
         //setting.ActionCheck = () => DataCenter.DefaultGCDRemain <= ElementTimeRaw;
+        setting.IsFriendly = true;
     }
 
     static partial void ModifyThunderPvE(ref ActionSetting setting)
@@ -231,12 +232,14 @@ partial class BlackMageRotation
     {
         setting.StatusProvide = [StatusID.Manaward];
         setting.UnlockedByQuestID = 65889;
+        setting.IsFriendly = true;
     }
 
     static partial void ModifyManafontPvE(ref ActionSetting setting)
     {
         setting.StatusProvide = [StatusID.Thunderhead];
         setting.UnlockedByQuestID = 66609;
+        setting.IsFriendly = true;
     }
 
     static partial void ModifyFireIiiPvE(ref ActionSetting setting)
@@ -317,6 +320,7 @@ partial class BlackMageRotation
     static partial void ModifyBetweenTheLinesPvE(ref ActionSetting setting)
     {
         setting.SpecialType = SpecialActionType.MovingBackward;
+        setting.IsFriendly = true;
         setting.CreateConfig = () => new ActionConfig()
         {
             AoeCount = 1,
@@ -336,6 +340,7 @@ partial class BlackMageRotation
     static partial void ModifyTriplecastPvE(ref ActionSetting setting)
     {
         setting.StatusProvide = StatusHelper.SwiftcastStatus;
+        setting.IsFriendly = true;
     }
 
     static partial void ModifyFoulPvE(ref ActionSetting setting)
@@ -377,6 +382,7 @@ partial class BlackMageRotation
     static partial void ModifyAmplifierPvE(ref ActionSetting setting)
     {
         setting.ActionCheck = () => (InAstralFire || InUmbralIce) && !EnochianEndAfter(10) && !IsPolyglotStacksMaxed;
+        setting.IsFriendly = true;
     }
 
     static partial void ModifyParadoxPvE(ref ActionSetting setting)

--- a/RotationSolver.Basic/Rotations/Basic/DancerRotation.cs
+++ b/RotationSolver.Basic/Rotations/Basic/DancerRotation.cs
@@ -95,6 +95,7 @@ partial class DancerRotation
         {
             AoeCount = 1,
         };
+        setting.IsFriendly = true;
     }
 
     static partial void ModifyShieldSambaPvE(ref ActionSetting setting)
@@ -249,12 +250,18 @@ partial class DancerRotation
         setting.ActionCheck = () => !IsDancing && !AllianceMembers.Any(b => b.HasStatus(true, StatusID.ClosedPosition_2026));
     }
 
+    static partial void ModifyEndingPvE(ref ActionSetting setting)
+    {
+        setting.IsFriendly = true;
+    }
+
     static partial void ModifyDevilmentPvE(ref ActionSetting setting)
     {
         setting.CreateConfig = () => new ActionConfig()
         {
             TimeToKill = 10,
         };
+        setting.IsFriendly = true;
     }
 
     static partial void ModifyFlourishPvE(ref ActionSetting setting)
@@ -262,6 +269,7 @@ partial class DancerRotation
         setting.StatusNeed = [StatusID.StandardFinish];
         setting.StatusProvide = [StatusID.ThreefoldFanDance, StatusID.FourfoldFanDance, StatusID.FinishingMoveReady];
         setting.ActionCheck = () => InCombat;
+        setting.IsFriendly = true;
     }
 
     static partial void ModifyTechnicalStepPvE(ref ActionSetting setting)
@@ -305,21 +313,25 @@ partial class DancerRotation
     static partial void ModifyEmboitePvE(ref ActionSetting setting)
     {
         setting.ActionCheck = () => (ActionID)JobGauge.NextStep == ActionID.EmboitePvE;
+        setting.IsFriendly = true;
     }
 
     static partial void ModifyEntrechatPvE(ref ActionSetting setting)
     {
         setting.ActionCheck = () => (ActionID)JobGauge.NextStep == ActionID.EntrechatPvE;
+        setting.IsFriendly = true;
     }
 
     static partial void ModifyJetePvE(ref ActionSetting setting)
     {
         setting.ActionCheck = () => (ActionID)JobGauge.NextStep == ActionID.JetePvE;
+        setting.IsFriendly = true;
     }
 
     static partial void ModifyPirouettePvE(ref ActionSetting setting)
     {
         setting.ActionCheck = () => (ActionID)JobGauge.NextStep == ActionID.PirouettePvE;
+        setting.IsFriendly = true;
     }
 
     static partial void ModifyLastDancePvE(ref ActionSetting setting)

--- a/RotationSolver.Basic/Rotations/Basic/DarkKnightRotation.cs
+++ b/RotationSolver.Basic/Rotations/Basic/DarkKnightRotation.cs
@@ -172,12 +172,12 @@ partial class DarkKnightRotation
 
     static partial void ModifyGritPvE(ref ActionSetting setting)
     {
-
+        setting.IsFriendly = true;
     }
 
     static partial void ModifyReleaseGritPvE(ref ActionSetting setting)
     {
-
+        setting.IsFriendly = true;
     }
 
     static partial void ModifyUnmendPvE(ref ActionSetting setting)
@@ -209,12 +209,14 @@ partial class DarkKnightRotation
             TimeToKill = 10,
         };
         setting.UnlockedByQuestID = 67591;
+        setting.IsFriendly = true;
     }
 
     static partial void ModifyShadowWallPvE(ref ActionSetting setting)
     {
         setting.StatusProvide = StatusHelper.RampartStatus;
         setting.ActionCheck = Player.IsTargetOnSelf;
+        setting.IsFriendly = true;
     }
 
     static partial void ModifyStalwartSoulPvE(ref ActionSetting setting)
@@ -236,6 +238,7 @@ partial class DarkKnightRotation
     static partial void ModifyDarkMindPvE(ref ActionSetting setting)
     {
         setting.StatusProvide = [StatusID.DarkMind];
+        setting.IsFriendly = true;
     }
 
     static partial void ModifyLivingDeadPvE(ref ActionSetting setting)
@@ -244,6 +247,7 @@ partial class DarkKnightRotation
         setting.ActionCheck = () => InCombat;
         setting.TargetType = TargetType.Self;
         setting.UnlockedByQuestID = 67594;
+        setting.IsFriendly = true;
     }
 
     static partial void ModifySaltedEarthPvE(ref ActionSetting setting)
@@ -296,6 +300,7 @@ partial class DarkKnightRotation
         {
             TimeToKill = 10,
         };
+        setting.IsFriendly = true;
     }
 
     static partial void ModifyTheBlackestNightPvE(ref ActionSetting setting)
@@ -303,6 +308,7 @@ partial class DarkKnightRotation
         setting.StatusProvide = [StatusID.BlackestNight];
         setting.ActionCheck = Player.IsTargetOnSelf;
         setting.UnlockedByQuestID = 68455;
+        setting.IsFriendly = true;
     }
 
     static partial void ModifyFloodOfShadowPvE(ref ActionSetting setting)
@@ -329,6 +335,7 @@ partial class DarkKnightRotation
         {
             AoeCount = 1,
         };
+        setting.IsFriendly = true;
     }
 
     static partial void ModifyLivingShadowPvE(ref ActionSetting setting)
@@ -344,6 +351,7 @@ partial class DarkKnightRotation
         {
             AoeCount = 1,
         };
+        setting.IsFriendly = true;
     }
 
     static partial void ModifySaltAndDarknessPvE(ref ActionSetting setting)
@@ -368,6 +376,7 @@ partial class DarkKnightRotation
     static partial void ModifyShadowedVigilPvE(ref ActionSetting setting)
     {
         setting.StatusProvide = StatusHelper.RampartStatus;
+        setting.IsFriendly = true;
     }
 
     static partial void ModifyScarletDeliriumPvE(ref ActionSetting setting)

--- a/RotationSolver.Basic/Rotations/Basic/DragoonRotation.cs
+++ b/RotationSolver.Basic/Rotations/Basic/DragoonRotation.cs
@@ -101,6 +101,7 @@ partial class DragoonRotation
     {
         setting.StatusProvide = [StatusID.LifeSurge];
         setting.ActionCheck = () => !IsLastAbility(ActionID.LifeSurgePvE);
+        setting.IsFriendly = true;
     }
 
     static partial void ModifyPiercingTalonPvE(ref ActionSetting setting)
@@ -132,6 +133,7 @@ partial class DragoonRotation
         };
         setting.StatusProvide = [StatusID.LanceCharge];
         setting.UnlockedByQuestID = 65975;
+        setting.IsFriendly = true;
     }
 
     static partial void ModifyJumpPvE(ref ActionSetting setting)
@@ -144,6 +146,7 @@ partial class DragoonRotation
     {
         setting.UnlockedByQuestID = 66604;
         setting.StatusProvide = [StatusID.EnhancedPiercingTalon];
+        setting.IsFriendly = true;
     }
 
     static partial void ModifyDoomSpikePvE(ref ActionSetting setting)

--- a/RotationSolver.Basic/Rotations/Basic/GunbreakerRotation.cs
+++ b/RotationSolver.Basic/Rotations/Basic/GunbreakerRotation.cs
@@ -158,6 +158,7 @@ partial class GunbreakerRotation
         {
             TimeToKill = 5,
         };
+        setting.IsFriendly = true;
     }
 
     static partial void ModifyBrutalShellPvE(ref ActionSetting setting)
@@ -180,6 +181,16 @@ partial class GunbreakerRotation
     }
 
     private protected sealed override IBaseAction TankStance => RoyalGuardPvE;
+
+    static partial void ModifyRoyalGuardPvE(ref ActionSetting setting)
+    {
+        setting.IsFriendly = true;
+    }
+
+    static partial void ModifyReleaseRoyalGuardPvE(ref ActionSetting setting)
+    {
+        setting.IsFriendly = true;
+    }
 
     static partial void ModifyLightningShotPvE(ref ActionSetting setting)
     {
@@ -220,6 +231,7 @@ partial class GunbreakerRotation
     static partial void ModifyAuroraPvE(ref ActionSetting setting)
     {
         setting.TargetStatusProvide = [StatusID.Aurora];
+        setting.IsFriendly = true;
     }
 
     static partial void ModifySuperbolidePvE(ref ActionSetting setting)
@@ -227,6 +239,7 @@ partial class GunbreakerRotation
         setting.StatusProvide = [StatusID.Superbolide];
         setting.ActionCheck = () => InCombat;
         setting.TargetType = TargetType.Self;
+        setting.IsFriendly = true;
     }
 
     static partial void ModifySonicBreakPvE(ref ActionSetting setting)
@@ -270,6 +283,7 @@ partial class GunbreakerRotation
         {
             AoeCount = 1,
         };
+        setting.IsFriendly = true;
     }
 
     static partial void ModifyHeartOfStonePvE(ref ActionSetting setting)
@@ -326,6 +340,7 @@ partial class GunbreakerRotation
     {
         setting.StatusProvide = [StatusID.CatharsisOfCorundum, StatusID.ClarityOfCorundum];
         setting.ActionCheck = () => Player.IsParty() || Player.IsTargetOnSelf();
+        setting.IsFriendly = true;
     }
 
     static partial void ModifyHypervelocityPvE(ref ActionSetting setting)
@@ -375,8 +390,6 @@ partial class GunbreakerRotation
         {
             AoeCount = 1
         };
-        //setting.ComboIds = [ActionID.ReignOfBeastsPvE];
-        // TODO: Having configs here breaks the rotation, investigate why
     }
 
     static partial void ModifyLionHeartPvE(ref ActionSetting setting)
@@ -386,7 +399,6 @@ partial class GunbreakerRotation
         {
             AoeCount = 1
         };
-        //setting.ComboIds = [ActionID.NobleBloodPvE];
     }
 
     #endregion

--- a/RotationSolver.Basic/Rotations/Basic/MachinistRotation.cs
+++ b/RotationSolver.Basic/Rotations/Basic/MachinistRotation.cs
@@ -164,6 +164,7 @@ partial class MachinistRotation
         {
             TimeToKill = 10,
         };
+        setting.IsFriendly = true;
     }
 
     static partial void ModifyHeatBlastPvE(ref ActionSetting setting)
@@ -285,6 +286,7 @@ partial class MachinistRotation
     {
         setting.StatusProvide = [StatusID.Hypercharged, StatusID.FullMetalMachinist];
         setting.ActionCheck = () => InCombat;
+        setting.IsFriendly = true;
     }
 
     static partial void ModifyBlazingShotPvE(ref ActionSetting setting)

--- a/RotationSolver.Basic/Rotations/Basic/MonkRotation.cs
+++ b/RotationSolver.Basic/Rotations/Basic/MonkRotation.cs
@@ -182,11 +182,13 @@ partial class MonkRotation
     {
         setting.SpecialType = SpecialActionType.MovingForward;
         setting.UnlockedByQuestID = 66598;
+        setting.IsFriendly = false;
     }
 
     static partial void ModifyInspiritedMeditationPvE(ref ActionSetting setting)
     {
         setting.ActionCheck = () => (!InBrotherhood && Chakra < 5 || InBrotherhood && Chakra < 10);
+        setting.IsFriendly = true;
     }
 
     static partial void ModifyHowlingFistPvE(ref ActionSetting setting)
@@ -207,6 +209,7 @@ partial class MonkRotation
             TimeToKill = 10,
             AoeCount = 1,
         };
+        setting.IsFriendly = true;
     }
 
     static partial void ModifyFourpointFuryPvE(ref ActionSetting setting)
@@ -231,17 +234,20 @@ partial class MonkRotation
         setting.ActionCheck = () => BeastChakras.Distinct().Count() == 1 && BeastChakras.Any(chakra => chakra == BeastChakra.None);
         setting.UnlockedByQuestID = 66602;
         setting.StatusProvide = [StatusID.PerfectBalance];
+        setting.IsFriendly = true;
     }
 
     static partial void ModifyFormShiftPvE(ref ActionSetting setting)
     {
         setting.StatusProvide = [StatusID.FormlessFist];
         setting.UnlockedByQuestID = 67563;
+        setting.IsFriendly = true;
     }
 
     static partial void ModifyForbiddenMeditationPvE(ref ActionSetting setting)
     {
         setting.ActionCheck = () => (!InBrotherhood && Chakra < 5 || InBrotherhood && Chakra < 10);
+        setting.IsFriendly = true;
     }
 
     static partial void ModifyTheForbiddenChakraPvE(ref ActionSetting setting)
@@ -322,6 +328,7 @@ partial class MonkRotation
         {
             TimeToKill = 10,
         };
+        setting.IsFriendly = true;
     }
 
     static partial void ModifyBrotherhoodPvE(ref ActionSetting setting)
@@ -342,11 +349,13 @@ partial class MonkRotation
         {
             TimeToKill = 10,
         };
+        setting.IsFriendly = true;
     }
 
     static partial void ModifyEnlightenedMeditationPvE(ref ActionSetting setting)
     {
         setting.ActionCheck = () => (!InBrotherhood && Chakra < 5 || InBrotherhood && Chakra < 10);
+        setting.IsFriendly = true;
     }
 
     static partial void ModifyEnlightenmentPvE(ref ActionSetting setting)

--- a/RotationSolver.Basic/Rotations/Basic/MonkRotation.cs
+++ b/RotationSolver.Basic/Rotations/Basic/MonkRotation.cs
@@ -136,6 +136,7 @@ partial class MonkRotation
     static partial void ModifySteeledMeditationPvE(ref ActionSetting setting)
     {
         setting.ActionCheck = () => (!InBrotherhood && Chakra < 5 || InBrotherhood && Chakra < 10);
+        setting.IsFriendly = true;
     }
 
     static partial void ModifySteelPeakPvE(ref ActionSetting setting)

--- a/RotationSolver.Basic/Rotations/Basic/NinjaRotation.cs
+++ b/RotationSolver.Basic/Rotations/Basic/NinjaRotation.cs
@@ -197,6 +197,7 @@ partial class NinjaRotation
     static partial void ModifyRabbitMediumPvE(ref ActionSetting setting)
     {
         setting.ActionCheck = () => RabbitMediumPvEActive;
+        setting.IsFriendly = true;
     }
 
     static partial void ModifySpinningEdgePvE(ref ActionSetting setting)
@@ -218,6 +219,7 @@ partial class NinjaRotation
     {
         setting.StatusProvide = [StatusID.Hidden];
         setting.ActionCheck = () => !InCombat;
+        setting.IsFriendly = true;
     }
 
     static partial void ModifyThrowingDaggerPvE(ref ActionSetting setting)
@@ -249,6 +251,7 @@ partial class NinjaRotation
     static partial void ModifyTenPvE(ref ActionSetting setting)
     {
         setting.UnlockedByQuestID = 65748;
+        setting.IsFriendly = true;
     }
 
     static partial void ModifyNinjutsuPvE(ref ActionSetting setting)
@@ -259,6 +262,7 @@ partial class NinjaRotation
     static partial void ModifyChiPvE(ref ActionSetting setting)
     {
         setting.UnlockedByQuestID = 65750;
+        setting.IsFriendly = true;
     }
 
     static partial void ModifyDeathBlossomPvE(ref ActionSetting setting)
@@ -283,6 +287,7 @@ partial class NinjaRotation
     static partial void ModifyJinPvE(ref ActionSetting setting)
     {
         setting.UnlockedByQuestID = 65768;
+        setting.IsFriendly = true;
     }
 
     static partial void ModifyKassatsuPvE(ref ActionSetting setting)
@@ -290,6 +295,7 @@ partial class NinjaRotation
         setting.StatusProvide = [StatusID.Kassatsu];
         setting.ActionCheck = () => !Player.HasStatus(true, StatusID.TenChiJin);
         setting.UnlockedByQuestID = 65770;
+        setting.IsFriendly = true;
     }
 
     static partial void ModifyHakkeMujinsatsuPvE(ref ActionSetting setting)
@@ -349,6 +355,7 @@ partial class NinjaRotation
         setting.ActionCheck = () => !HasKassatsu;
         setting.StatusProvide = [StatusID.TenChiJin, StatusID.TenriJindoReady];
         setting.UnlockedByQuestID = 68488;
+        setting.IsFriendly = true;
     }
 
     static partial void ModifyMeisuiPvE(ref ActionSetting setting)
@@ -356,6 +363,7 @@ partial class NinjaRotation
         setting.StatusNeed = [StatusID.ShadowWalker];
         setting.StatusProvide = [StatusID.Meisui];
         setting.ActionCheck = () => !HasKassatsu && InCombat && !HasTenChiJin;
+        setting.IsFriendly = true;
     }
 
     static partial void ModifyBunshinPvE(ref ActionSetting setting)

--- a/RotationSolver.Basic/Rotations/Basic/PaladinRotation.cs
+++ b/RotationSolver.Basic/Rotations/Basic/PaladinRotation.cs
@@ -127,6 +127,7 @@ partial class PaladinRotation
         {
             TimeToKill = 0,
         };
+        setting.IsFriendly = true;
     }
 
     static partial void ModifyRiotBladePvE(ref ActionSetting setting)
@@ -185,6 +186,7 @@ partial class PaladinRotation
     static partial void ModifySentinelPvE(ref ActionSetting setting)
     {
         setting.TargetType = TargetType.Self;
+        setting.IsFriendly = true;
     }
 
     static partial void ModifyProminencePvE(ref ActionSetting setting)
@@ -205,6 +207,7 @@ partial class PaladinRotation
         setting.ActionCheck = () => OathGauge >= 50;
         setting.UnlockedByQuestID = 66595;
         setting.TargetType = TargetType.BeAttacked;
+        setting.IsFriendly = true;
     }
 
     static partial void ModifyCircleOfScornPvE(ref ActionSetting setting)
@@ -222,11 +225,13 @@ partial class PaladinRotation
         setting.StatusProvide = [StatusID.HallowedGround];
         setting.UnlockedByQuestID = 66596;
         setting.ActionCheck = () => InCombat;
+        setting.IsFriendly = true;
     }
 
     static partial void ModifyBulwarkPvE(ref ActionSetting setting)
     {
         setting.StatusProvide = [StatusID.Bulwark];
+        setting.IsFriendly = true;
     }
 
     static partial void ModifyGoringBladePvE(ref ActionSetting setting)
@@ -239,6 +244,7 @@ partial class PaladinRotation
     {
         setting.UnlockedByQuestID = 67571;
         setting.StatusProvide = [StatusID.DivineVeil_1362];
+        setting.IsFriendly = true;
     }
 
     static partial void ModifyClemencyPvE(ref ActionSetting setting)
@@ -249,6 +255,7 @@ partial class PaladinRotation
             if (t.HasStatus(false, StatusHelper.TankStanceStatus)) return false;
             return true;
         };
+        setting.IsFriendly = true;
     }
 
     static partial void ModifyRoyalAuthorityPvE(ref ActionSetting setting)
@@ -282,6 +289,7 @@ partial class PaladinRotation
     {
         setting.StatusProvide = [StatusID.PassageOfArms];
         setting.UnlockedByQuestID = 68111;
+        setting.IsFriendly = true;
     }
 
     static partial void ModifyHolyCirclePvE(ref ActionSetting setting)
@@ -323,6 +331,7 @@ partial class PaladinRotation
         setting.StatusProvide = [StatusID.HolySheltron];
         setting.UnlockedByQuestID = 66592;
         setting.TargetType = TargetType.Self;
+        setting.IsFriendly = true;
     }
 
     static partial void ModifyExpiacionPvE(ref ActionSetting setting)
@@ -364,6 +373,7 @@ partial class PaladinRotation
     {
         setting.StatusProvide = StatusHelper.RampartStatus;
         setting.TargetType = TargetType.Self;
+        setting.IsFriendly = true;
     }
 
     static partial void ModifyImperatorPvE(ref ActionSetting setting)

--- a/RotationSolver.Basic/Rotations/Basic/PaladinRotation.cs
+++ b/RotationSolver.Basic/Rotations/Basic/PaladinRotation.cs
@@ -115,6 +115,17 @@ partial class PaladinRotation
 
     private protected sealed override IBaseAction TankStance => IronWillPvE;
     #region PvE
+
+    static partial void ModifyIronWillPvE(ref ActionSetting setting)
+    {
+        setting.IsFriendly = true;
+    }
+
+    static partial void ModifyReleaseIronWillPvE(ref ActionSetting setting)
+    {
+        setting.IsFriendly = true;
+    }
+
     static partial void ModifyFastBladePvE(ref ActionSetting setting)
     {
 

--- a/RotationSolver.Basic/Rotations/Basic/PictomancerRotation.cs
+++ b/RotationSolver.Basic/Rotations/Basic/PictomancerRotation.cs
@@ -394,6 +394,7 @@ public partial class PictomancerRotation
     static partial void ModifySmudgePvE(ref ActionSetting setting)
     {
         setting.SpecialType = SpecialActionType.MovingForward;
+        setting.IsFriendly = true;
     }
 
     static partial void ModifyFireIiInRedPvE(ref ActionSetting setting)

--- a/RotationSolver.Basic/Rotations/Basic/ReaperRotation.cs
+++ b/RotationSolver.Basic/Rotations/Basic/ReaperRotation.cs
@@ -209,11 +209,13 @@ partial class ReaperRotation
     static partial void ModifyHellsIngressPvE(ref ActionSetting setting)
     {
         setting.StatusProvide = [StatusID.EnhancedHarpe, StatusID.Bind];
+        setting.IsFriendly = true;
     }
 
     static partial void ModifyHellsEgressPvE(ref ActionSetting setting)
     {
         setting.StatusProvide = [StatusID.EnhancedHarpe, StatusID.Bind];
+        setting.IsFriendly = true;
     }
 
     static partial void ModifySpinningScythePvE(ref ActionSetting setting)
@@ -309,6 +311,7 @@ partial class ReaperRotation
     {
         setting.StatusProvide = [StatusID.Soulsow];
         setting.ActionCheck = () => !InCombat;
+        setting.IsFriendly = true;
     }
 
     static partial void ModifyPlentifulHarvestPvE(ref ActionSetting setting)
@@ -339,6 +342,7 @@ partial class ReaperRotation
     static partial void ModifyRegressPvE(ref ActionSetting setting)
     {
         setting.ActionCheck = () => RegressPvEIngressReady || RegressPvEEgressReady;
+        setting.IsFriendly = true;
     }
 
     static partial void ModifyVoidReapingPvE(ref ActionSetting setting)

--- a/RotationSolver.Basic/Rotations/Basic/RedMageRotation.cs
+++ b/RotationSolver.Basic/Rotations/Basic/RedMageRotation.cs
@@ -172,6 +172,7 @@ partial class RedMageRotation
             TimeToKill = 10,
         };
         setting.UnlockedByQuestID = 68118;
+        setting.IsFriendly = true;
     }
 
     static partial void ModifyCorpsacorpsPvE(ref ActionSetting setting)

--- a/RotationSolver.Basic/Rotations/Basic/SageRotation.cs
+++ b/RotationSolver.Basic/Rotations/Basic/SageRotation.cs
@@ -78,6 +78,7 @@ partial class SageRotation
         {
             TimeToKill = 0,
         };
+        setting.IsFriendly = true;
     }
 
     static partial void ModifyPrognosisPvE(ref ActionSetting setting)
@@ -115,6 +116,7 @@ partial class SageRotation
     {
         setting.ActionCheck = () => !HasEukrasia;
         setting.StatusProvide = [StatusID.Eukrasia];
+        setting.IsFriendly = true;
     }
 
     static partial void ModifyEukrasianDiagnosisPvE(ref ActionSetting setting)

--- a/RotationSolver.Basic/Rotations/Basic/SamuraiRotation.cs
+++ b/RotationSolver.Basic/Rotations/Basic/SamuraiRotation.cs
@@ -170,7 +170,7 @@ partial class SamuraiRotation
     static partial void ModifyJinpuPvE(ref ActionSetting setting)
     {
         setting.ActionCheck = () => Kenki <= 95;
-        setting.ComboIds = new[] { ActionID.HakazePvE, ActionID.GyofuPvE };
+        setting.ComboIds = [ActionID.HakazePvE, ActionID.GyofuPvE];
     }
 
     static partial void ModifyEnpiPvE(ref ActionSetting setting)
@@ -180,13 +180,14 @@ partial class SamuraiRotation
 
     static partial void ModifyThirdEyePvE(ref ActionSetting setting)
     {
-        setting.StatusProvide = new[] { StatusID.ThirdEye };
+        setting.StatusProvide = [StatusID.ThirdEye];
+        setting.IsFriendly = true;
     }
 
     static partial void ModifyShifuPvE(ref ActionSetting setting)
     {
         setting.ActionCheck = () => Kenki <= 95;
-        setting.ComboIds = new[] { ActionID.HakazePvE, ActionID.GyofuPvE };
+        setting.ComboIds = [ActionID.HakazePvE, ActionID.GyofuPvE];
     }
 
     static partial void ModifyFugaPvE(ref ActionSetting setting)
@@ -200,7 +201,7 @@ partial class SamuraiRotation
 
     static partial void ModifyGekkoPvE(ref ActionSetting setting)
     {
-        setting.ComboIds = new[] { ActionID.JinpuPvE };
+        setting.ComboIds = [ActionID.JinpuPvE];
         setting.ActionCheck = () => Kenki <= 90;
     }
 
@@ -211,7 +212,7 @@ partial class SamuraiRotation
 
     static partial void ModifyMangetsuPvE(ref ActionSetting setting)
     {
-        setting.ComboIds = new[] { ActionID.FukoPvE };
+        setting.ComboIds = [ActionID.FukoPvE];
         setting.ActionCheck = () => Kenki <= 90;
         setting.CreateConfig = () => new ActionConfig()
         {
@@ -222,12 +223,12 @@ partial class SamuraiRotation
     static partial void ModifyKashaPvE(ref ActionSetting setting)
     {
         setting.ActionCheck = () => Kenki <= 90;
-        setting.ComboIds = new[] { ActionID.ShifuPvE };
+        setting.ComboIds = [ActionID.ShifuPvE];
     }
 
     static partial void ModifyOkaPvE(ref ActionSetting setting)
     {
-        setting.ComboIds = new[] { ActionID.FukoPvE };
+        setting.ComboIds = [ActionID.FukoPvE];
         setting.ActionCheck = () => Kenki <= 90;
         setting.CreateConfig = () => new ActionConfig()
         {
@@ -237,17 +238,18 @@ partial class SamuraiRotation
 
     static partial void ModifyYukikazePvE(ref ActionSetting setting)
     {
-        setting.ComboIds = new[] { ActionID.HakazePvE, ActionID.GyofuPvE };
+        setting.ComboIds = [ActionID.HakazePvE, ActionID.GyofuPvE];
         setting.ActionCheck = () => Kenki <= 85;
     }
 
     static partial void ModifyMeikyoShisuiPvE(ref ActionSetting setting)
     {
-        setting.StatusProvide = new[] { StatusID.MeikyoShisui, StatusID.Tendo };
+        setting.StatusProvide = [StatusID.MeikyoShisui, StatusID.Tendo];
         setting.CreateConfig = () => new ActionConfig()
         {
             TimeToKill = 0,
         };
+        setting.IsFriendly = true;
     }
 
     static partial void ModifyHissatsuShintenPvE(ref ActionSetting setting)
@@ -274,6 +276,7 @@ partial class SamuraiRotation
     {
         setting.UnlockedByQuestID = 68101;
         setting.ActionCheck = () => !IsMoving;
+        setting.IsFriendly = true;
     }
 
     static partial void ModifyHissatsuKyutenPvE(ref ActionSetting setting)
@@ -284,12 +287,14 @@ partial class SamuraiRotation
     static partial void ModifyHagakurePvE(ref ActionSetting setting)
     {
         setting.ActionCheck = () => (SenCount == 1 && Kenki <= 90) || (SenCount == 2 && Kenki <= 80) || (SenCount == 3 && Kenki <= 70);
+        setting.IsFriendly = true;
     }
 
     static partial void ModifyIkishotenPvE(ref ActionSetting setting)
     {
-        setting.StatusProvide = new[] { StatusID.OgiNamikiriReady, StatusID.ZanshinReady };
+        setting.StatusProvide = [StatusID.OgiNamikiriReady, StatusID.ZanshinReady];
         setting.ActionCheck = () => InCombat && Kenki <= 50;
+        setting.IsFriendly = true;
     }
 
     static partial void ModifyHissatsuGurenPvE(ref ActionSetting setting)
@@ -323,7 +328,8 @@ partial class SamuraiRotation
 
     static partial void ModifyTengentsuPvE(ref ActionSetting setting)
     {
-        setting.StatusProvide = new[] { StatusID.Tengentsu };
+        setting.StatusProvide = [StatusID.Tengentsu];
+        setting.IsFriendly = true;
     }
 
     static partial void ModifyFukoPvE(ref ActionSetting setting)
@@ -337,7 +343,7 @@ partial class SamuraiRotation
 
     static partial void ModifyOgiNamikiriPvE(ref ActionSetting setting)
     {
-        setting.StatusNeed = new[] { StatusID.OgiNamikiriReady };
+        setting.StatusNeed = [StatusID.OgiNamikiriReady];
         setting.ActionCheck = () => MeditationStacks <= 2;
         setting.CreateConfig = () => new ActionConfig()
         {
@@ -352,7 +358,7 @@ partial class SamuraiRotation
 
     static partial void ModifyZanshinPvE(ref ActionSetting setting)
     {
-        setting.StatusNeed = new[] { StatusID.ZanshinReady_3855 };
+        setting.StatusNeed = [StatusID.ZanshinReady_3855];
         setting.ActionCheck = () => Kenki >= 50;
         setting.CreateConfig = () => new ActionConfig()
         {
@@ -365,7 +371,7 @@ partial class SamuraiRotation
     static partial void ModifyHiganbanaPvE(ref ActionSetting setting)
     {
         setting.ActionCheck = () => HiganbanaReady;
-        setting.TargetStatusProvide = new[] { StatusID.Higanbana };
+        setting.TargetStatusProvide = [StatusID.Higanbana];
         setting.CreateConfig = () => new ActionConfig()
         {
             TimeToKill = 48,
@@ -400,7 +406,7 @@ partial class SamuraiRotation
     static partial void ModifyKaeshiSetsugekkaPvE(ref ActionSetting setting)
     {
         setting.ActionCheck = () => KaeshiSetsugekkaReady;
-        setting.StatusNeed = new[] { StatusID.Tsubamegaeshi };
+        setting.StatusNeed = [StatusID.Tsubamegaeshi];
     }
 
     static partial void ModifyKaeshiNamikiriPvE(ref ActionSetting setting)
@@ -425,8 +431,8 @@ partial class SamuraiRotation
     static partial void ModifyTendoSetsugekkaPvE(ref ActionSetting setting)
     {
         setting.ActionCheck = () => TendoSetsugekkaReady;
-        setting.StatusProvide = new[] { StatusID.Tsubamegaeshi };
-        setting.StatusNeed = new[] { StatusID.Tendo };
+        setting.StatusProvide = [StatusID.Tsubamegaeshi];
+        setting.StatusNeed = [StatusID.Tendo];
     }
 
     static partial void ModifyTendoKaeshiGokenPvE(ref ActionSetting setting)
@@ -442,7 +448,7 @@ partial class SamuraiRotation
     static partial void ModifyTendoKaeshiSetsugekkaPvE(ref ActionSetting setting)
     {
         setting.ActionCheck = () => TendoKaeshiSetsugekkaReady;
-        setting.StatusNeed = new[] { StatusID.Tsubamegaeshi_4218 };
+        setting.StatusNeed = [StatusID.Tsubamegaeshi_4218];
     }
 
     #endregion

--- a/RotationSolver.Basic/Rotations/Basic/ScholarRotation.cs
+++ b/RotationSolver.Basic/Rotations/Basic/ScholarRotation.cs
@@ -73,6 +73,7 @@ partial class ScholarRotation
     static partial void ModifySummonEosPvE(ref ActionSetting setting)
     {
         setting.ActionCheck = () => !DataCenter.HasPet && !Player.HasStatus(true, StatusID.Dissipation);
+        setting.IsFriendly = true;
     }
 
     static partial void ModifyResurrectionPvE(ref ActionSetting setting)
@@ -233,6 +234,7 @@ partial class ScholarRotation
         {
             TimeToKill = 10,
         };
+        setting.IsFriendly = true;
     }
 
     static partial void ModifyAetherpactPvE(ref ActionSetting setting)

--- a/RotationSolver.Basic/Rotations/Basic/SummonerRotation.cs
+++ b/RotationSolver.Basic/Rotations/Basic/SummonerRotation.cs
@@ -288,6 +288,7 @@ partial class SummonerRotation
     static partial void ModifyRadiantAegisPvE(ref ActionSetting setting)
     {
         setting.ActionCheck = () => HasSummon;
+        setting.IsFriendly = true;
     }
 
     static partial void ModifyPhysickPvE(ref ActionSetting setting)

--- a/RotationSolver.Basic/Rotations/Basic/WarriorRotation.cs
+++ b/RotationSolver.Basic/Rotations/Basic/WarriorRotation.cs
@@ -103,6 +103,7 @@ partial class WarriorRotation
         {
             TimeToKill = 0,
         };
+        setting.IsFriendly = true;
     }
 
     static partial void ModifyOverpowerPvE(ref ActionSetting setting)
@@ -115,12 +116,12 @@ partial class WarriorRotation
 
     static partial void ModifyDefiancePvE(ref ActionSetting setting)
     {
-
+        setting.IsFriendly = true;
     }
 
     static partial void ModifyReleaseDefiancePvE(ref ActionSetting setting)
     {
-
+        setting.IsFriendly = true;
     }
 
     static partial void ModifyTomahawkPvE(ref ActionSetting setting)
@@ -139,6 +140,7 @@ partial class WarriorRotation
     {
         setting.StatusProvide = [StatusID.ThrillOfBattle];
         setting.UnlockedByQuestID = 65855;
+        setting.IsFriendly = true;
     }
 
     static partial void ModifyInnerBeastPvE(ref ActionSetting setting)
@@ -151,6 +153,7 @@ partial class WarriorRotation
     {
         setting.StatusProvide = StatusHelper.RampartStatus;
         setting.ActionCheck = Player.IsTargetOnSelf;
+        setting.IsFriendly = true;
     }
 
     static partial void ModifyMythrilTempestPvE(ref ActionSetting setting)
@@ -169,6 +172,7 @@ partial class WarriorRotation
         setting.StatusProvide = [StatusID.Holmgang_409];
         setting.TargetType = TargetType.Self;
         setting.ActionCheck = () => InCombat;
+        setting.IsFriendly = true;
     }
 
     static partial void ModifySteelCyclonePvE(ref ActionSetting setting)
@@ -200,6 +204,7 @@ partial class WarriorRotation
             TimeToKill = 0,
         };
         setting.UnlockedByQuestID = 66590;
+        setting.IsFriendly = true;
     }
 
     static partial void ModifyFellCleavePvE(ref ActionSetting setting)
@@ -214,6 +219,7 @@ partial class WarriorRotation
         setting.ActionCheck = Player.IsTargetOnSelf;
         setting.StatusProvide = [StatusID.RawIntuition];
         setting.UnlockedByQuestID = 66132;
+        setting.IsFriendly = true;
     }
 
     static partial void ModifyEquilibriumPvE(ref ActionSetting setting)
@@ -221,6 +227,7 @@ partial class WarriorRotation
         setting.UnlockedByQuestID = 66134;
         setting.ActionCheck = Player.IsTargetOnSelf;
         setting.StatusProvide = [StatusID.Equilibrium];
+        setting.IsFriendly = true;
     }
 
     static partial void ModifyDecimatePvE(ref ActionSetting setting)
@@ -251,6 +258,7 @@ partial class WarriorRotation
         {
             AoeCount = 1,
         };
+        setting.IsFriendly = true;
     }
 
     static partial void ModifyInnerReleasePvE(ref ActionSetting setting)
@@ -261,6 +269,7 @@ partial class WarriorRotation
         };
         setting.UnlockedByQuestID = 68440;
         setting.StatusProvide = [StatusID.InnerRelease, StatusID.PrimalRendReady, StatusID.InnerStrength];
+        setting.IsFriendly = true;
     }
 
     static partial void ModifyNascentFlashPvE(ref ActionSetting setting)
@@ -273,6 +282,7 @@ partial class WarriorRotation
     static partial void ModifyBloodwhettingPvE(ref ActionSetting setting)
     {
         setting.StatusProvide = [StatusID.StemTheTide, StatusID.StemTheFlow];
+        setting.IsFriendly = true;
     }
 
     static partial void ModifyOrogenyPvE(ref ActionSetting setting)

--- a/RotationSolver.Basic/Rotations/Basic/WhiteMageRotation.cs
+++ b/RotationSolver.Basic/Rotations/Basic/WhiteMageRotation.cs
@@ -143,6 +143,7 @@ partial class WhiteMageRotation
         };
         setting.UnlockedByQuestID = 66615;
         setting.StatusProvide = [StatusID.SacredSight];
+        setting.IsFriendly = true;
     }
 
     static partial void ModifyRegenPvE(ref ActionSetting setting)
@@ -167,6 +168,7 @@ partial class WhiteMageRotation
     static partial void ModifyAetherialShiftPvE(ref ActionSetting setting)
     {
         setting.SpecialType = SpecialActionType.MovingForward;
+        setting.IsFriendly = true;
     }
 
     static partial void ModifyHolyPvE(ref ActionSetting setting)
@@ -234,6 +236,7 @@ partial class WhiteMageRotation
     {
         setting.UnlockedByQuestID = 67259;
         setting.StatusProvide = [StatusID.ThinAir];
+        setting.IsFriendly = true;
     }
 
     static partial void ModifyTetragrammatonPvE(ref ActionSetting setting)
@@ -296,6 +299,7 @@ partial class WhiteMageRotation
     static partial void ModifyTemperancePvE(ref ActionSetting setting)
     {
         setting.StatusProvide = [StatusID.Temperance, StatusID.DivineGrace];
+        setting.IsFriendly = true;
     }
 
     static partial void ModifyGlareIiiPvE(ref ActionSetting setting)


### PR DESCRIPTION
Systematic review of all action categorizations in PvE base rotations to better organize them in the Actions config window. Also, some slight comment cleanup.

I also exorcised the ghost of redundant type declaration from Samurai that must've overcome LTS in a fit of manic 3am coding.