### PR TITLE
Update Physranged PvP rotations and enhance healing logic to handle special Doom statuses

### DIFF
--- a/BasicRotations/PVPRotations/Ranged/BRD_Default.PVP.cs
+++ b/BasicRotations/PVPRotations/Ranged/BRD_Default.PVP.cs
@@ -1,6 +1,6 @@
 ﻿namespace RebornRotations.PVPRotations.Ranged;
 
-[Rotation("Default PVP", CombatType.PvP, GameVersion = "7.2")]
+[Rotation("Default PVP", CombatType.PvP, GameVersion = "7.21")]
 [SourceCode(Path = "main/RebornRotations/PVPRotations/Ranged/BRD_Default.PvP.cs")]
 [Api(4)]
 public sealed class BRD_DefaultPvP : BardRotation
@@ -41,6 +41,8 @@ public sealed class BRD_DefaultPvP : BardRotation
         action = null;
         if (RespectGuard && Player.HasStatus(true, StatusID.Guard)) return false;
         if (DoPurify(out action)) return true;
+        if (InCombat && BraveryPvP.CanUse(out action)) return true;
+        if (InCombat && DervishPvP.CanUse(out action)) return true;
 
         return base.EmergencyAbility(nextGCD, out action);
     }
@@ -60,10 +62,12 @@ public sealed class BRD_DefaultPvP : BardRotation
         if (RepellingShotPvP.CanUse(out action) && !Player.HasStatus(true, StatusID.Repertoire)) return true;
         if (EncoreOfLightPvP.CanUse(out action)) return true;
         if (SilentNocturnePvP.CanUse(out action) && !Player.HasStatus(true, StatusID.Repertoire)) return true;
+        if (EagleEyeShotPvP.CanUse(out action)) return true;
 
         return base.AttackAbility(nextGCD, out action);
     }
     #endregion
+
     #region GCDs
     protected override bool GeneralGCD(out IAction? action)
     {

--- a/BasicRotations/PVPRotations/Ranged/DNC_Default.PVP.cs
+++ b/BasicRotations/PVPRotations/Ranged/DNC_Default.PVP.cs
@@ -1,6 +1,6 @@
 ﻿namespace RebornRotations.PVPRotations.Ranged;
 
-[Rotation("Default PVP", CombatType.PvP, GameVersion = "7.2")]
+[Rotation("Default PVP", CombatType.PvP, GameVersion = "7.21")]
 [SourceCode(Path = "main/RebornRotations/PVPRotations/Ranged/DNC_Default.PvP.cs")]
 [Api(4)]
 public sealed class DNC_DefaultPvP : DancerRotation
@@ -44,6 +44,9 @@ public sealed class DNC_DefaultPvP : DancerRotation
 
         if (ClosedPositionPvP.CanUse(out action) && !Player.HasStatus(true, StatusID.ClosedPosition_2026)) return true;
 
+        if (InCombat && BraveryPvP.CanUse(out action)) return true;
+        if (InCombat && DervishPvP.CanUse(out action)) return true;
+
         return base.EmergencyAbility(nextGCD, out action);
     }
 
@@ -81,6 +84,7 @@ public sealed class DNC_DefaultPvP : DancerRotation
         if (RespectGuard && Player.HasStatus(true, StatusID.Guard)) return false;
 
         if (FanDancePvP.CanUse(out action)) return true;
+        if (EagleEyeShotPvP.CanUse(out action)) return true;
 
         return base.AttackAbility(nextGCD, out action);
     }

--- a/BasicRotations/PVPRotations/Ranged/MCH_Default.PvP.cs
+++ b/BasicRotations/PVPRotations/Ranged/MCH_Default.PvP.cs
@@ -1,6 +1,6 @@
 namespace RebornRotations.PVPRotations.Ranged;
 
-[Rotation("Default PVP", CombatType.PvP, GameVersion = "7.2")]
+[Rotation("Default PVP", CombatType.PvP, GameVersion = "7.21")]
 [SourceCode(Path = "main/RebornRotations/PVPRotations/Ranged/MCH_Default.PvP.cs")]
 [Api(4)]
 public sealed class MCH_DefaultPvP : MachinistRotation
@@ -42,6 +42,9 @@ public sealed class MCH_DefaultPvP : MachinistRotation
         if (RespectGuard && Player.HasStatus(true, StatusID.Guard)) return false;
         if (DoPurify(out action)) return true;
 
+        if (InCombat && BraveryPvP.CanUse(out action)) return true;
+        if (InCombat && DervishPvP.CanUse(out action)) return true;
+
         return base.EmergencyAbility(nextGCD, out action);
     }
 
@@ -62,6 +65,7 @@ public sealed class MCH_DefaultPvP : MachinistRotation
         if (nextGCD.IsTheSameTo(false, ActionID.DrillPvP, ActionID.BioblasterPvP, ActionID.AirAnchorPvP, ActionID.ChainSawPvP) && AnalysisPvP.CanUse(out action, usedUp: true)) return true;
         if (Player.HasStatus(true, StatusID.Overheated_3149) && WildfirePvP.CanUse(out action)) return true;
         if (BishopAutoturretPvP.CanUse(out action)) return true;
+        if (EagleEyeShotPvP.CanUse(out action)) return true;
 
         return base.AttackAbility(nextGCD, out action);
     }

--- a/RotationSolver.Basic/Helpers/StatusHelper.cs
+++ b/RotationSolver.Basic/Helpers/StatusHelper.cs
@@ -153,11 +153,26 @@ public static class StatusHelper
     };
 
     /// <summary>
+    /// 
+    /// </summary>
+    public static StatusID[] DoomHealStatus { get; } =
+    {
+        StatusID.Doom_1769,
+    };
+
+    /// <summary>
     /// Check whether the target needs to be healing.
     /// </summary>
-    /// <param name="p"></param>
+    /// <param name="Invulnp"></param>
     /// <returns></returns>
-    public static bool NeedHealing(this IGameObject p) => p.WillStatusEndGCD(2, 0, false, NoNeedHealingStatus);
+    public static bool NoNeedHealingInvuln(this IGameObject Invulnp) => Invulnp.WillStatusEndGCD(2, 0, false, NoNeedHealingStatus);
+
+    /// <summary>
+    /// Check if the target needs to be healed because of Doomed To Heal status.
+    /// </summary>
+    /// <param name="Doomp"></param>
+    /// <returns></returns>
+    public static bool DoomNeedHealing(this IGameObject Doomp) => Doomp.HasStatus(false, DoomHealStatus);
 
     /// <summary>
     /// Will any of <paramref name="statusIDs"/> end after <paramref name="gcdCount"/> GCDs plus <paramref name="offset"/> seconds?

--- a/RotationSolver.Basic/Rotations/CustomRotation_Actions.cs
+++ b/RotationSolver.Basic/Rotations/CustomRotation_Actions.cs
@@ -150,6 +150,8 @@ partial class CustomRotation
 
     static partial void ModifyDervishPvP(ref ActionSetting setting)
     {
+        setting.StatusNeed = [StatusID.PvPRoleActionDervish];
+        setting.StatusProvide = [StatusID.Dervish];
         setting.CreateConfig = () => new ActionConfig()
         {
             AoeCount = 1,
@@ -158,16 +160,19 @@ partial class CustomRotation
 
     static partial void ModifyBraveryPvP(ref ActionSetting setting)
     {
+        setting.StatusNeed = [StatusID.PvPRoleActionBravery];
+        setting.StatusProvide = [StatusID.Bravery];
         setting.TargetType = TargetType.Self;
     }
 
     static partial void ModifyEagleEyeShotPvP(ref ActionSetting setting)
     {
-
+        setting.StatusNeed = [StatusID.PvPRoleActionEagleEyeShot];
     }
 
     static partial void ModifyCometPvP(ref ActionSetting setting)
     {
+        setting.StatusNeed = [StatusID.PvPRoleActionComet];
         setting.IsFriendly = false;
         setting.CreateConfig = () => new ActionConfig()
         {
@@ -177,6 +182,7 @@ partial class CustomRotation
 
     static partial void ModifyRustPvP(ref ActionSetting setting)
     {
+        setting.StatusNeed = [StatusID.PvPRoleActionRust];
         setting.CreateConfig = () => new ActionConfig()
         {
             AoeCount = 1,
@@ -185,11 +191,12 @@ partial class CustomRotation
 
     static partial void ModifyPhantomDartPvP(ref ActionSetting setting)
     {
-
+        setting.StatusNeed = [StatusID.PvPRoleActionPhantomDart];
     }
 
     static partial void ModifyRampagePvP(ref ActionSetting setting)
     {
+        setting.StatusNeed = [StatusID.PvPRoleActionRampage];
         setting.CreateConfig = () => new ActionConfig()
         {
             AoeCount = 1,
@@ -198,21 +205,22 @@ partial class CustomRotation
 
     static partial void ModifyRampartPvP(ref ActionSetting setting)
     {
-
+        setting.StatusNeed = [StatusID.PvPRoleActionRampart];
     }
 
     static partial void ModifyFullSwingPvP(ref ActionSetting setting)
     {
-
+        setting.StatusNeed = [StatusID.PvPRoleActionFullSwing];
     }
 
     static partial void ModifyHaelanPvP(ref ActionSetting setting)
     {
-
+        setting.StatusNeed = [StatusID.PvPRoleActionHaelan];
     }
 
     static partial void ModifyStoneskinIiPvP(ref ActionSetting setting)
     {
+        setting.StatusNeed = [StatusID.PvPRoleActionStoneskinIi];
         setting.CreateConfig = () => new ActionConfig()
         {
             AoeCount = 1,
@@ -221,6 +229,7 @@ partial class CustomRotation
 
     static partial void ModifyDiabrosisPvP(ref ActionSetting setting)
     {
+        setting.StatusNeed = [StatusID.Diabrosis];
         setting.CreateConfig = () => new ActionConfig()
         {
             AoeCount = 1,
@@ -229,17 +238,17 @@ partial class CustomRotation
 
     static partial void ModifyBloodbathPvP(ref ActionSetting setting)
     {
-
+        setting.StatusNeed = [StatusID.PvPRoleActionBloodbath];
     }
 
     static partial void ModifySwiftPvP(ref ActionSetting setting)
     {
-
+        setting.StatusNeed = [StatusID.PvPRoleActionSwift];
     }
 
     static partial void ModifySmitePvP(ref ActionSetting setting)
     {
-
+        setting.StatusNeed = [StatusID.PvPRoleActionSmite];
     }
 
     #endregion

--- a/RotationSolver.Basic/Rotations/CustomRotation_OtherInfo.cs
+++ b/RotationSolver.Basic/Rotations/CustomRotation_OtherInfo.cs
@@ -148,7 +148,7 @@ partial class CustomRotation
     /// <summary>
     /// The last attacked hostile target.
     /// </summary>
-    protected static IBattleChara? HostileTarget => DataCenter.HostileTarget;
+    protected static IBattleChara? HostileTarget => DataCenter.HostileTarget ?? null;
 
     /// <summary>
     /// Is player in position to hit the positional?

--- a/RotationSolver/UI/RotationConfigWindow.cs
+++ b/RotationSolver/UI/RotationConfigWindow.cs
@@ -1759,6 +1759,13 @@ public partial class RotationConfigWindow : Window
             {
                 try
                 {
+                    var target = action.Target.Target;
+                    if (target is not IBattleChara battleChara)
+                    {
+                        ImGui.TextColored(ImGuiColors.DalamudRed, "Target is not a valid BattleChara.");
+                        return;
+                    }
+
                     ImGui.Text("ID: " + action.Info.ID);
                     ImGui.Text("AdjustedID: " + Service.GetAdjustedActionId(action.Info.ID));
                     ImGui.Text($"Can Use: {action.CanUse(out _)} ");
@@ -2777,6 +2784,7 @@ public partial class RotationConfigWindow : Window
         }
         ImGui.Text($"OnlineStatus: {Player.OnlineStatus}");
         ImGui.Text($"IsDead: {Player.Object.IsDead}");
+        ImGui.Text($"DoomNeedHealing: {Player.Object.DoomNeedHealing()}");
         ImGui.Text($"Dead Time: {DataCenter.DeadTimeRaw}");
         ImGui.Text($"Alive Time: {DataCenter.AliveTimeRaw}");
         ImGui.Text($"Moving: {DataCenter.IsMoving}");
@@ -2922,6 +2930,7 @@ public partial class RotationConfigWindow : Window
         ImGui.Text($"Is in Alliance Raid: {DataCenter.IsInAllianceRaid}");
         ImGui.Text($"Number of Alliance Members: {DataCenter.AllianceMembers.Count}");
         ImGui.Text($"Average Party HP Percent: {DataCenter.PartyMembersAverHP * 100}");
+        ImGui.Text($"Number of Party Members with Doomed To Heal status: {DataCenter.PartyMembers.Count(member => member.DoomNeedHealing())}");
         foreach (var p in Svc.Party)
         {
             if (p.GameObject is not IBattleChara b) continue;


### PR DESCRIPTION
- Added emergency ability checks for "BraveryPvP" and "DervishPvP".
- Introduced "EagleEyeShotPvP" check in attack abilities.
- Enhanced null checks in `ActionTargetInfo` to prevent exceptions.
- Updated healing logic to prioritize targets with "Doom" status.
- Improved `GeneralHealTarget` and `ShouldHealSingle` methods for better healing decisions.
- Added UI updates in `RotationConfigWindow` to display "Doom" status information.