### PR TITLE
Update IPC management, add low HP tankbuster sheild prio

### DIFF
--- a/RotationSolver.Basic/Actions/BaseAction.cs
+++ b/RotationSolver.Basic/Actions/BaseAction.cs
@@ -10,10 +10,20 @@ namespace RotationSolver.Basic.Actions;
 /// </summary>
 public class BaseAction : IBaseAction
 {
-    /// <inheritdoc/>
+    /// <summary>
+    /// Gets or sets the target to use for the action.
+    /// </summary>
+    /// <value>
+    /// A <see cref="TargetResult"/> representing the target of the action.
+    /// </value>
     public TargetResult Target { get; set; } = new(Player.Object, [], null);
 
-    /// <inheritdoc/>
+    /// <summary>
+    /// Gets the target for preview purposes.
+    /// </summary>
+    /// <value>
+    /// A nullable <see cref="TargetResult"/> representing the preview target, or <c>null</c> if no preview target is available.
+    /// </value>
     public TargetResult? PreviewTarget { get; private set; } = null;
 
     /// <inheritdoc/>

--- a/RotationSolver.Basic/Configuration/Configs.cs
+++ b/RotationSolver.Basic/Configuration/Configs.cs
@@ -1,6 +1,7 @@
 ﻿using Dalamud.Configuration;
 using ECommons.DalamudServices;
 using ECommons.ExcelServices;
+using Lumina.Excel.Sheets;
 using System.Collections.Concurrent;
 using static RotationSolver.Basic.Configuration.ConfigTypes;
 
@@ -502,6 +503,10 @@ internal partial class Configs : IPluginConfiguration
     [ConditionBool, UI("Heal party members with GCD if there is nothing to do in combat.",
         Filter = HealingActionCondition, Section = 3)]
     private static readonly bool _healWhenNothingTodo = true;
+
+    [ConditionBool, UI("Prioritize Low HP tank for tankbusters.",
+        Filter = HealingActionCondition, Section = 3)]
+    private static readonly bool _priolowtank = false;
 
     [UI("The duration of special windows opened by /macro commands by default.",
         Filter = BasicTimer, Section = 1)]

--- a/RotationSolver.Basic/Helpers/StatusHelper.cs
+++ b/RotationSolver.Basic/Helpers/StatusHelper.cs
@@ -170,7 +170,12 @@ public static class StatusHelper
     /// <param name="statusIDs"></param>
     /// <returns></returns>
     public static bool WillStatusEndGCD(this IGameObject? obj, uint gcdCount = 0, float offset = 0, bool isFromSelf = true, params StatusID[] statusIDs)
-        => WillStatusEnd(obj, DataCenter.GCDTime(gcdCount, offset), isFromSelf, statusIDs);
+    {
+        if (obj == null) return false;
+        if (statusIDs == null) return false;
+
+        return WillStatusEnd(obj, DataCenter.GCDTime(gcdCount, offset), isFromSelf, statusIDs);
+    }
 
     /// <summary>
     /// Will any of <paramref name="statusIDs"/> end after <paramref name="time"/> seconds?
@@ -182,6 +187,10 @@ public static class StatusHelper
     /// <returns></returns>
     public static bool WillStatusEnd(this IGameObject? obj, float time, bool isFromSelf = true, params StatusID[] statusIDs)
     {
+        if (obj == null) return false;
+        if (statusIDs == null) return false;
+        if (Player.Object == null) return false;
+
         if (HasApplyStatus(obj, statusIDs)) return false;
         if (obj.StatusTime(isFromSelf, statusIDs) < 0 && obj.HasStatus(isFromSelf, statusIDs)) return false;
         return obj.StatusTime(isFromSelf, statusIDs) <= time;
@@ -196,10 +205,9 @@ public static class StatusHelper
     /// <returns></returns>
     public static float StatusTime(this IGameObject? obj, bool isFromSelf, params StatusID[] statusIDs)
     {
-        if (obj == null)
-        {
-            return 0;
-        }
+        if (obj == null) return 0;
+        if (statusIDs == null) return 0;
+        if (Player.Object == null) return 0;
 
         try
         {
@@ -217,10 +225,9 @@ public static class StatusHelper
 
     internal static IEnumerable<float> StatusTimes(this IGameObject? obj, bool isFromSelf, params StatusID[] statusIDs)
     {
-        if (obj == null)
-        {
-            return Enumerable.Empty<float>();
-        }
+        if (obj == null) return Enumerable.Empty<float>();
+        if (statusIDs == null) return Enumerable.Empty<float>();
+        if (Player.Object == null) return Enumerable.Empty<float>();
 
         var result = new List<float>();
 
@@ -241,10 +248,8 @@ public static class StatusHelper
     /// <returns></returns>
     public static byte StatusStack(this IGameObject? obj, bool isFromSelf, params StatusID[] statusIDs)
     {
-        if (obj == null)
-        {
-            return 0;
-        }
+        if (obj == null) return 0;
+        if (Player.Object == null) return 0;
 
         if (HasApplyStatus(obj, statusIDs)) return byte.MaxValue;
         if (obj.StatusStacks(isFromSelf, statusIDs) == null || !obj.StatusStacks(isFromSelf, statusIDs).Any()) return 0;
@@ -253,10 +258,9 @@ public static class StatusHelper
 
     private static IEnumerable<byte> StatusStacks(this IGameObject? obj, bool isFromSelf, params StatusID[] statusIDs)
     {
-        if (obj == null)
-        {
-            return Enumerable.Empty<byte>();
-        }
+        if (obj == null) return Enumerable.Empty<byte>();
+        if (statusIDs == null) return Enumerable.Empty<byte>();
+        if (Player.Object == null) return Enumerable.Empty<byte>();
 
         var result = new List<byte>();
 
@@ -278,6 +282,7 @@ public static class StatusHelper
     public static bool HasStatus(this IGameObject? obj, bool isFromSelf, params StatusID[] statusIDs)
     {
         if (obj == null) return false;
+        if (statusIDs == null) return false;
         if (Player.Object == null) return false;
 
         if (HasApplyStatus(obj, statusIDs)) return true;
@@ -296,7 +301,7 @@ public static class StatusHelper
     {
         if (obj == null) return false;
         if (statusIDs == null) return false;
-        if (statusIDs.Length == 0) return false;
+        if (Player.Object == null) return false;
 
         if (DataCenter.InEffectTime && DataCenter.ApplyStatus.TryGetValue(obj.GameObjectId, out var statusId))
         {
@@ -315,15 +320,8 @@ public static class StatusHelper
     /// <param name="status"></param>
     public static void StatusOff(StatusID status)
     {
-        if (Player.Object == null)
-        {
-            return;
-        }
-
-        if (!Player.Object.HasStatus(false, status))
-        {
-            return;
-        }
+        if (Player.Object == null) return;
+        if (!Player.Object.HasStatus(false, status)) return;
 
         try
         {
@@ -364,6 +362,7 @@ public static class StatusHelper
         var newEffects = new HashSet<uint>(statusIDs.Select(a => (uint)a));
         var result = new List<Status>();
 
+        if (Player.Object == null) return Enumerable.Empty<Status>();
         if (obj == null) return Enumerable.Empty<Status>();
         if (statusIDs == null) return Enumerable.Empty<Status>();
         if (statusIDs.Length == 0) return Enumerable.Empty<Status>();

--- a/RotationSolver/Commands/RSCommands_StateSpecialCommand.cs
+++ b/RotationSolver/Commands/RSCommands_StateSpecialCommand.cs
@@ -69,7 +69,7 @@ namespace RotationSolver.Commands
             Service.Config.TargetingIndex = index;
         }
 
-        private static void UpdateState(StateCommandType stateType, JobRole role)
+        public static void UpdateState(StateCommandType stateType, JobRole role)
         {
             switch (stateType)
             {

--- a/RotationSolver/IPC/IPCProvider.cs
+++ b/RotationSolver/IPC/IPCProvider.cs
@@ -1,7 +1,8 @@
 ﻿using ECommons.DalamudServices;
 using ECommons.EzIpcManager;
+using RotationSolver.Commands;
 
-namespace RotationSolver.Basic.IPC
+namespace RotationSolver.IPC
 {
     internal class IPCProvider
     {
@@ -113,21 +114,7 @@ namespace RotationSolver.Basic.IPC
         [EzIPC]
         public void ChangeOperatingMode(StateCommandType stateCommand)
         {
-            switch (stateCommand)
-            {
-                case StateCommandType.Auto:
-                    DataCenter.IsManual = false;
-                    DataCenter.State = true;
-                    break;
-                case StateCommandType.Manual:
-                    DataCenter.IsManual = true;
-                    DataCenter.State = true;
-                    break;
-                case StateCommandType.Off:
-                    DataCenter.State = false;
-                    DataCenter.IsManual = false;
-                    break;
-            }
+            RSCommands.UpdateState(stateCommand, (JobRole)DataCenter.Job);
             Svc.Log.Debug($"IPC ChangeOperatingMode was called. StateCommand:{stateCommand}");
         }
 

--- a/RotationSolver/RotationSolverPlugin.cs
+++ b/RotationSolver/RotationSolverPlugin.cs
@@ -8,7 +8,7 @@ using ECommons.GameHelpers;
 using ECommons.ImGuiMethods;
 using Lumina.Excel.Sheets;
 using RotationSolver.Basic.Configuration;
-using RotationSolver.Basic.IPC;
+using RotationSolver.IPC;
 using RotationSolver.Commands;
 using RotationSolver.Data;
 using RotationSolver.Helpers;


### PR DESCRIPTION
Migrated IPC from Basic to core project, hooking ChangeOperatingMode directly into RSCommands. Laid groundwork for IPC support of actions.

Add config (disabled by default) to attempt to prioritize Low HP ratio tanks during tankbusters.

Made StatusHelper more robust, removed nullability of TargetResult to prevent crashes.