### PR TITLE
SGE, BRD, and DNC fixes

### DIFF
--- a/BasicRotations/Healer/SGE_Default.cs
+++ b/BasicRotations/Healer/SGE_Default.cs
@@ -431,6 +431,9 @@ public sealed class SGE_Default : SageRotation
         act = null;
         if (IsLastAction(ActionID.SwiftcastPvE) && SwiftLogic && MergedStatus.HasFlag(AutoStatus.Raise)) return false;
 
+        if (DoEukrasianPrognosis(out act)) return true;
+        if (DoEukrasianDiagnosis(out act)) return true;
+
         if (PhlegmaPvE.CanUse(out act, usedUp: IsMoving)) return true;
 
         foreach (var member in PartyMembers)
@@ -452,12 +455,7 @@ public sealed class SGE_Default : SageRotation
         if (IsMoving && ToxikonPvE.CanUse(out act)) return true;
 
         if (DoEukrasianDyskrasia(out act)) return true;
-
-        if ((_EukrasiaActionAim == null)
-            && DyskrasiaPvE.CanUse(out act)) return true;
-
-        if (DoEukrasianPrognosis(out act)) return true;
-        if (DoEukrasianDiagnosis(out act)) return true;
+        if (DyskrasiaPvE.CanUse(out act)) return true;
 
         if (DoEukrasianDosis(out act)) return true;
         if (DosisPvE.CanUse(out act)) return true;

--- a/BasicRotations/Limited Jobs/BLU_Basic.cs
+++ b/BasicRotations/Limited Jobs/BLU_Basic.cs
@@ -124,73 +124,6 @@ public sealed class Blue_Basic : BlueMageRotation
 
     #endregion
 
-    /// <summary>
-    ///
-    /// </summary>
-    public enum BluDPSSpell : byte
-    {
-        /// <summary>
-        ///
-        /// </summary>
-        WaterCannon,
-
-        /// <summary>
-        ///
-        /// </summary>
-        SonicBoom,
-
-        /// <summary>
-        ///
-        /// </summary>
-        GoblinPunch,
-    }
-
-    /// <summary>
-    ///
-    /// </summary>
-    public enum BluAOESpell : byte
-    {
-        /// <summary>
-        ///
-        /// </summary>
-        Glower,
-
-        /// <summary>
-        ///
-        /// </summary>
-        FlyingFrenzy,
-
-        /// <summary>
-        ///
-        /// </summary>
-        FlameThrower,
-
-        /// <summary>
-        ///
-        /// </summary>
-        DrillCannons,
-
-        /// <summary>
-        ///
-        /// </summary>
-        Plaincracker,
-
-        /// <summary>
-        ///
-        /// </summary>
-        HighVoltage,
-
-        /// <summary>
-        ///
-        /// </summary>
-        MindBlast,
-
-        /// <summary>
-        ///
-        /// </summary>
-        ThousandNeedles,
-    }
-
     public Blue_Basic()
     {
         BluDPSSpellActions.Add(BluDPSSpell.WaterCannon, WaterCannonPvE);
@@ -208,37 +141,6 @@ public sealed class Blue_Basic : BlueMageRotation
         BluAOESpellActions.Add(BluAOESpell.HighVoltage, HighVoltagePvE);
         BluAOESpellActions.Add(BluAOESpell.MindBlast, MindBlastPvE);
         BluAOESpellActions.Add(BluAOESpell.ThousandNeedles, _1000NeedlesPvE);
-    }
-
-    /// <summary>
-    ///
-    /// </summary>
-    public Dictionary<BluDPSSpell, IBaseAction> BluDPSSpellActions = [];
-
-    /// <summary>
-    ///
-    /// </summary>
-    public Dictionary<BluAOESpell, IBaseAction> BluAOESpellActions = [];
-
-    /// <summary>
-    ///
-    /// </summary>
-    public Dictionary<BluHealSpell, IBaseAction> BluHealSpellActions = [];
-
-    /// <summary>
-    ///
-    /// </summary>
-    public enum BluHealSpell : byte
-    {
-        /// <summary>
-        ///
-        /// </summary>
-        WhiteWind,
-
-        /// <summary>
-        ///
-        /// </summary>
-        AngelsSnack,
     }
 
     #region GCD Logic

--- a/BasicRotations/Ranged/BRD_Default.cs
+++ b/BasicRotations/Ranged/BRD_Default.cs
@@ -1,6 +1,6 @@
 namespace RebornRotations.Ranged;
 
-[Rotation("Default", CombatType.PvE, GameVersion = "7.15",
+[Rotation("Default", CombatType.PvE, GameVersion = "7.20",
     Description = "Please make sure that the three song times add up to 120 seconds, Wanderers default first song for now.")]
 [SourceCode(Path = "main/BasicRotations/Ranged/BRD_Default.cs")]
 [Api(4)]
@@ -32,6 +32,9 @@ public sealed class BRD_Default : BardRotation
 
     [RotationConfig(CombatType.PvE, Name = "Use Warden's Paean on other players")]
     public bool BRDEsuna { get; set; } = true;
+
+    [RotationConfig(CombatType.PvE, Name = "Prevent the use of defense abilties during burst")]
+    private bool BurstDefense { get; set; } = true;
 
     private float WANDRemainTime => 45 - WANDTime;
     private float MAGERemainTime => 45 - MAGETime;
@@ -91,10 +94,10 @@ public sealed class BRD_Default : BardRotation
     }
 
     [RotationDesc(ActionID.TroubadourPvE)]
-    protected override bool DefenseAreaAbility(IAction nextGCD, out IAction act)
+    protected override bool DefenseAreaAbility(IAction nextGCD, out IAction? act)
     {
-        if (TroubadourPvE.CanUse(out act)) return true;
-        return false;
+        if ((!BurstDefense || (BurstDefense && !InBurstStatus)) && TroubadourPvE.CanUse(out act)) return true;
+        return base.DefenseAreaAbility(nextGCD, out act);
     }
 
     protected override bool GeneralAbility(IAction nextGCD, out IAction? act)
@@ -234,8 +237,8 @@ public sealed class BRD_Default : BardRotation
         //aoe
         if (ShadowbitePvE.CanUse(out act)) return true;
         if (WideVolleyPvE.CanUse(out act)) return true;
-        if (LadonsbitePvE.CanUse(out act) && !Player.HasStatus(true, StatusID.HawksEye_3861)) return true;
-        if (QuickNockPvE.CanUse(out act) && !Player.HasStatus(true, StatusID.HawksEye_3861)) return true;
+        if (LadonsbitePvE.CanUse(out act) && !Player.HasStatus(true, StatusID.HawksEye_3861) && !Player.HasStatus(true, StatusID.Barrage)) return true;
+        if (QuickNockPvE.CanUse(out act) && !Player.HasStatus(true, StatusID.HawksEye_3861) && !Player.HasStatus(true, StatusID.Barrage)) return true;
 
         if (IronJawsPvE.EnoughLevel && HostileTarget?.HasStatus(true, StatusID.Windbite, StatusID.Stormbite) == true && HostileTarget?.HasStatus(true, StatusID.VenomousBite, StatusID.CausticBite) == true)
         {
@@ -250,8 +253,8 @@ public sealed class BRD_Default : BardRotation
 
         if (RefulgentArrowPvE.CanUse(out act, skipComboCheck: true)) return true;
         if (StraightShotPvE.CanUse(out act)) return true;
-        if (BurstShotPvE.CanUse(out act) && !Player.HasStatus(true, StatusID.HawksEye_3861)) return true;
-        if (HeavyShotPvE.CanUse(out act) && !Player.HasStatus(true, StatusID.HawksEye_3861)) return true;
+        if (BurstShotPvE.CanUse(out act) && !Player.HasStatus(true, StatusID.HawksEye_3861) && !Player.HasStatus(true, StatusID.Barrage)) return true;
+        if (HeavyShotPvE.CanUse(out act) && !Player.HasStatus(true, StatusID.HawksEye_3861) && !Player.HasStatus(true, StatusID.Barrage)) return true;
 
         return base.GeneralGCD(out act);
     }

--- a/RotationSolver.Basic/Data/CombatType.cs
+++ b/RotationSolver.Basic/Data/CombatType.cs
@@ -32,7 +32,25 @@ public enum CombatType : byte
 /// </summary>
 public enum CombatRole
 {
-    None, Tank, Healer, DPS
+    /// <summary>
+    /// 
+    /// </summary>
+    None,
+
+    /// <summary>
+    /// 
+    /// </summary>
+    Tank,
+
+    /// <summary>
+    /// 
+    /// </summary>
+    Healer,
+
+    /// <summary>
+    /// 
+    /// </summary>
+    DPS
 }
 
 /// <summary>

--- a/RotationSolver.Basic/Rotations/Basic/BlueMageRotation.cs
+++ b/RotationSolver.Basic/Rotations/Basic/BlueMageRotation.cs
@@ -1,6 +1,4 @@
-using ECommons;
 using ECommons.DalamudServices;
-using ECommons.GameFunctions;
 using FFXIVClientStructs.FFXIV.Client.Game;
 using CombatRole = RotationSolver.Basic.Data.CombatRole;
 
@@ -151,6 +149,9 @@ partial class BlueMageRotation
     /// </summary>
     protected abstract IBaseAction[] ActiveActions { get; }
 
+    /// <summary>
+    /// 
+    /// </summary>
     public BlueMageRotation()
     {
         SetBlueMageActions();
@@ -159,7 +160,6 @@ partial class BlueMageRotation
     /// <summary>
     /// Attempts to set the actions for the Blue Mage character.
     /// </summary>
-    /// <param name="actions">An array of actions implementing the <see cref="IBaseAction"/> interface to be set for the Blue Mage. The maximum number of actions is 24.</param>
     /// <returns>Returns <c>true</c> if the actions are successfully set; otherwise, returns <c>false</c>.</returns>
     protected unsafe bool SetBlueMageActions()
     {


### PR DESCRIPTION
- Updated `SGE_Default.cs` to streamline `GeneralGCD` with new checks for Eukrasian abilities and removed redundant checks.
- Refactored `BLU_Basic.cs` by removing unnecessary enums and dictionaries, simplifying the class structure.
- Incremented version number in `BRD_Default.cs` and added a config option to prevent defense abilities during burst phases, modifying `DefenseAreaAbility` accordingly.
- Similar updates in `DNC_Default.cs` with version increment and new config option for burst defense, also adjusting logic for Starfall Dance.
- Cleaned up `BlueMageRotation.cs` by removing unused directives and adding a constructor for better action initialization.