### PR TITLE
Refine Ninjutsu conditions and Dancer ability logic

### DIFF
--- a/BasicRotations/Melee/NIN_Default.cs
+++ b/BasicRotations/Melee/NIN_Default.cs
@@ -213,26 +213,26 @@ public sealed class NIN_Default : NinjaRotation
         {
             // Attempts to set high-damage AoE Ninjutsu if available under Kassatsu's effect.
             // These are prioritized due to Kassatsu's enhancement of Ninjutsu abilities.
-            if (DeathBlossomPvE.CanUse(out _) && GokaMekkyakuPvE.EnoughLevel)
+            if (DeathBlossomPvE.CanUse(out _) && GokaMekkyakuPvE.EnoughLevel && GokaMekkyakuPvE.EnoughLevel)
             {
                 SetNinjutsu(GokaMekkyakuPvE);
             }
-            if (!DeathBlossomPvE.CanUse(out _) && HyoshoRanryuPvE.EnoughLevel)
+            if (!DeathBlossomPvE.CanUse(out _) && HyoshoRanryuPvE.EnoughLevel && HyoshoRanryuPvE.EnoughLevel)
             {
                 SetNinjutsu(HyoshoRanryuPvE);
             }
 
-            if (!IsShadowWalking && ShadowWalkerNeeded && !HyoshoRanryuPvE.EnoughLevel)
+            if (!IsShadowWalking && ShadowWalkerNeeded && !HyoshoRanryuPvE.EnoughLevel && HutonPvE.EnoughLevel)
             {
                 SetNinjutsu(HutonPvE);
             }
 
-            if (DeathBlossomPvE.CanUse(out _) && !HyoshoRanryuPvE.EnoughLevel)
+            if (DeathBlossomPvE.CanUse(out _) && !HyoshoRanryuPvE.EnoughLevel && KatonPvE.EnoughLevel)
             {
                 SetNinjutsu(KatonPvE);
             }
 
-            if (!DeathBlossomPvE.CanUse(out _) && !HyoshoRanryuPvE.EnoughLevel)
+            if (!DeathBlossomPvE.CanUse(out _) && !HyoshoRanryuPvE.EnoughLevel && RaitonPvE.EnoughLevel)
             {
                 SetNinjutsu(RaitonPvE);
             }
@@ -255,11 +255,12 @@ public sealed class NIN_Default : NinjaRotation
             }
 
             //Aoe
-            if (DeathBlossomPvE.CanUse(out _) && KatonPvE.EnoughLevel && TenPvE.CanUse(out _))
+            if (DeathBlossomPvE.CanUse(out _) && TenPvE.CanUse(out _))
             {
-                if (!HasDoton && !IsMoving && !IsLastGCD(true, DotonPvE) && (!TenChiJinPvE.Cooldown.WillHaveOneCharge(6)) || !HasDoton && !TenChiJinPvE.Cooldown.IsCoolingDown)
+                if (!HasDoton && !IsMoving && !IsLastGCD(true, DotonPvE) && (!TenChiJinPvE.Cooldown.WillHaveOneCharge(6)) && DotonPvE.EnoughLevel 
+                    || !HasDoton && !TenChiJinPvE.Cooldown.IsCoolingDown && DotonPvE.EnoughLevel)
                     SetNinjutsu(DotonPvE);
-                else SetNinjutsu(KatonPvE);
+                else if (KatonPvE.EnoughLevel) SetNinjutsu(KatonPvE);
             }
 
             //Single

--- a/BasicRotations/Ranged/DNC_Default.cs
+++ b/BasicRotations/Ranged/DNC_Default.cs
@@ -1,6 +1,6 @@
 namespace RebornRotations.Ranged;
 
-[Rotation("Default", CombatType.PvE, GameVersion = "7.20", Description = "")]
+[Rotation("Default", CombatType.PvE, GameVersion = "7.20")]
 [SourceCode(Path = "main/BasicRotations/Ranged/DNC_Default.cs")]
 [Api(4)]
 public sealed class DNC_Default : DancerRotation
@@ -240,13 +240,11 @@ public sealed class DNC_Default : DancerRotation
         }
 
         if (FinishingMovePvE.CanUse(out act, skipAoeCheck: true)) return true;
-
-        if (Player.WillStatusEndGCD(2, 0, true, StatusID.FlourishingStarfall) && StarfallDancePvE.CanUse(out act, skipAoeCheck: true)) return true;
+        if (Esprit < 100 && StarfallDancePvE.CanUse(out act, skipAoeCheck: true)) return true;
+        if (Player.WillStatusEndGCD(3, 0, true, StatusID.Devilment) && StarfallDancePvE.CanUse(out act, skipAoeCheck: true)) return true;
 
         // Further prioritized GCD abilities
         if ((burst || (Esprit >= 70 && !TechnicalStepPvE.Cooldown.ElapsedAfter(115))) && SaberDancePvE.CanUse(out act, skipAoeCheck: true)) return true;
-
-        if (StarfallDancePvE.CanUse(out act, skipAoeCheck: true)) return true;
 
         bool standardReady = StandardStepPvE.Cooldown.ElapsedAfter(28);
         bool technicalReady = TechnicalStepPvE.Cooldown.ElapsedAfter(118);


### PR DESCRIPTION
Updated NIN_Default.cs to include additional checks for Ninjutsu abilities' `EnoughLevel`, improving clarity and correctness in ability usage.

In DNC_Default.cs, modified conditions for using `StarfallDancePvE` to prioritize based on `Esprit` levels and added checks for the `Devilment` status effect. Removed redundant checks for `StarfallDancePvE` to streamline ability prioritization.

Updated commit hash in ECommons to reflect changes in the subproject's state.