### PR TITLE
ActionTargetInfo.cs: "CastType is not valid!"

### DIFF
--- a/RotationSolver.Basic/Actions/ActionTargetInfo.cs
+++ b/RotationSolver.Basic/Actions/ActionTargetInfo.cs
@@ -793,7 +793,7 @@ public struct ActionTargetInfo(IBaseAction action)
                 return dis <= EffectRange && dis >= 8;
 
             default:
-                Svc.Log.Debug($"{action.Action.Name.ExtractText}'s CastType is not valid! The value is {action.Action.CastType}");
+                Svc.Log.Debug($"{action.Action.Name.ExtractText().ToString()}'s CastType is not valid! The value is {action.Action.CastType}");
                 return false;
         }
     }


### PR DESCRIPTION
log now properly display the action's name instead of "System Func`1[System.String]'s CastType is not valid..."