### PR TITLE
Refactor GNB_Default class and improve resource cleanup

### DIFF
--- a/RotationSolver.Basic/Service.cs
+++ b/RotationSolver.Basic/Service.cs
@@ -158,6 +158,10 @@ internal class Service : IDisposable
     {
         if (disposing)
         {
+            // Dispose the EzHook instance
+            actorVfxCreateHook?.Disable();
+
+            // Clean up ForceDisableMovement if necessary
             if (!_canMove && ForceDisableMovement > 0)
             {
                 ForceDisableMovement--;


### PR DESCRIPTION
- Added `UsePots` configuration option to `GNB_Default` for tincture usage in the opener.
- Removed `NoMercyLogic` option and updated related logic in `EmergencyAbility`, `AttackAbility`, and `GeneralGCD` methods.
- Enhanced resource management in `Service.cs` by disposing of the `EzHook` instance during cleanup.