### PR TITLE
Reworked Karida logic and update to UI

### DIFF
--- a/BasicRotations/Magical/BLM_zAlpha.cs
+++ b/BasicRotations/Magical/BLM_zAlpha.cs
@@ -3,7 +3,7 @@
 [Rotation("zAlpha DO NOT USE", CombatType.PvE, GameVersion = "7.2")]
 [SourceCode(Path = "main/BasicRotations/Magical/BLM_Alpha.cs")]
 [Api(4)]
-public class BLM_Alpha : BlackMageRotation
+public class BLM_zAlpha : BlackMageRotation
 {
     #region Config Options
     [RotationConfig(CombatType.PvE, Name = "Use Transpose to Astral Fire before Paradox")]

--- a/BasicRotations/RebornRotations.csproj
+++ b/BasicRotations/RebornRotations.csproj
@@ -27,7 +27,7 @@
     <Compile Include="Duty\EmanationDefault" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="Magical\BLM_Alpha.cs" />
+    <None Include="Magical\BLM_zAlpha.cs" />
     <None Include="Tank\GNB_Default.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/RotationSolver.Basic/Actions/ActionTargetInfo.cs
+++ b/RotationSolver.Basic/Actions/ActionTargetInfo.cs
@@ -894,6 +894,7 @@ public struct ActionTargetInfo(IBaseAction action)
             TargetType.MimicryTarget => FindMimicryTarget(),
             TargetType.TheSpear => FindTheSpear(),
             TargetType.TheBalance => FindTheBalance(),
+            TargetType.Kardia => FindKardia(),
             _ => FindHostile(),
         };
 
@@ -996,6 +997,44 @@ public struct ActionTargetInfo(IBaseAction action)
                 ?? RandomRangeTarget(IGameObjects)
                 ?? RandomMagicalTarget(IGameObjects)
                 ?? RandomPhysicalTarget(IGameObjects)
+                ?? null;
+        }
+
+        IBattleChara? FindKardia()
+        {
+            Job[] KardiaTankpriority = { Job.PLD, Job.WAR, Job.GNB, Job.DRK, Job.GLA, Job.MRD };
+
+            if (DataCenter.PartyMembers == null) return null;
+
+            // First, prioritize tanks with TankStanceStatus and without Kardion from anyone, accounting for Double Sage parties
+            foreach (var member in DataCenter.PartyMembers.Where(member => member.IsJobCategory(JobRole.Tank)))
+            {
+                foreach (var job in KardiaTankpriority)
+                {
+                    if (member.IsJobs(job) && !member.IsDead && member.HasStatus(false, StatusHelper.TankStanceStatus) && !member.HasStatus(false, StatusID.Kardion))
+                    {
+                        return member;
+                    }
+                }
+            }
+
+            // If no tanks with TankStanceStatus are found, pick any tank
+            foreach (var member in DataCenter.PartyMembers.Where(member => member.IsJobCategory(JobRole.Tank)))
+            {
+                foreach (var job in KardiaTankpriority)
+                {
+                    if (member.IsJobs(job) && !member.IsDead)
+                    {
+                        return member;
+                    }
+                }
+            }
+
+            return FindTankTarget()
+                ?? RandomMeleeTarget(DataCenter.PartyMembers)
+                ?? RandomPhysicalTarget(DataCenter.PartyMembers)
+                ?? RandomRangeTarget(DataCenter.PartyMembers)
+                ?? RandomMagicalTarget(DataCenter.PartyMembers)
                 ?? null;
         }
 
@@ -1378,6 +1417,7 @@ public enum TargetType : byte
     MimicryTarget,
     TheBalance,
     TheSpear,
+    Kardia,
 }
 #pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
 

--- a/RotationSolver.Basic/Helpers/StatusHelper.cs
+++ b/RotationSolver.Basic/Helpers/StatusHelper.cs
@@ -89,6 +89,7 @@ public static class StatusHelper
         StatusID.RoyalGuard_1833,
         StatusID.IronWill,
         StatusID.Defiance,
+        StatusID.Defiance_3124,
     };
 
     /// <summary>

--- a/RotationSolver.Basic/Rotations/Basic/SageRotation.cs
+++ b/RotationSolver.Basic/Rotations/Basic/SageRotation.cs
@@ -71,7 +71,7 @@ partial class SageRotation
 
     static partial void ModifyKardiaPvE(ref ActionSetting setting)
     {
-        setting.TargetType = TargetType.Tank;
+        setting.TargetType = TargetType.Kardia;
         setting.TargetStatusProvide = [StatusID.Kardion];
         setting.ActionCheck = () => !DataCenter.PartyMembers.Any(m => m.HasStatus(true, StatusID.Kardion));
         setting.CreateConfig = () => new ActionConfig()

--- a/RotationSolver/UI/RotationConfigWindow.cs
+++ b/RotationSolver/UI/RotationConfigWindow.cs
@@ -357,12 +357,16 @@ public partial class RotationConfigWindow : Window
                 // Skip the tab if it has the TabSkipAttribute
                 if (item.GetAttribute<TabSkipAttribute>() != null) continue;
 
+                string displayName = item == RotationConfigWindowTab.Job && Player.Object != null
+                    ? Player.Job.ToString() // Use the current player's job name
+                    : item.ToString();
+
                 if (IconSet.GetTexture(item.GetAttribute<TabIconAttribute>()?.Icon ?? 0, out var icon) && wholeWidth <= JOB_ICON_WIDTH * Scale)
                 {
                     ImGuiHelper.DrawItemMiddle(() =>
                     {
                         var cursor = ImGui.GetCursorPos();
-                        if (ImGuiHelper.NoPaddingNoColorImageButton(icon.ImGuiHandle, Vector2.One * iconSize, item.ToString()))
+                        if (ImGuiHelper.NoPaddingNoColorImageButton(icon.ImGuiHandle, Vector2.One * iconSize, displayName))
                         {
                             _activeTab = item;
                             _searchResults = [];
@@ -370,14 +374,14 @@ public partial class RotationConfigWindow : Window
                         ImGuiHelper.DrawActionOverlay(cursor, iconSize, _activeTab == item ? 1 : 0);
                     }, Math.Max(Scale * MIN_COLUMN_WIDTH, wholeWidth), iconSize);
 
-                    var desc = item.ToString();
+                    var desc = displayName;
                     var addition = item.GetDescription();
                     if (!string.IsNullOrEmpty(addition)) desc += "\n \n" + addition;
                     ImguiTooltips.HoveredTooltip(desc);
                 }
                 else
                 {
-                    if (ImGui.Selectable(item.ToString(), _activeTab == item, ImGuiSelectableFlags.None, new Vector2(0, 20)))
+                    if (ImGui.Selectable(displayName, _activeTab == item, ImGuiSelectableFlags.None, new Vector2(0, 20)))
                     {
                         _activeTab = item;
                         _searchResults = [];
@@ -392,6 +396,18 @@ public partial class RotationConfigWindow : Window
 
                 // Add a separator after the "Debug" tab
                 if (item == RotationConfigWindowTab.Debug)
+                {
+                    ImGui.Separator();
+                }
+
+                // Add a separator after the "Debug" tab
+                if (item == RotationConfigWindowTab.Job)
+                {
+                    ImGui.Separator();
+                }
+
+                // Add a separator after the "Debug" tab
+                if (item == RotationConfigWindowTab.Main)
                 {
                     ImGui.Separator();
                 }
@@ -667,6 +683,14 @@ public partial class RotationConfigWindow : Window
                 switch (_activeTab)
                 {
 
+                    case RotationConfigWindowTab.Main:
+                        DrawAbout();
+                        break;
+
+                    case RotationConfigWindowTab.Job:
+                        DrawRotation();
+                        break;
+
                     case RotationConfigWindowTab.AutoDuty:
                         DrawAutoduty();
                         break;
@@ -753,10 +777,17 @@ public partial class RotationConfigWindow : Window
             ImGui.TextWrapped(UiString.ConfigWindow_About_Warning.GetDescription());
         }
 
+        ImGui.Spacing();
+        var width2 = ImGui.GetWindowWidth();
+        if (IconSet.GetTexture("https://storage.ko-fi.com/cdn/brandasset/kofi_button_red.png", out var icon2) && ImGuiHelper.TextureButton(icon2, width2, 250 * Scale, "Ko-fi link"))
+        {
+            Util.OpenLink("https://ko-fi.com/ltscombatreborn");
+        }
+
         var width = ImGui.GetWindowWidth();
 
         // Draw the Discord link button
-        if (IconSet.GetTexture("https://discordapp.com/api/guilds/1064448004498653245/embed.png?style=banner2", out var icon) && ImGuiHelper.TextureButton(icon, width, width))
+        if (IconSet.GetTexture("https://discordapp.com/api/guilds/1064448004498653245/embed.png?style=banner2", out var icon) && ImGuiHelper.TextureButton(icon, width, 250 * Scale, "Discord link"))
         {
             Util.OpenLink("https://discord.gg/p54TZMPnC9");
         }
@@ -2862,6 +2893,20 @@ public partial class RotationConfigWindow : Window
             ImGui.Text("Party Members: None");
         }
 
+        var tankPartyMembers = DataCenter.PartyMembers.Where(member => member.IsJobCategory(JobRole.Tank)).ToList();
+        if (tankPartyMembers.Count != 0)
+        {
+            ImGui.Text("Tank Party Members:");
+            foreach (var member in tankPartyMembers)
+            {
+                ImGui.Text($"- {member.Name}");
+            }
+        }
+        else
+        {
+            ImGui.Text("Tank Party Members: None");
+        }
+
         // Display all party members
         var friendlyNPCMembers = DataCenter.FriendlyNPCMembers;
         if (friendlyNPCMembers.Count != 0)
@@ -2981,6 +3026,8 @@ public partial class RotationConfigWindow : Window
             ImGui.Text($"Is Alive: {battleChara.IsAlive()}");
             ImGui.Text($"Is Party: {battleChara.IsParty()}");
             ImGui.Text($"Is Healer: {battleChara.IsJobCategory(JobRole.Healer)}");
+            ImGui.Text($"Is DPS: {battleChara.IsJobCategory(JobRole.AllDPS)}");
+            ImGui.Text($"Is Tank: {battleChara.IsJobCategory(JobRole.Tank)}");
             ImGui.Text($"Is Alliance: {battleChara.IsAllianceMember()}");
             ImGui.Text($"Distance To Player: {battleChara.DistanceToPlayer()}");
             ImGui.Text($"CanProvoke: {battleChara.CanProvoke()}");

--- a/RotationSolver/UI/RotationConfigWindowTab.cs
+++ b/RotationSolver/UI/RotationConfigWindowTab.cs
@@ -28,6 +28,12 @@ internal enum RotationConfigWindowTab : byte
     [TabSkip] About,
     [TabSkip] Rotation,
 
+    [Description("Useful information and macro list.")]
+    [TabIcon(Icon = 4)] Main,
+
+    [Description("Rotation specific configs.")]
+    [TabIcon(Icon = 4)] Job,
+
     [Description("Configure abilities and custom conditions for your current job.")]
     [TabIcon(Icon = 4)] Actions,
 


### PR DESCRIPTION
- Added new tabs to the sidebar to allow users to access main menu and job configs from there rather than the icons.
- Renamed `BLM_Alpha.cs` to `BLM_zAlpha.cs` to move it off defaulted rotation
- Added a new target type `Kardia` in `ActionTargetInfo.cs` with a method `FindKardia()` for prioritizing tanks with specific statuses.
- Updated `StatusHelper` to include a new status ID `Defiance_3124`.
- Changed the target type for Kardia in `SageRotation.cs` from `Tank` to `Kardia`.
- Overall improvements to functionality and organization, particularly regarding the Kardia target type and Black Mage rotation logic.