### PR TITLE
Improve targeting logic for Bozja and Zadnor content

### DIFF
--- a/RotationSolver.Basic/Configuration/Configs.cs
+++ b/RotationSolver.Basic/Configuration/Configs.cs
@@ -169,7 +169,7 @@ internal partial class Configs : IPluginConfiguration
         Filter = TargetConfig)]
     private static readonly bool _strongOfSheildTarget = true;
 
-    [ConditionBool, UI("Attempt to handle Bozja CE mob targeting. (Experimental)",
+    [ConditionBool, UI("Prevent targeting invalid targets in Bozjan Southern Front and Zadnor",
         Filter = TargetConfig)]
     private static readonly bool _bozjaCEmobtargeting = false;
 

--- a/RotationSolver.Basic/DataCenter.cs
+++ b/RotationSolver.Basic/DataCenter.cs
@@ -111,33 +111,29 @@ internal static class DataCenter
     /// <summary>
     /// Determines if the current content is Bozjan Southern Front or Zadnor.
     /// </summary>
-    public static bool IsInBozjanFieldOp => Content.ContentType == ECommons.GameHelpers.ContentType.FieldOperations 
-        && DataCenter.Territory?.ContentType == TerritoryContentType.SaveTheQueen;
+    public static bool IsInBozjanFieldOp => Content.ContentType == ECommons.GameHelpers.ContentType.FieldOperations;
 
     /// <summary>
     /// Determines if the current content is Bozjan Southern Front CE or Zadnor CE.
     /// </summary>
     public static bool IsInBozjanFieldOpCE => Content.ContentType == ECommons.GameHelpers.ContentType.FieldOperations 
-        && Player.Object.HasStatus(false, StatusID.DutiesAsAssigned)
-        && DataCenter.Territory?.ContentType == TerritoryContentType.SaveTheQueen;
+        && Player.Object.HasStatus(false, StatusID.DutiesAsAssigned);
 
     /// <summary>
-    /// Determines if the current content is Delubrum Reginae, Dalriada, or Castrum Lacus Litore.
+    /// Determines if the current content is Delubrum Reginae.
     /// </summary>
-    public static bool IsInBozjanFieldRaids => Content.ContentType == ECommons.GameHelpers.ContentType.FieldRaid 
-        && DataCenter.Territory?.ContentType == TerritoryContentType.SaveTheQueen;
+    public static bool IsInDelubrumNormal => Content.ContentType == ECommons.GameHelpers.ContentType.FieldRaid;
 
     /// <summary>
     /// Determines if the current content is Delubrum Reginae (Savage).
     /// </summary>
     public static bool IsInDelubrumSavage => Content.ContentType == ECommons.GameHelpers.ContentType.FieldRaid
-        && Content.ContentDifficulty == ContentDifficulty.FieldRaidsSavage
-        && DataCenter.Territory?.ContentType == TerritoryContentType.SaveTheQueen;
+        && Content.ContentDifficulty == ContentDifficulty.FieldRaidsSavage;
 
     /// <summary>
     /// Determines if the current territory is Bozja and is either a field operation or field raid.
     /// </summary>
-    public static bool IsInBozja => DataCenter.Territory?.ContentType == TerritoryContentType.SaveTheQueen && (IsInBozjanFieldOp || IsInBozjanFieldRaids || IsInDelubrumSavage);
+    public static bool IsInBozja => (IsInBozjanFieldOp || IsInDelubrumNormal || IsInDelubrumSavage);
 
     #endregion
 

--- a/RotationSolver/UI/RotationConfigWindow.cs
+++ b/RotationSolver/UI/RotationConfigWindow.cs
@@ -2771,10 +2771,10 @@ public partial class RotationConfigWindow : Window
         ImGui.Text($"TargetingType: {DataCenter.TargetingType}");
         ImGui.Text($"DeathTarget: {DataCenter.DeathTarget}");
         ImGui.Spacing();
-        ImGui.Text($"IsInFieldOp: {DataCenter.IsInBozjanFieldOp}");
-        ImGui.Text($"IsInFieldOpCE: {DataCenter.IsInBozjanFieldOpCE}");
-        ImGui.Text($"IsInFieldRaids: {DataCenter.IsInBozjanFieldRaids}");
-        ImGui.Text($"IsInFieldRaidsSavage: {DataCenter.IsInDelubrumSavage}");
+        ImGui.Text($"IsInBozjanFieldOp: {DataCenter.IsInBozjanFieldOp}");
+        ImGui.Text($"IsInBozjanFieldOpCE: {DataCenter.IsInBozjanFieldOpCE}");
+        ImGui.Text($"IsInDelubrumNormal: {DataCenter.IsInDelubrumNormal}");
+        ImGui.Text($"IsInDelubrumSavage: {DataCenter.IsInDelubrumSavage}");
         ImGui.Text($"IsInBozja: {DataCenter.IsInBozja}");
         ImGui.Spacing();
         ImGui.Text($"AttackedTargets: {DataCenter.AttackedTargets?.Count() ?? 0}");
@@ -2879,12 +2879,23 @@ public partial class RotationConfigWindow : Window
         ImGui.Text($"MP: {DataCenter.CurrentMp}");
         ImGui.Text($"Count Down: {Service.CountDownTime}");
 
+        ImGui.Spacing();
+        ImGui.Text($"Statuses:");
         foreach (var status in Player.Object.StatusList)
         {
             var source = status.SourceId == Player.Object.GameObjectId ? "You" : Svc.Objects.SearchById(status.SourceId) == null ? "None" : "Others";
             byte stacks = Player.Object.StatusStack(true, (StatusID)status.StatusId);
             string stackDisplay = stacks == byte.MaxValue ? "N/A" : stacks.ToString(); // Convert 255 to "N/A"
             ImGui.Text($"{status.GameData.Value.Name}: {status.StatusId} From: {source} Stacks: {stackDisplay}");
+        }
+
+        ImGui.Spacing();
+        ImGui.Text($"Enemies:");
+        ImGui.Text($"All: {DataCenter.AllTargets.Count()}");
+        ImGui.Text($"Hostile: {DataCenter.AllHostileTargets.Count()}");
+        foreach (var item in DataCenter.AllHostileTargets)
+        {
+            ImGui.Text(item.Name.ToString());
         }
     }
 
@@ -2923,7 +2934,12 @@ public partial class RotationConfigWindow : Window
 
         if (target is IBattleChara battleChara)
         {
+            ImGui.Text($"NamePlate: {battleChara.GetNamePlateIcon()}");
+            ImGui.Text($"Name Id: {battleChara.NameId}");
+            ImGui.Text($"Data Id: {battleChara.DataId}");
             ImGui.Text($"HP: {battleChara.CurrentHp} / {battleChara.MaxHp}");
+            ImGui.Text($"Is Enemy Action Check: {battleChara.IsEnemy()}");
+            ImGui.Text($"Is Attackable: {battleChara.IsAttackable()}");
             ImGui.Text($"FateID: {battleChara.FateId().ToString() ?? string.Empty}");
             ImGui.Text($"EventType: {battleChara.GetEventType().ToString() ?? string.Empty}");
             ImGui.Text($"IsBozjanCEFateMob: {battleChara.IsBozjanCEFateMob()}");
@@ -2941,36 +2957,24 @@ public partial class RotationConfigWindow : Window
             ImGui.Text($"Is Party: {battleChara.IsParty()}");
             ImGui.Text($"Is Healer: {battleChara.IsJobCategory(JobRole.Healer)}");
             ImGui.Text($"Is Alliance: {battleChara.IsAllianceMember()}");
-            ImGui.Text($"Is Enemy: {battleChara.IsEnemy()}");
             ImGui.Text($"Distance To Player: {battleChara.DistanceToPlayer()}");
-            ImGui.Text($"Is Attackable: {battleChara.IsAttackable()}");
-            ImGui.Text($"Is Jeuno Boss Immune: {battleChara.IsJeunoBossImmune()}");
             ImGui.Text($"CanProvoke: {battleChara.CanProvoke()}");
-            //ImGui.Text($"EventType: {battleChara.GetEventType()}");
             ImGui.Text($"NamePlate: {battleChara.GetNamePlateIcon()}");
             ImGui.Text($"StatusFlags: {battleChara.StatusFlags}");
             ImGui.Text($"InView: {Svc.GameGui.WorldToScreen(battleChara.Position, out _)}");
-            ImGui.Text($"Name Id: {battleChara.NameId}");
-            ImGui.Text($"Data Id: {battleChara.DataId}");
             ImGui.Text($"Enemy Positional: {battleChara.FindEnemyPositional()}");
             ImGui.Text($"NameplateKind: {battleChara.GetNameplateKind()}");
             ImGui.Text($"BattleNPCSubKind: {battleChara.GetBattleNPCSubKind()}");
             ImGui.Text($"Is Top Priority Hostile: {battleChara.IsTopPriorityHostile()}");
-            ImGui.Text($"Is Others Players: {battleChara.IsOthersPlayers()}");
+            ImGui.Text($"Is Others Players Mob: {battleChara.IsOthersPlayersMob()}");
             ImGui.Text($"Targetable: {battleChara.Struct()->Character.GameObject.TargetableStatus}");
-
+            ImGui.Spacing();
+            ImGui.Text($"Statuses:");
             foreach (var status in battleChara.StatusList)
             {
                 var source = status.SourceId == Player.Object.GameObjectId ? "You" : Svc.Objects.SearchById(status.SourceId) == null ? "None" : "Others";
                 ImGui.Text($"{status.GameData.Value.Name}: {status.StatusId} From: {source}");
             }
-        }
-
-        ImGui.Text($"All: {DataCenter.AllTargets.Count()}");
-        ImGui.Text($"Hostile: {DataCenter.AllHostileTargets.Count()}");
-        foreach (var item in DataCenter.AllHostileTargets)
-        {
-            ImGui.Text(item.Name.ToString());
         }
     }
 


### PR DESCRIPTION
- Added a configuration option in `Configs` to prevent targeting invalid targets in Bozja.
- Simplified methods in `DataCenter` for determining player content areas, removing unnecessary checks.
- Renamed and modified methods in `ObjectHelper` for clarity, including a new method for special mob exceptions.
- Updated `RotationConfigWindow` to reflect changes in `DataCenter`, ensuring accurate UI information.
- Added special exception logic, for now just for the door in CLL.