### PR TITLE
SAM fixes and misc work

### DIFF
--- a/BasicRotations/Melee/SAM_Default.cs
+++ b/BasicRotations/Melee/SAM_Default.cs
@@ -168,7 +168,8 @@ public sealed class SAM_Default : SamuraiRotation
             return false;
         }
 
-        if ((!HiganbanaTargets || (HiganbanaTargets && NumberOfAllHostilesInRange < 2)) && (HostileTarget?.WillStatusEnd(18, true, StatusID.Higanbana) ?? false) && HiganbanaPvE.CanUse(out act, skipStatusProvideCheck: true)) return true;
+        if ((!HiganbanaTargets || (HiganbanaTargets && NumberOfAllHostilesInRange < 2)) && (HostileTarget?.WillStatusEnd(18, true, StatusID.Higanbana) ?? false) && HiganbanaPvE.CanUse(out act, skipStatusProvideCheck: true, skipComboCheck: true)) return true;
+        if (KaeshiNamikiriPvE.CanUse(out act)) return true;
 
         if (NumberOfHostilesInRange >= 3)
         {
@@ -189,23 +190,22 @@ public sealed class SAM_Default : SamuraiRotation
         if (!HagakurePvE.EnoughLevel && NumberOfHostilesInRange >= 3 && MidareSetsugekkaPvE.CanUse(out act)) return true;
 
         if (TendoKaeshiGokenPvE.CanUse(out act)) return true;
-        if (TendoGokenPvE.CanUse(out act)) return true;
-        if (KaeshiGokenPvE.CanUse(out act)) return true;
-        if (TenkaGokenPvE.CanUse(out act)) return true;
+        if (TendoGokenPvE.CanUse(out act, skipComboCheck: true)) return true;
+        if (KaeshiGokenPvE.CanUse(out act, skipComboCheck: true)) return true;
+        if (TenkaGokenPvE.CanUse(out act, skipComboCheck: true)) return true;
 
         // aoe 12 combo's 2
         if ((!HasMoon || IsMoonTimeLessThanFlower || !OkaPvE.EnoughLevel) && MangetsuPvE.CanUse(out act, skipComboCheck: HaveMeikyoShisui && !HasGetsu)) return true;
         if ((!HasFlower || !IsMoonTimeLessThanFlower) && OkaPvE.CanUse(out act, skipComboCheck: HaveMeikyoShisui && !HasKa)) return true;
 
         // initiate aoe
-        if (FukoPvE.CanUse(out act, skipComboCheck: true)) return true;
-        if (!FukoPvE.EnoughLevel && FugaPvE.CanUse(out act, skipComboCheck: true)) return true;
+        if (FukoPvE.CanUse(out act)) return true;
+        if (!FukoPvE.EnoughLevel && FugaPvE.CanUse(out act)) return true;
 
-        if (TendoSetsugekkaPvE.CanUse(out act)) return true;
-        if (MidareSetsugekkaPvE.CanUse(out act)) return true;
+        if (TendoSetsugekkaPvE.CanUse(out act, skipComboCheck: true)) return true;
+        if (MidareSetsugekkaPvE.CanUse(out act, skipComboCheck: true)) return true;
 
         // use 2nd finisher combo spell first
-        if (KaeshiNamikiriPvE.CanUse(out act, usedUp: true)) return true;
         if (!KaeshiNamikiriReady && KaeshiSetsugekkaPvE.CanUse(out act, usedUp: true)) return true;
         if (!KaeshiNamikiriReady && TendoKaeshiSetsugekkaPvE.CanUse(out act, usedUp: true)) return true;
 
@@ -237,7 +237,7 @@ public sealed class SAM_Default : SamuraiRotation
             if (HakazePvE.CanUse(out act)) return true;
 
             // target out of range
-            if (EnpiPvE.CanUse(out act)) return true;
+            if (EnpiPvE.CanUse(out act, skipComboCheck: true)) return true;
         }
 
         return base.GeneralGCD(out act);

--- a/RotationSolver.Basic/RotationSolver.Basic.csproj
+++ b/RotationSolver.Basic/RotationSolver.Basic.csproj
@@ -55,30 +55,30 @@
             <Private>False</Private>
         </Reference>
 
-        <Using Include="System.ComponentModel"/>
-        <Using Include="Dalamud.Game.ClientState.JobGauge.Types"/>
+        <Using Include="System.ComponentModel" />
+        <Using Include="Dalamud.Game.ClientState.JobGauge.Types" />
 
-        <Using Include="Dalamud.Game.ClientState.Objects.Types"/>
+        <Using Include="Dalamud.Game.ClientState.Objects.Types" />
 
-        <Using Include="RotationSolver.Basic"/>
-        <Using Include="RotationSolver.Basic.Actions"/>
-        <Using Include="RotationSolver.Basic.Attributes"/>
-        <Using Include="RotationSolver.Basic.Configuration.RotationConfig"/>
-        <Using Include="RotationSolver.Basic.Data"/>
-        <Using Include="RotationSolver.Basic.Helpers"/>
-        <Using Include="RotationSolver.Basic.Rotations"/>
-        <Using Include="RotationSolver.Basic.Rotations.Basic"/>
-        <Using Include="Dalamud.Game.ClientState.JobGauge.Enums"/>
-        <Using Include="Dalamud.Interface"/>
-        <Using Include="ImGuiNET"/>
-        <Using Include="Newtonsoft.Json"/>
+        <Using Include="RotationSolver.Basic" />
+        <Using Include="RotationSolver.Basic.Actions" />
+        <Using Include="RotationSolver.Basic.Attributes" />
+        <Using Include="RotationSolver.Basic.Configuration.RotationConfig" />
+        <Using Include="RotationSolver.Basic.Data" />
+        <Using Include="RotationSolver.Basic.Helpers" />
+        <Using Include="RotationSolver.Basic.Rotations" />
+        <Using Include="RotationSolver.Basic.Rotations.Basic" />
+        <Using Include="Dalamud.Game.ClientState.JobGauge.Enums" />
+        <Using Include="Dalamud.Interface" />
+        <Using Include="ImGuiNET" />
+        <Using Include="Newtonsoft.Json" />
 
         <ProjectReference Include="..\ECommons\ECommons\ECommons.csproj">
             <PrivateAssets>all</PrivateAssets>
         </ProjectReference>
 
-        <PackageReference Include="System.Drawing.Common" Version="9.0.3"/>
-        <ProjectReference Include="..\RotationSolver.SourceGenerators\RotationSolver.SourceGenerators.csproj" OutputItemType="Analyzer" ExcludeAssets="All"/>
+        <PackageReference Include="System.Drawing.Common" Version="9.0.4" />
+        <ProjectReference Include="..\RotationSolver.SourceGenerators\RotationSolver.SourceGenerators.csproj" OutputItemType="Analyzer" ExcludeAssets="All" />
 
         <None Include="..\COPYING.LESSER">
             <Pack>True</Pack>
@@ -88,7 +88,7 @@
             <Pack>True</Pack>
             <PackagePath>\</PackagePath>
         </None>
-        <PackageReference Include="Svg" Version="3.4.7"/>
+        <PackageReference Include="Svg" Version="3.4.7" />
         <None Update="README.md">
             <Pack>True</Pack>
             <PackagePath>\</PackagePath>

--- a/RotationSolver/RotationSolverPlugin.cs
+++ b/RotationSolver/RotationSolverPlugin.cs
@@ -226,7 +226,7 @@ public sealed class RotationSolverPlugin : IDalamudPlugin, IDisposable
             && !Svc.Condition[ConditionFlag.OccupiedInCutSceneEvent]
             && !Svc.Condition[ConditionFlag.Occupied38] //Treasure hunt.
             && !Svc.Condition[ConditionFlag.WaitingForDuty]
-            && (!Svc.Condition[ConditionFlag.UsingParasol] || Player.Object.StatusFlags.HasFlag(Dalamud.Game.ClientState.Objects.Enums.StatusFlags.WeaponOut))
+            && (!Svc.Condition[ConditionFlag.UsingFashionAccessory] || Player.Object.StatusFlags.HasFlag(Dalamud.Game.ClientState.Objects.Enums.StatusFlags.WeaponOut))
             && !Svc.Condition[ConditionFlag.OccupiedInQuestEvent]);
 
         _nextActionWindow!.IsOpen = isValid && Service.Config.ShowNextActionWindow;


### PR DESCRIPTION
- Modified `SAM_Default.cs` to add `skipComboCheck` to ability checks, correcting logic for some GCDs that dont break combos.
- Added a new check for `KaeshiNamikiriPvE` to enhance ability usage logic.
- Updated subproject commit hash in `ECommons`.
- Reformatted `Using` directives and updated `System.Drawing.Common` package version in `RotationSolver.Basic.csproj`.
- Adjusted conditions in `RotationSolverPlugin.cs` to align with updated name for Conditionflag.