### PR TITLE
Soul Stack tracking, BraveryPvP modification

### DIFF
--- a/BasicRotations/Magical/BLM_Beta
+++ b/BasicRotations/Magical/BLM_Beta
@@ -1,6 +1,6 @@
 ﻿namespace RebornRotations.Magical;
 
-[Rotation("Pending Rework", CombatType.PvE, GameVersion = "7.2")]
+[Rotation("Pending Rework2", CombatType.PvE, GameVersion = "7.2")]
 [SourceCode(Path = "main/BasicRotations/Magical/BLM_Beta.cs")]
 [Api(4)]
 

--- a/BasicRotations/Magical/BLM_Default.cs
+++ b/BasicRotations/Magical/BLM_Default.cs
@@ -118,7 +118,7 @@ public class BLM_Default : BlackMageRotation
                 if (TriplecastPvE.CanUse(out act, usedUp: true)) return true;
             }
 
-            if (UmbralIceStacks < 3 && LucidDreamingPvE.CanUse(out act)) return true;
+            if (UmbralIceStacks < MaxSoulCount && LucidDreamingPvE.CanUse(out act)) return true;
         }
 
         if (InAstralFire)
@@ -185,14 +185,14 @@ public class BLM_Default : BlackMageRotation
     private bool MaintainIce(out IAction? act)
     {
         act = null;
-        if (UmbralIceStacks == 1)
+        if (UmbralIceStacks == 1 && MaxSoulCount == 3)
         {
             if (BlizzardIiPvE.CanUse(out act)) return true;
 
             if (Player.Level == 90 && BlizzardPvE.CanUse(out act)) return true;
             if (BlizzardIiiPvE.CanUse(out act)) return true;
         }
-        if (UmbralIceStacks == 2 && Player.Level < 90)
+        if (UmbralIceStacks == 2 && Player.Level < 90 && MaxSoulCount == 3)
         {
             if (BlizzardIiPvE.CanUse(out act)) return true;
             if (BlizzardPvE.CanUse(out act)) return true;
@@ -207,10 +207,10 @@ public class BLM_Default : BlackMageRotation
         if (IsLastAction(ActionID.UmbralSoulPvE, ActionID.TransposePvE)
             && IsParadoxActive && BlizzardPvE.CanUse(out act)) return true;
 
-        if (UmbralIceStacks == 3 && UsePolyglot(out act)) return true;
+        if (UmbralIceStacks == MaxSoulCount && UsePolyglot(out act)) return true;
 
         //Add Hearts
-        if (UmbralIceStacks == 3 &&
+        if (UmbralIceStacks == MaxSoulCount &&
             BlizzardIvPvE.EnoughLevel && UmbralHearts < 3 && !IsLastGCD
             (ActionID.BlizzardIvPvE, ActionID.FreezePvE))
         {
@@ -237,7 +237,7 @@ public class BLM_Default : BlackMageRotation
         act = null;
 
         //Transpose line
-        if (UmbralIceStacks < 3) return false;
+        if (UmbralIceStacks < MaxSoulCount) return false;
 
         //Need more MP
         if (CurrentMp < 9600) return false;
@@ -386,7 +386,7 @@ public class BLM_Default : BlackMageRotation
         if (UmbralSoulPvE.CanUse(out act)) return true;
         if (InAstralFire && TransposePvE.CanUse(out act)) return true;
         if (UseTransposeForParadox &&
-            InUmbralIce && !IsParadoxActive && UmbralIceStacks == 3
+            InUmbralIce && !IsParadoxActive && UmbralIceStacks == MaxSoulCount
             && TransposePvE.CanUse(out act)) return true;
 
         return false;

--- a/BasicRotations/RebornRotations.csproj
+++ b/BasicRotations/RebornRotations.csproj
@@ -25,7 +25,6 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Duty\EmanationDefault" />
-    <Compile Include="Magical\ICWA_PCT_BETA" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Tank\GNB_Default.cs" />

--- a/RotationSolver.Basic/Rotations/Basic/BlackMageRotation.cs
+++ b/RotationSolver.Basic/Rotations/Basic/BlackMageRotation.cs
@@ -99,6 +99,55 @@ partial class BlackMageRotation
     }
 
     /// <summary>
+    /// Returns the higher value between Astral Fire stacks and Umbral Ice stacks.
+    /// </summary>
+    public static byte SoulStackCount => Math.Max(AstralFireStacks, UmbralIceStacks);
+
+    /// <summary>
+    /// A check with variable max stacks of Polyglot based on the trait level.
+    /// </summary>
+    public static bool IsSoulStacksMaxed
+    {
+        get
+        {
+            if (Player.Level >= 35)
+            {
+                return SoulStackCount == 3;
+            }
+            else if (Player.Level >= 20)
+            {
+                return SoulStackCount == 2;
+            }
+            else
+            {
+                return SoulStackCount == 1;
+            }
+        }
+    }
+
+    /// <summary>
+    /// A check with variable max stacks of Polyglot based on the trait level.
+    /// </summary>
+    public static byte MaxSoulCount
+    {
+        get
+        {
+            if (Player.Level >= 35)
+            {
+                return 3;
+            }
+            else if (Player.Level >= 20)
+            {
+                return 2;
+            }
+            else
+            {
+                return 1;
+            }
+        }
+    }
+
+    /// <summary>
     /// A check with variable max stacks of Polyglot based on the trait level.
     /// </summary>
     public static bool IsPolyglotStacksMaxed
@@ -174,22 +223,28 @@ partial class BlackMageRotation
     /// <inheritdoc/>
     public override void DisplayStatus()
     {
-        ImGui.Text("Is next GCD be instant " + NextGCDisInstant.ToString());
-        ImGui.Text("Can next GCD be instant " + CanMakeInstant.ToString());
-        ImGui.Text("Number of Instant Casts Available " + ThisManyInstantCasts.ToString());
-        ImGui.Text("AstralDefecit " + AstralDefecit.ToString());
+        ImGui.Text("Is next GCD be instant: " + NextGCDisInstant.ToString());
+        ImGui.Text("Can next GCD be instant: " + CanMakeInstant.ToString());
+        ImGui.Text("Number of Instant Casts Available: " + ThisManyInstantCasts.ToString());
+        ImGui.Text("AstralDefecit: " + AstralDefecit.ToString());
         ImGui.Text("HasFire: " + HasFire.ToString());
         ImGui.Text("HasThunder: " + HasThunder.ToString());
+        ImGui.Separator();
+        ImGui.Text("PolyglotStacks: " + PolyglotStacks.ToString());
         ImGui.Text("IsPolyglotStacksMaxed: " + IsPolyglotStacksMaxed.ToString());
+        ImGui.Separator();
+        ImGui.Text("InUmbralIce: " + InUmbralIce.ToString());
+        ImGui.Text("InAstralFire: " + InAstralFire.ToString());
+        ImGui.Separator();
         ImGui.Text("UmbralIceStacks: " + UmbralIceStacks.ToString());
         ImGui.Text("AstralFireStacks: " + AstralFireStacks.ToString());
         ImGui.Text("AstralSoulStacks: " + AstralSoulStacks.ToString());
-        ImGui.Text("PolyglotStacks: " + PolyglotStacks.ToString());
+        ImGui.Text("Soul Stack Count: " + SoulStackCount.ToString());
+        ImGui.Text("Is Soul Stacks Maxed: " + IsSoulStacksMaxed.ToString());
+        ImGui.Text("Max Soul Stacks: " + MaxSoulCount.ToString());
+        ImGui.Separator();
         ImGui.Text("UmbralHearts: " + UmbralHearts.ToString());
         ImGui.Text("IsParadoxActive: " + IsParadoxActive.ToString());
-        ImGui.Text("UmbralIceStacks: " + UmbralIceStacks.ToString());
-        ImGui.Text("InUmbralIce: " + InUmbralIce.ToString());
-        ImGui.Text("InAstralFire: " + InAstralFire.ToString());
         ImGui.Text("IsEnochianActive: " + IsEnochianActive.ToString());
         ImGui.Text("EnochianTimeRaw: " + EnochianTimeRaw.ToString());
         ImGui.Text("EnochianTime: " + EnochianTime.ToString());

--- a/RotationSolver.Basic/Rotations/CustomRotation_Actions.cs
+++ b/RotationSolver.Basic/Rotations/CustomRotation_Actions.cs
@@ -158,7 +158,7 @@ partial class CustomRotation
 
     static partial void ModifyBraveryPvP(ref ActionSetting setting)
     {
-        
+        setting.TargetType = TargetType.Self;
     }
 
     static partial void ModifyEagleEyeShotPvP(ref ActionSetting setting)


### PR DESCRIPTION
Updated `BlackMageRotation.cs` to include checks for maximum soul stacks based on player level. Modified `BLM_Default.cs` to use dynamic references for `UmbralIceStacks`. Updated project file to reflect restructuring and ongoing development in `ECommons`. Set BraveryPvP to self target only.