### PR TITLE
PLD FoF Fix, MCH mit during burst, rare crashfix

### DIFF
--- a/BasicRotations/Ranged/MCH_Default.cs
+++ b/BasicRotations/Ranged/MCH_Default.cs
@@ -1,6 +1,6 @@
 namespace RebornRotations.Ranged;
 
-[Rotation("Default", CombatType.PvE, GameVersion = "7.15")]
+[Rotation("Default", CombatType.PvE, GameVersion = "7.20")]
 [SourceCode(Path = "main/BasicRotations/Ranged/MCH_Default.cs")]
 [Api(4)]
 public sealed class MCH_Default : MachinistRotation

--- a/BasicRotations/Ranged/MCH_HighEnd.cs
+++ b/BasicRotations/Ranged/MCH_HighEnd.cs
@@ -1,6 +1,6 @@
 namespace RebornRotations.Ranged;
 
-[Rotation("High End", CombatType.PvE, GameVersion = "7.15")]
+[Rotation("High End", CombatType.PvE, GameVersion = "7.20")]
 [SourceCode(Path = "main/BasicRotations/Ranged/MCH_HighEnd.cs")]
 [Api(4)]
 public sealed class MCH_HighEnd : MachinistRotation
@@ -17,6 +17,9 @@ public sealed class MCH_HighEnd : MachinistRotation
 
     [RotationConfig(CombatType.PvE, Name = "Use Bioblaster while moving")]
     private bool BioMove { get; set; } = true;
+
+    [RotationConfig(CombatType.PvE, Name = "Prevent the use of defense abilties during hypercharge burst")]
+    private bool BurstDefense { get; set; } = false;
     #endregion
 
     private const float HYPERCHARGE_DURATION = 8f;
@@ -75,11 +78,12 @@ public sealed class MCH_HighEnd : MachinistRotation
     }
 
     [RotationDesc(ActionID.TacticianPvE, ActionID.DismantlePvE)]
-    protected override bool DefenseAreaAbility(IAction nextGCD, out IAction act)
+    protected override bool DefenseAreaAbility(IAction nextGCD, out IAction? act)
     {
-        if (TacticianPvE.CanUse(out act)) return true;
-        if (DismantlePvE.CanUse(out act)) return true;
-        return false;
+        if ((!BurstDefense || (BurstDefense && !IsOverheated)) && TacticianPvE.CanUse(out act)) return true;
+        if ((!BurstDefense || (BurstDefense && !IsOverheated)) && DismantlePvE.CanUse(out act)) return true;
+
+        return base.DefenseAreaAbility(nextGCD, out act);
     }
 
     // Logic for using attack abilities outside of GCD, focusing on burst windows and cooldown management.

--- a/BasicRotations/Tank/PLD_Default.cs
+++ b/BasicRotations/Tank/PLD_Default.cs
@@ -1,12 +1,15 @@
 ﻿namespace RebornRotations.Tank;
 
-[Rotation("Default", CombatType.PvE, GameVersion = "7.15")]
+[Rotation("Default", CombatType.PvE, GameVersion = "7.20")]
 [SourceCode(Path = "main/BasicRotations/Tank/PLD_Default.cs")]
 [Api(4)]
 
 public sealed class PLD_Default : PaladinRotation
 {
     #region Config Options
+
+    [RotationConfig(CombatType.PvE, Name = "Only use Fight or Flight while in melee range of an enemy")]
+    public bool MeleeFoF { get; set; } = true;
 
     [RotationConfig(CombatType.PvE, Name = "Prevent actions while you have Passage of Arms up")]
     public bool PassageProtec { get; set; } = false;
@@ -82,12 +85,15 @@ public sealed class PLD_Default : PaladinRotation
         if (CoverPvE.CanUse(out act) && CoverPvE.Target.Target?.DistanceToPlayer() < 10 &&
             CoverPvE.Target.Target?.GetHealthRatio() < CoverRatio) return true;
 
-        if (!RiotBladePvE.EnoughLevel && nextGCD.IsTheSameTo(true, FastBladePvE) && FightOrFlightPvE.CanUse(out act)) return true;
-        if (!RageOfHalonePvE.EnoughLevel && nextGCD.IsTheSameTo(true, RiotBladePvE, TotalEclipsePvE) && FightOrFlightPvE.CanUse(out act)) return true;
-        if (!ProminencePvE.EnoughLevel && nextGCD.IsTheSameTo(true, RageOfHalonePvE, TotalEclipsePvE) && FightOrFlightPvE.CanUse(out act)) return true;
-        if (!AtonementPvE.EnoughLevel && nextGCD.IsTheSameTo(true, RoyalAuthorityPvE, ProminencePvE) && FightOrFlightPvE.CanUse(out act)) return true;
-        if (AtonementPvE.EnoughLevel && (Player.HasStatus(true, StatusID.AtonementReady, StatusID.SepulchreReady, StatusID.SupplicationReady, StatusID.DivineMight) || IsLastAction(true, RoyalAuthorityPvE)) && FightOrFlightPvE.CanUse(out act)) return true;
+        if ((HasHostilesInRange && MeleeFoF) || !MeleeFoF)
+        {
+            if (!RiotBladePvE.EnoughLevel && nextGCD.IsTheSameTo(true, FastBladePvE) && FightOrFlightPvE.CanUse(out act)) return true;
+            if (!RageOfHalonePvE.EnoughLevel && nextGCD.IsTheSameTo(true, RiotBladePvE, TotalEclipsePvE) && FightOrFlightPvE.CanUse(out act)) return true;
+            if (!ProminencePvE.EnoughLevel && nextGCD.IsTheSameTo(true, RageOfHalonePvE, TotalEclipsePvE) && FightOrFlightPvE.CanUse(out act)) return true;
+            if (!AtonementPvE.EnoughLevel && nextGCD.IsTheSameTo(true, RoyalAuthorityPvE, ProminencePvE) && FightOrFlightPvE.CanUse(out act)) return true;
+            if (AtonementPvE.EnoughLevel && (Player.HasStatus(true, StatusID.AtonementReady, StatusID.SepulchreReady, StatusID.SupplicationReady, StatusID.DivineMight) || IsLastAction(true, RoyalAuthorityPvE)) && FightOrFlightPvE.CanUse(out act)) return true;
 
+        }
 
         // if requiscat is able to proc confiteor, use it immediately after Fight or Flight
         if (RequiescatMasteryTrait.EnoughLevel)

--- a/RotationSolver.Basic/DataCenter.cs
+++ b/RotationSolver.Basic/DataCenter.cs
@@ -598,7 +598,20 @@ internal static class DataCenter
             var refinedHP = new Dictionary<ulong, float>();
             foreach (var member in PartyMembers)
             {
-                refinedHP[member.GameObjectId] = GetPartyMemberHPRatio(member);
+                try
+                {
+                    if (member == null || member.GameObjectId == 0)
+                    {
+                        continue; // Skip invalid or null members
+                    }
+
+                    refinedHP[member.GameObjectId] = GetPartyMemberHPRatio(member);
+                }
+                catch (AccessViolationException ex)
+                {
+                    Svc.Log.Error($"AccessViolationException in RefinedHP: {ex.Message}");
+                    continue; // Skip problematic members
+                }
             }
             return refinedHP;
         }

--- a/RotationSolver.Basic/Helpers/ObjectHelper.cs
+++ b/RotationSolver.Basic/Helpers/ObjectHelper.cs
@@ -815,6 +815,7 @@ public static class ObjectHelper
     {
         if (g is not IBattleChara b) return 0;
         if (DataCenter.RefinedHP.TryGetValue(b.GameObjectId, out var hp)) return hp;
+        if (b.MaxHp == 0) return 0; // Avoid division by zero
         return (float)b.CurrentHp / b.MaxHp;
     }
 


### PR DESCRIPTION
- Added `BurstDefense` option in `MCH_HighEnd.cs` to control defense abilities during hypercharge.
- Modified `DefenseAreaAbility` method to accept a nullable `act` parameter and updated its logic to use the `BurstDefense` setting.
- Introduced `MeleeFoF` option in `PLD_Default.cs` for Fight or Flight usage based on melee range.
- Enhanced ability-checking logic in `PLD_Default.cs` to consider the `MeleeFoF` setting.
- Added error handling in `DataCenter.cs` for party member health retrieval to skip invalid members and log access violations.
- Implemented division by zero check in `ObjectHelper.cs` when calculating health ratios.