### PR TITLE
Enhance Thunder spell functionality and update UI messages

### DIFF
--- a/RotationSolver.Basic/Rotations/Basic/BlackMageRotation.cs
+++ b/RotationSolver.Basic/Rotations/Basic/BlackMageRotation.cs
@@ -198,7 +198,7 @@ partial class BlackMageRotation
     static partial void ModifyThunderPvE(ref ActionSetting setting)
     {
         setting.StatusNeed = [StatusID.Thunderhead];
-        setting.TargetStatusProvide = [StatusID.HighThunder_3872, StatusID.Thunder];
+        setting.TargetStatusProvide = [StatusID.HighThunder_3872, StatusID.Thunder, StatusID.HighThunder];
     }
 
     static partial void ModifyBlizzardIiPvE(ref ActionSetting setting)
@@ -225,7 +225,7 @@ partial class BlackMageRotation
     static partial void ModifyThunderIiPvE(ref ActionSetting setting)
     {
         setting.StatusNeed = [StatusID.Thunderhead];
-        setting.TargetStatusProvide = [StatusID.HighThunder_3872];
+        setting.TargetStatusProvide = [StatusID.HighThunder_3872, StatusID.Thunder, StatusID.HighThunder];
     }
 
     static partial void ModifyManawardPvE(ref ActionSetting setting)
@@ -272,7 +272,7 @@ partial class BlackMageRotation
 
     static partial void ModifyThunderIiiPvE(ref ActionSetting setting)
     {
-        setting.TargetStatusProvide = [StatusID.HighThunder_3872, StatusID.Thunder];
+        setting.TargetStatusProvide = [StatusID.HighThunder_3872, StatusID.Thunder, StatusID.HighThunder];
         setting.StatusNeed = [StatusID.Thunderhead];
         setting.UnlockedByQuestID = 66612;
     }
@@ -329,7 +329,7 @@ partial class BlackMageRotation
 
     static partial void ModifyThunderIvPvE(ref ActionSetting setting)
     {
-        setting.TargetStatusProvide = [StatusID.HighThunder_3872, StatusID.Thunder];
+        setting.TargetStatusProvide = [StatusID.HighThunder_3872, StatusID.Thunder, StatusID.HighThunder];
         setting.StatusNeed = [StatusID.Thunderhead];
         setting.CreateConfig = () => new ActionConfig()
         {
@@ -394,13 +394,13 @@ partial class BlackMageRotation
     static partial void ModifyHighThunderPvE(ref ActionSetting setting)
     {
         setting.StatusNeed = [StatusID.Thunderhead];
-        setting.TargetStatusProvide = [StatusID.HighThunder_3872, StatusID.Thunder];
+        setting.TargetStatusProvide = [StatusID.HighThunder_3872, StatusID.Thunder, StatusID.HighThunder];
     }
 
     static partial void ModifyHighThunderIiPvE(ref ActionSetting setting)
     {
         setting.StatusNeed = [StatusID.Thunderhead];
-        setting.TargetStatusProvide = [StatusID.HighThunder_3872, StatusID.Thunder];
+        setting.TargetStatusProvide = [StatusID.HighThunder_3872, StatusID.Thunder, StatusID.HighThunder];
         setting.CreateConfig = () => new ActionConfig()
         {
             AoeCount = 3,

--- a/RotationSolver/UI/RotationConfigWindow.cs
+++ b/RotationSolver/UI/RotationConfigWindow.cs
@@ -170,12 +170,12 @@ public partial class RotationConfigWindow : Window
     private void DrawErrorZone()
     {
         var errorText = "No internal errors.";
-        string cautionText;
+        //string cautionText;
         float availableWidth = ImGui.GetContentRegionAvail().X; // Get the available width dynamically
 
         var incompatiblePlugins = DownloadHelper.IncompatiblePlugins ?? Array.Empty<IncompatiblePlugin>();
         var installedIncompatiblePlugin = incompatiblePlugins.FirstOrDefault(p => p.IsInstalled && (int)p.Type == 5);
-        var installedCautionaryPlugin = incompatiblePlugins.FirstOrDefault(p => p.IsInstalled && (int)p.Type != 5);
+        //var installedCautionaryPlugin = incompatiblePlugins.FirstOrDefault(p => p.IsInstalled && (int)p.Type != 5);
 
         if (installedIncompatiblePlugin.Name != null)
         {
@@ -230,16 +230,16 @@ public partial class RotationConfigWindow : Window
             ImGui.PopTextWrapPos(); // Reset text wrapping position
         }
 
-        if (installedCautionaryPlugin.Name != null)
-        {
-            cautionText = $"Notice: {installedCautionaryPlugin.Name} settings may cause {installedCautionaryPlugin.Features}";
+        //if (installedCautionaryPlugin.Name != null)
+        //{
+        //    cautionText = $"Notice: {installedCautionaryPlugin.Name} settings may cause {installedCautionaryPlugin.Features}";
 
-            ImGui.PushTextWrapPos(ImGui.GetCursorPos().X + availableWidth);
-            ImGui.PushStyleColor(ImGuiCol.Text, ImGuiColors.DalamudYellow);
-            ImGui.Text(cautionText);
-            ImGui.PopStyleColor();
-            ImGui.PopTextWrapPos();
-        }
+        //    ImGui.PushTextWrapPos(ImGui.GetCursorPos().X + availableWidth);
+        //    ImGui.PushStyleColor(ImGuiCol.Text, ImGuiColors.DalamudYellow);
+        //    ImGui.Text(cautionText);
+        //    ImGui.PopStyleColor();
+        //    ImGui.PopTextWrapPos();
+        //}
     }
 
     private void DrawSideBar()


### PR DESCRIPTION
Updated `BlackMageRotation.cs` to include `StatusID.HighThunder` in the `TargetStatusProvide` for multiple Thunder-related methods, improving spell effectiveness.

Commented out cautionary plugin message logic in `RotationConfigWindow.cs`, disabling warning displays for plugin settings.