### PR TITLE
Enhance action checks and update cautionary messages

### DIFF
--- a/BasicRotations/Tank/DRK_Default.cs
+++ b/BasicRotations/Tank/DRK_Default.cs
@@ -62,7 +62,7 @@ public sealed class DRK_Default : DarkKnightRotation
         if (Player.HasStatus(true, StatusID.BlackestNight)) return false;
 
         //10
-        if (OblationPvE.CanUse(out act, usedUp: true)) return true;
+        if (OblationPvE.CanUse(out act, usedUp: true, skipStatusProvideCheck: false)) return true;
 
         if (TheBlackestNightPvE.CanUse(out act)) return true;
         //20

--- a/RotationSolver.Basic/Rotations/Basic/AstrologianRotation.cs
+++ b/RotationSolver.Basic/Rotations/Basic/AstrologianRotation.cs
@@ -172,7 +172,7 @@ partial class AstrologianRotation
     static partial void ModifyTheArrowPvE(ref ActionSetting setting)
     {
         setting.ActionCheck = () => HasArrow;
-        setting.TargetStatusProvide = [StatusID.TheArrow_3888, StatusID.BrinkOfDeath];
+        setting.TargetStatusProvide = [StatusID.TheArrow_3888];
         setting.TargetType = TargetType.BeAttacked;
         setting.IsFriendly = true;
     }
@@ -180,7 +180,7 @@ partial class AstrologianRotation
     static partial void ModifyTheSpirePvE(ref ActionSetting setting)
     {
         setting.ActionCheck = () => HasSpire;
-        setting.TargetStatusProvide = [StatusID.TheSpire_3892, StatusID.BrinkOfDeath];
+        setting.TargetStatusProvide = [StatusID.TheSpire_3892];
         setting.TargetType = TargetType.BeAttacked;
         setting.IsFriendly = true;
     }
@@ -197,7 +197,7 @@ partial class AstrologianRotation
     static partial void ModifyTheBolePvE(ref ActionSetting setting)
     {
         setting.ActionCheck = () => HasBole;
-        setting.TargetStatusProvide = [StatusID.TheBole_3890, StatusID.BrinkOfDeath];
+        setting.TargetStatusProvide = [StatusID.TheBole_3890];
         setting.TargetType = TargetType.BeAttacked;
         setting.IsFriendly = true;
     }
@@ -205,7 +205,7 @@ partial class AstrologianRotation
     static partial void ModifyTheEwerPvE(ref ActionSetting setting)
     {
         setting.ActionCheck = () => HasEwer;
-        setting.TargetStatusProvide = [StatusID.TheEwer_3891, StatusID.BrinkOfDeath];
+        setting.TargetStatusProvide = [StatusID.TheEwer_3891];
         setting.TargetType = TargetType.BeAttacked;
         setting.IsFriendly = true;
     }

--- a/RotationSolver/UI/RotationConfigWindow.cs
+++ b/RotationSolver/UI/RotationConfigWindow.cs
@@ -232,7 +232,7 @@ public partial class RotationConfigWindow : Window
 
         if (installedCautionaryPlugin.Name != null)
         {
-            cautionText = $"Notice: {installedCautionaryPlugin.Name} has {installedCautionaryPlugin.Features}";
+            cautionText = $"Notice: {installedCautionaryPlugin.Name} settings may cause {installedCautionaryPlugin.Features}";
 
             ImGui.PushTextWrapPos(ImGui.GetCursorPos().X + availableWidth);
             ImGui.PushStyleColor(ImGuiCol.Text, ImGuiColors.DalamudYellow);


### PR DESCRIPTION
- Modified `OblationPvE.CanUse` in `DRK_Default.cs` to include `skipStatusProvideCheck: false`.
- Updated `TargetStatusProvide` in several methods of `AstrologianRotation.cs` to remove `StatusID.BrinkOfDeath`.
- Rephrased cautionary message in `RotationConfigWindow.cs` for clarity on plugin settings.