### PR TITLE
Add Bozja CE mob targeting configuration and logic

### DIFF
--- a/RotationSolver.Basic/Configuration/Configs.cs
+++ b/RotationSolver.Basic/Configuration/Configs.cs
@@ -169,6 +169,10 @@ internal partial class Configs : IPluginConfiguration
         Filter = TargetConfig)]
     private static readonly bool _strongOfSheildTarget = true;
 
+    [ConditionBool, UI("Attempt to handle Bozja CE mob targeting. (Experimental)",
+        Filter = TargetConfig)]
+    private static readonly bool _bozjaCEmobtargeting = false;
+
     [ConditionBool, UI("Teaching mode", Filter = UiInformation)]
     private static readonly bool _teachingMode = false;
 

--- a/RotationSolver.Basic/DataCenter.cs
+++ b/RotationSolver.Basic/DataCenter.cs
@@ -307,7 +307,6 @@ internal static class DataCenter
     public static float GCDTime(uint gcdCount = 0, float offset = 0) => DefaultGCDTotal * gcdCount + offset;
     #endregion
 
-
     public static uint[] BluSlots { get; internal set; } = new uint[24];
 
     public static uint[] DutyActions { get; internal set; } = new uint[2];

--- a/RotationSolver/UI/RotationConfigWindow.cs
+++ b/RotationSolver/UI/RotationConfigWindow.cs
@@ -2926,6 +2926,7 @@ public partial class RotationConfigWindow : Window
             ImGui.Text($"HP: {battleChara.CurrentHp} / {battleChara.MaxHp}");
             ImGui.Text($"FateID: {battleChara.FateId().ToString() ?? string.Empty}");
             ImGui.Text($"EventType: {battleChara.GetEventType().ToString() ?? string.Empty}");
+            ImGui.Text($"IsBozjanCEFateMob: {battleChara.IsBozjanCEFateMob()}");
             ImGui.Text($"Is Current Focus Target: {battleChara.IsFocusTarget()}");
             ImGui.Text($"TTK: {battleChara.GetTTK()}");
             ImGui.Text($"Is Boss TTK: {battleChara.IsBossFromTTK()}");


### PR DESCRIPTION
- Introduced `_bozjaCEmobtargeting` option in `Configs` to manage targeting of Bozja CE mobs, defaulting to `false`.
- Implemented `IsBozjanCEFateMob` method in `ObjectHelper` to identify Bozjan CE fate mobs.
- Updated targeting logic in `ObjectHelper` to respect the new configuration and player state.
- Enhanced `RotationConfigWindow` to display Bozjan CE fate mob status.
- Cleaned up commented-out code related to targeting in Bozja CE for improved clarity.