### PR TITLE
Enhance target selection

### DIFF
--- a/RotationSolver.Basic/Configuration/Configs.cs
+++ b/RotationSolver.Basic/Configuration/Configs.cs
@@ -133,6 +133,10 @@ internal partial class Configs : IPluginConfiguration
         Filter = TargetConfig)]
     private static readonly bool _filterOneHPInvincible = true;
 
+    [ConditionBool, UI("Ignore Non-Fate targets while in a Fate and Fate targets if not in Fate.",
+        Filter = TargetConfig)]
+    private static readonly bool _ignoreNonFateInFate = true;
+
     [ConditionBool, UI("Ignore immune Ark Angels in Jenuo: The First Walk.",
         Filter = TargetConfig)]
     private static readonly bool _jeunoTarget = true;
@@ -140,6 +144,18 @@ internal partial class Configs : IPluginConfiguration
     [ConditionBool, UI("Ignore immune targets in Cloud of Darkness Chaotic.",
         Filter = TargetConfig)]
     private static readonly bool _cODTarget = true;
+
+    [ConditionBool, UI("Ignore immune targets based on Resistance status (Void Ark Alliance and Leviathan).",
+        Filter = TargetConfig)]
+    private static readonly bool _resistanceImmune = true;
+
+    [ConditionBool, UI("Ignore immune Omega Variants (O12N/O12S).",
+        Filter = TargetConfig)]
+    private static readonly bool _omegaImmune = true;
+
+    [ConditionBool, UI("Ignore immune targets in Limitless Blue (Normal/Extreme).",
+        Filter = TargetConfig)]
+    private static readonly bool _limitlessImmune = true;
 
     [ConditionBool, UI("Ignore immune targets in Cinder Drift (Extreme).",
         Filter = TargetConfig)]

--- a/RotationSolver.Basic/DataCenter.cs
+++ b/RotationSolver.Basic/DataCenter.cs
@@ -211,7 +211,7 @@ internal static class DataCenter
     internal static float DeadTimeRaw { get; set; }
     internal static float AliveTimeRaw { get; set; }
 
-    public static unsafe ushort FateId
+    public static unsafe ushort PlayerFateId
     {
         get
         {

--- a/RotationSolver/UI/RotationConfigWindow.cs
+++ b/RotationSolver/UI/RotationConfigWindow.cs
@@ -2750,7 +2750,7 @@ public partial class RotationConfigWindow : Window
         ImGui.Text($"Merged Status: {DataCenter.MergedStatus}");
         if ((IntPtr)FateManager.Instance() != IntPtr.Zero)
         {
-            ImGui.Text($"Fate: {DataCenter.FateId}");
+            ImGui.Text($"Fate: {DataCenter.PlayerFateId}");
         }
         ImGui.Text($"Height: {Player.Character->ModelContainer.CalculateHeight()}");
         var conditions = Svc.Condition.AsReadOnlySet().ToArray();
@@ -2917,6 +2917,7 @@ public partial class RotationConfigWindow : Window
         if (target is IBattleChara battleChara)
         {
             ImGui.Text($"HP: {battleChara.CurrentHp} / {battleChara.MaxHp}");
+            ImGui.Text($"FateID: {battleChara.FateId().ToString() ?? string.Empty}");
             ImGui.Text($"Is Current Focus Target: {battleChara.IsFocusTarget()}");
             ImGui.Text($"TTK: {battleChara.GetTTK()}");
             ImGui.Text($"Is Boss TTK: {battleChara.IsBossFromTTK()}");


### PR DESCRIPTION
- Added configuration options in `Configs` to ignore specific immune targets, including non-Fate targets and immune variants.
- Renamed `FateId` to `PlayerFateId` in `DataCenter` for clarity.
- Updated `CanProvoke` method in `ObjectHelper` to use `PlayerFateId`.
- Introduced new methods in `ObjectHelper` to check for immunity statuses: `IsResistanceImmune`, `IsOmegaImmune`, and `IsLimitlessBlue`.
- Modified `DrawStatus` in `RotationConfigWindow` to show the player's Fate ID.