### PR TITLE
Update target references in rotation classes

### DIFF
--- a/BasicRotations/Magical/SMN_Default.cs
+++ b/BasicRotations/Magical/SMN_Default.cs
@@ -74,8 +74,8 @@ public sealed class SMN_Default : SummonerRotation
     #region oGCD Logic
     protected override bool AttackAbility(IAction nextGCD, out IAction? act)
     {
-        bool isTargetBoss = HostileTarget?.IsBossFromTTK() ?? false;
-        bool isTargetDying = HostileTarget?.IsDying() ?? false;
+        bool isTargetBoss = CurrentTarget?.IsBossFromTTK() ?? false;
+        bool isTargetDying = CurrentTarget?.IsDying() ?? false;
         bool targetIsBossAndDying = isTargetBoss && isTargetDying;
         bool inBigInvocation = !SummonBahamutPvE.EnoughLevel || (InBahamut || InPhoenix || InSolarBahamut);
         bool inSolarUnique = Player.Level == 100 ? !InBahamut && !InPhoenix && InSolarBahamut : InBahamut && !InPhoenix;

--- a/BasicRotations/Melee/RPR_Default.cs
+++ b/BasicRotations/Melee/RPR_Default.cs
@@ -33,15 +33,15 @@ public sealed class RPR_Default : ReaperRotation
     #region oGCD Logic
     protected override bool AttackAbility(IAction nextGCD, out IAction? act)
     {
-        bool IsTargetBoss = HostileTarget?.IsBossFromTTK() ?? false;
-        bool IsTargetDying = HostileTarget?.IsDying() ?? false;
+        bool IsTargetBoss = CurrentTarget?.IsBossFromTTK() ?? false;
+        bool IsTargetDying = CurrentTarget?.IsDying() ?? false;
         bool NoEnshroudPooling = !EnshroudPooling && Shroud >= 50;
         bool YesEnshroudPooling = EnshroudPooling && Shroud >= 50 && (!PlentifulHarvestPvE.EnoughLevel || Player.HasStatus(true, StatusID.ArcaneCircle) || ArcaneCirclePvE.Cooldown.WillHaveOneCharge(8) || !Player.HasStatus(true, StatusID.ArcaneCircle) && ArcaneCirclePvE.Cooldown.WillHaveOneCharge(65) && !ArcaneCirclePvE.Cooldown.WillHaveOneCharge(50) || !Player.HasStatus(true, StatusID.ArcaneCircle) && Shroud >= 90);
         bool IsIdealHost = Player.HasStatus(true, StatusID.IdealHost);
 
         if (IsBurst)
         {
-            if ((ArcaneCirclePvE.Target.Target?.HasStatus(true, StatusID.DeathsDesign) ?? false)
+            if ((CurrentTarget?.HasStatus(true, StatusID.DeathsDesign) ?? false)
                 && !CombatElapsedLess(3.5f) && ArcaneCirclePvE.CanUse(out act, skipAoeCheck: true)) return true;
         }
 
@@ -89,7 +89,7 @@ public sealed class RPR_Default : ReaperRotation
         }
 
         if (WhorlOfDeathPvE.CanUse(out act)) return true;
-        if (UseCustomDDTiming && ((!ShadowOfDeathPvE.Target.Target?.HasStatus(true, StatusID.DeathsDesign) ?? false) || (ShadowOfDeathPvE.Target.Target?.WillStatusEnd(RefreshDDSecondsRemaining, true, StatusID.DeathsDesign) ?? false)))
+        if (UseCustomDDTiming && ((!CurrentTarget?.HasStatus(true, StatusID.DeathsDesign) ?? false) || (CurrentTarget?.WillStatusEnd(RefreshDDSecondsRemaining, true, StatusID.DeathsDesign) ?? false)))
         {
             if (ShadowOfDeathPvE.CanUse(out act, skipStatusProvideCheck: true)) return true;
         }

--- a/BasicRotations/Melee/SAM_Default.cs
+++ b/BasicRotations/Melee/SAM_Default.cs
@@ -101,12 +101,12 @@ public sealed class SAM_Default : SamuraiRotation
             return false;
         }
 
-        var isTargetBoss = HostileTarget?.IsBossFromTTK() ?? false;
-        var isTargetDying = HostileTarget?.IsDying() ?? false;
+        var isTargetBoss = CurrentTarget?.IsBossFromTTK() ?? false;
+        var isTargetDying = CurrentTarget?.IsDying() ?? false;
 
         // from old version - didn't touch this, didn't test this, personally i doubt it's working !!! check later !!!
         if (HasHostilesInRange && IsLastGCD(true, YukikazePvE, MangetsuPvE, OkaPvE) &&
-            (!isTargetBoss || (HostileTarget?.HasStatus(true, StatusID.Higanbana) ?? false) && !(HostileTarget?.WillStatusEnd(40, true, StatusID.Higanbana) ?? false) || !HasMoon && !HasFlower || isTargetBoss && isTargetDying))
+            (!isTargetBoss || (CurrentTarget?.HasStatus(true, StatusID.Higanbana) ?? false) && !(CurrentTarget?.WillStatusEnd(40, true, StatusID.Higanbana) ?? false) || !HasMoon && !HasFlower || isTargetBoss && isTargetDying))
         {
             if (MeikyoShisuiPvE.CanUse(out act, usedUp: true)) return true;
         }
@@ -121,8 +121,8 @@ public sealed class SAM_Default : SamuraiRotation
             return false;
         }
 
-        var isTargetBoss = HostileTarget?.IsBossFromTTK() ?? false;
-        var isTargetDying = HostileTarget?.IsDying() ?? false;
+        var isTargetBoss = CurrentTarget?.IsBossFromTTK() ?? false;
+        var isTargetDying = CurrentTarget?.IsDying() ?? false;
 
         // IkishotenPvE logic combined with the delayed opener:
         // you should weave the tincture in manually after rsr lands the first gcd (usually Gekko)
@@ -130,9 +130,9 @@ public sealed class SAM_Default : SamuraiRotation
         if (!CombatElapsedLessGCD(2) && IkishotenPvE.CanUse(out act)) return true;
         if (ShohaPvE.CanUse(out act)) return true;
         // from old version - didn't touch this, didn't test this, never saw Hagakure button pressed personally !!! check later !!!
-        if ((HostileTarget?.HasStatus(true, StatusID.Higanbana) ?? false) &&
-            (HostileTarget?.WillStatusEnd(32, true, StatusID.Higanbana) ?? false) &&
-            !(HostileTarget?.WillStatusEnd(28, true, StatusID.Higanbana) ?? false) &&
+        if ((CurrentTarget?.HasStatus(true, StatusID.Higanbana) ?? false) &&
+            (CurrentTarget?.WillStatusEnd(32, true, StatusID.Higanbana) ?? false) &&
+            !(CurrentTarget?.WillStatusEnd(28, true, StatusID.Higanbana) ?? false) &&
             SenCount == 1 && IsLastAction(true, YukikazePvE) && !HaveMeikyoShisui)
         {
             if (HagakurePvE.CanUse(out act)) return true;
@@ -160,8 +160,8 @@ public sealed class SAM_Default : SamuraiRotation
     protected override bool GeneralGCD(out IAction? act)
     {
         act = null;
-        var isTargetBoss = HostileTarget?.IsBossFromTTK() ?? false;
-        var isTargetDying = HostileTarget?.IsDying() ?? false;
+        var isTargetBoss = CurrentTarget?.IsBossFromTTK() ?? false;
+        var isTargetDying = CurrentTarget?.IsDying() ?? false;
 
         if (EnableTEAChecker && Target.Name.ToString() == "Jagd Doll" && Target.GetHealthRatio() < 0.25)
         {

--- a/BasicRotations/Melee/VPR_Default.cs
+++ b/BasicRotations/Melee/VPR_Default.cs
@@ -139,8 +139,8 @@ public sealed class VPR_Default : ViperRotation
         }
 
         // Uncoiled Fury Overcap protection
-        var isTargetBoss = HostileTarget?.IsBossFromTTK() ?? false;
-        var isTargetDying = HostileTarget?.IsDying() ?? false;
+        var isTargetBoss = CurrentTarget?.IsBossFromTTK() ?? false;
+        var isTargetDying = CurrentTarget?.IsDying() ?? false;
         if ((MaxRattling == RattlingCoilStacks || RattlingCoilStacks >= MaxUncoiledStacksUser || isTargetBoss && isTargetDying && RattlingCoilStacks > 0) && !Player.HasStatus(true, StatusID.ReadyToReawaken) && SerpentCombo == SerpentCombo.None)
         {
             if (UncoiledFuryPvE.CanUse(out act, usedUp: true)) return true;

--- a/BasicRotations/Ranged/BRD_Default.cs
+++ b/BasicRotations/Ranged/BRD_Default.cs
@@ -152,7 +152,7 @@ public sealed class BRD_Default : BardRotation
         {
             if ((!RadiantFinalePvE.EnoughLevel && !RagingStrikesPvE.Cooldown.IsCoolingDown
                     || RadiantFinalePvE.EnoughLevel && !RadiantFinalePvE.Cooldown.IsCoolingDown && RagingStrikesPvE.EnoughLevel && (!RagingStrikesPvE.Cooldown.IsCoolingDown || RagingStrikesPvE.Cooldown.WillHaveOneCharge(BuffAlignment)))
-                    && HostileTarget?.HasStatus(true, StatusID.Windbite, StatusID.Stormbite) == true && HostileTarget?.HasStatus(true, StatusID.VenomousBite, StatusID.CausticBite) == true && BattleVoicePvE.CanUse(out act, isLastAbility: OGCDTimers)) return true;
+                    && CurrentTarget?.HasStatus(true, StatusID.Windbite, StatusID.Stormbite) == true && CurrentTarget?.HasStatus(true, StatusID.VenomousBite, StatusID.CausticBite) == true && BattleVoicePvE.CanUse(out act, isLastAbility: OGCDTimers)) return true;
 
             if (!Player.WillStatusEnd(0, true, StatusID.BattleVoice) && RadiantFinalePvE.CanUse(out act, isFirstAbility: OGCDTimers)) return true;
 
@@ -237,7 +237,7 @@ public sealed class BRD_Default : BardRotation
         {
             if (!Player.HasStatus(true, StatusID.RagingStrikes)) return true;
             if (Player.HasStatus(true, StatusID.RagingStrikes) && BarragePvE.Cooldown.IsCoolingDown) return true;
-            if (HostileTarget?.WillStatusEndGCD(1, 0.5f, true, StatusID.Windbite, StatusID.Stormbite, StatusID.VenomousBite, StatusID.CausticBite) ?? false) return false;
+            if (CurrentTarget?.WillStatusEndGCD(1, 0.5f, true, StatusID.Windbite, StatusID.Stormbite, StatusID.VenomousBite, StatusID.CausticBite) ?? false) return false;
         }
 
         //aoe
@@ -246,7 +246,7 @@ public sealed class BRD_Default : BardRotation
         if (LadonsbitePvE.CanUse(out act) && !Player.HasStatus(true, StatusID.HawksEye_3861) && !Player.HasStatus(true, StatusID.Barrage)) return true;
         if (QuickNockPvE.CanUse(out act) && !Player.HasStatus(true, StatusID.HawksEye_3861) && !Player.HasStatus(true, StatusID.Barrage)) return true;
 
-        if (IronJawsPvE.EnoughLevel && HostileTarget?.HasStatus(true, StatusID.Windbite, StatusID.Stormbite) == true && HostileTarget?.HasStatus(true, StatusID.VenomousBite, StatusID.CausticBite) == true)
+        if (IronJawsPvE.EnoughLevel && CurrentTarget?.HasStatus(true, StatusID.Windbite, StatusID.Stormbite) == true && CurrentTarget?.HasStatus(true, StatusID.VenomousBite, StatusID.CausticBite) == true)
         {
             // Do not use WindbitePvE or VenomousBitePvE if both statuses are present and IronJawsPvE has enough level
         }
@@ -274,7 +274,7 @@ public sealed class BRD_Default : BardRotation
         if (QuickNockPvE.CanUse(out _) && SoulVoice == 100) return true;
         if (LadonsbitePvE.CanUse(out _) && SoulVoice == 100) return true;
 
-        if (HostileTarget?.WillStatusEndGCD(1, 1, true, StatusID.Windbite, StatusID.Stormbite, StatusID.VenomousBite, StatusID.CausticBite) ?? false) return false;
+        if (CurrentTarget?.WillStatusEndGCD(1, 1, true, StatusID.Windbite, StatusID.Stormbite, StatusID.VenomousBite, StatusID.CausticBite) ?? false) return false;
 
         if (Song == Song.Wanderer && SoulVoice >= 80 && !Player.HasStatus(true, StatusID.RagingStrikes)) return false;
 

--- a/RotationSolver.Basic/DataCenter.cs
+++ b/RotationSolver.Basic/DataCenter.cs
@@ -24,10 +24,24 @@ internal static class DataCenter
 
     public static bool IsActivated() => State || IsManual || Service.Config.TeachingMode;
 
+    private static IBattleChara? _cachedHostileTarget;
+
     internal static IBattleChara? HostileTarget
     {
-        get => Svc.Objects.SearchById(_hostileTargetId) as IBattleChara;
-        set => _hostileTargetId = value?.GameObjectId ?? 0;
+        get
+        {
+            if (_cachedHostileTarget?.GameObjectId == _hostileTargetId)
+                return _cachedHostileTarget;
+
+            var target = Svc.Objects.SearchById(_hostileTargetId);
+            _cachedHostileTarget = target as IBattleChara;
+            return _cachedHostileTarget;
+        }
+        set
+        {
+            _hostileTargetId = value?.GameObjectId ?? 0;
+            _cachedHostileTarget = value;
+        }
     }
 
     internal static List<uint> PrioritizedNameIds { get; set; } = new();

--- a/RotationSolver.Basic/Rotations/CustomRotation_OtherInfo.cs
+++ b/RotationSolver.Basic/Rotations/CustomRotation_OtherInfo.cs
@@ -156,7 +156,6 @@ partial class CustomRotation
     /// </summary>
     protected static IBattleChara? HostileTarget => DataCenter.HostileTarget;
 
-
     /// <summary>
     /// Is player in position to hit the positional?
     /// </summary>


### PR DESCRIPTION
Refactor character rotation logic to use `CurrentTarget` instead of `HostileTarget` and `ActionID.Target.Target?.` across multiple classes (SMN_Default, RPR_Default, SAM_Default, BRD_Default). Modify hostiletarget to attempt to mitigate crashes.