### PR TITLE
WHM fixes and rotation config UI fix

### DIFF
--- a/BasicRotations/Healer/WHM_Default.cs
+++ b/BasicRotations/Healer/WHM_Default.cs
@@ -20,8 +20,15 @@ public sealed class WHM_Default : WhiteMageRotation
     [RotationConfig(CombatType.PvE, Name = "Use DOT while moving even if it does not need refresh (disabling is a damage down)")]
     public bool DOTUpkeep { get; set; } = true;
 
-    [RotationConfig(CombatType.PvE, Name = "Use Lily at max stacks.")]
+    [RotationConfig(CombatType.PvE, Name = "Use Lily at max stacks/about to overcap.")]
     public bool UseLilyWhenFull { get; set; } = true;
+
+    [RotationConfig(CombatType.PvE, Name = "Use Lily if about to overcap and no valid target nearby.")]
+    public bool UseLilyDowntime { get; set; } = true;
+
+    [Range(1, 13, ConfigUnitType.None, 1)]
+    [RotationConfig(CombatType.PvE, Name = "Number of GCDs before you cap on blue lillies that overcap protection will consider 'near full'.")]
+    public int LilyOvercapTime { get; set; } = 3;
 
     [RotationConfig(CombatType.PvE, Name = "Regen on Tank at 5 seconds remaining on Prepull Countdown.")]
     public bool UsePreRegen { get; set; } = true;
@@ -211,7 +218,7 @@ public sealed class WHM_Default : WhiteMageRotation
 
         if (AfflatusMiseryPvE.CanUse(out act, skipAoeCheck: true)) return true;
 
-        bool liliesNearlyFull = Lily == 2 && LilyTime > 13;
+        bool liliesNearlyFull = Lily == 2 && LilyTime < LilyOvercapTime;
         bool liliesFullNoBlood = Lily == 3;
         if (UseLilyWhenFull && (liliesNearlyFull || liliesFullNoBlood) && AfflatusMiseryPvE.EnoughLevel && BloodLily < 3)
         {
@@ -226,7 +233,7 @@ public sealed class WHM_Default : WhiteMageRotation
 
         if (StonePvE.CanUse(out act)) return true;
 
-        if (Lily >= 2)
+        if (UseLilyDowntime && (liliesNearlyFull || liliesFullNoBlood))
         {
             if (UseLily(out act)) return true;
         }

--- a/RotationSolver.Basic/Configuration/RotationConfig/RotationConfigCombo.cs
+++ b/RotationSolver.Basic/Configuration/RotationConfig/RotationConfigCombo.cs
@@ -16,7 +16,7 @@ internal class RotationConfigCombo : RotationConfigBase
     /// <param name="rotation">The custom rotation instance.</param>
     /// <param name="property">The property information.</param>
     public RotationConfigCombo(ICustomRotation rotation, PropertyInfo property)
-        : base(rotation, property)
+    : base(rotation, property)
     {
         if (!property.PropertyType.IsEnum)
         {
@@ -26,10 +26,26 @@ internal class RotationConfigCombo : RotationConfigBase
         var names = new List<string>();
         foreach (Enum v in Enum.GetValues(property.PropertyType))
         {
-            names.Add(v.ToString());
+            // Retrieve the Description attribute if it exists
+            var fieldInfo = property.PropertyType.GetField(v.ToString());
+            var descriptionAttribute = fieldInfo?.GetCustomAttribute<DescriptionAttribute>();
+            names.Add(descriptionAttribute?.Description ?? v.ToString());
         }
 
         DisplayValues = names.ToArray();
+
+        // Set the Value to the description of the default enum value
+        var defaultEnumValue = property.GetValue(rotation);
+        if (defaultEnumValue is Enum defaultEnum)
+        {
+            var defaultFieldInfo = property.PropertyType.GetField(defaultEnum.ToString());
+            var defaultDescriptionAttribute = defaultFieldInfo?.GetCustomAttribute<DescriptionAttribute>();
+            Value = defaultDescriptionAttribute?.Description ?? defaultEnum.ToString();
+        }
+        else
+        {
+            Value = DisplayValues[0]; // Fallback to the first item if no default is found
+        }
     }
 
     /// <summary>

--- a/RotationSolver/UI/RotationConfigWindow.cs
+++ b/RotationSolver/UI/RotationConfigWindow.cs
@@ -1448,7 +1448,10 @@ public partial class RotationConfigWindow : Window
             {
                 var names = c.DisplayValues;
                 var selectedValue = c.Value;
-                var index = names.IndexOf(n => n == selectedValue);
+
+                // Ensure the selected value matches the description, not the enum name
+                var index = names.IndexOf(n => n.Equals(selectedValue, StringComparison.OrdinalIgnoreCase));
+                if (index == -1) index = 0; // Fallback to the first item if no match is found
 
                 ImGui.SetNextItemWidth(ImGui.CalcTextSize(c.DisplayValues.OrderByDescending(v => v.Length).First()).X + 50 * Scale);
                 if (ImGui.Combo(name, ref index, names, names.Length))


### PR DESCRIPTION
Adjusted default logic for lily overcapping to be much tighter 
Added config for lily downtime use
Added config to adjust when the rotation considers lily to be near full 
Adjusted RSR handling of rotation config to display descriptions of bytes rather than the byte for muli option configs