### PR TITLE
Adjusted Kardia logic in rotation to account for changes to Kardia targeting

### DIFF
--- a/BasicRotations/Healer/SGE_Default.cs
+++ b/BasicRotations/Healer/SGE_Default.cs
@@ -1,6 +1,6 @@
 namespace RebornRotations.Healer;
 
-[Rotation("Default", CombatType.PvE, GameVersion = "7.2")]
+[Rotation("Default", CombatType.PvE, GameVersion = "7.21")]
 [SourceCode(Path = "main/BasicRotations/Healer/SGE_Default.cs")]
 [Api(4)]
 public sealed class SGE_Default : SageRotation
@@ -198,8 +198,6 @@ public sealed class SGE_Default : SageRotation
 
         if ((!TaurocholePvE.EnoughLevel || TaurocholePvE.Cooldown.IsCoolingDown) && DruocholePvE.CanUse(out act)) return true;
 
-
-
         foreach (var member in PartyMembers)
         {
             if (SoteriaPvE.CanUse(out act) && member.HasStatus(true, StatusID.Kardion) && member.GetHealthRatio() < SoteriaHeal)
@@ -251,13 +249,11 @@ public sealed class SGE_Default : SageRotation
         return base.HealSingleAbility(nextGCD, out act);
     }
 
-    [RotationDesc(ActionID.EukrasianPrognosisPvE, ActionID.EukrasianPrognosisIiPvE)]
+    [RotationDesc(ActionID.KardiaPvE, ActionID.RhizomataPvE, ActionID.SoteriaPvE)]
     protected override bool GeneralAbility(IAction nextGCD, out IAction? act)
     {
-        // If not in combat and lacking the Kardia status, attempt to use KardiaPvE
-        if (!InCombat && !Player.HasStatus(true, StatusID.Kardia) && KardiaPvE.CanUse(out act)) return true;
-
-        if (KardiaPvE.CanUse(out act)) return true;
+        // If lacking the Kardia status, attempt to use KardiaPvE
+        if (!HasKardia && KardiaPvE.CanUse(out act)) return true;
 
         if (OOCRhizomata && !InCombat && Addersgall <= 1 && RhizomataPvE.CanUse(out act)) return true;
         if (InCombat && Addersgall <= 1 && RhizomataPvE.CanUse(out act)) return true;
@@ -411,8 +407,8 @@ public sealed class SGE_Default : SageRotation
             if (PneumaPvE.CanUse(out act)) return true;
         }
 
-        if (Player.HasStatus(true, StatusID.Eukrasia) && EukrasiaActionHeal && EukrasianPrognosisPvE.CanUse(out act)) return true;
-        if (EukrasiaPvE.EnoughLevel && !Player.HasStatus(true, StatusID.Eukrasia) && EukrasiaActionHeal && EukrasiaPvE.CanUse(out act)) return true;
+        if (HasEukrasia && EukrasiaActionHeal && EukrasianPrognosisPvE.CanUse(out act)) return true;
+        if (EukrasiaPvE.EnoughLevel && !HasEukrasia && EukrasiaActionHeal && EukrasiaPvE.CanUse(out act)) return true;
 
         if (_EukrasiaActionAim == null && PrognosisPvE.CanUse(out act))
         {
@@ -427,8 +423,8 @@ public sealed class SGE_Default : SageRotation
     {
         act = null;
         if (IsLastAction(ActionID.SwiftcastPvE) && SwiftLogic && MergedStatus.HasFlag(AutoStatus.Raise)) return false;
-        if (Player.HasStatus(true, StatusID.Eukrasia) && EukrasiaActionHeal && EukrasianDiagnosisPvE.CanUse(out act)) return true;
-        if (EukrasiaPvE.EnoughLevel && !Player.HasStatus(true, StatusID.Eukrasia) && EukrasiaActionHeal && EukrasiaPvE.CanUse(out act)) return true;
+        if (HasEukrasia && EukrasiaActionHeal && EukrasianDiagnosisPvE.CanUse(out act)) return true;
+        if (EukrasiaPvE.EnoughLevel && !HasEukrasia && EukrasiaActionHeal && EukrasiaPvE.CanUse(out act)) return true;
         if (_EukrasiaActionAim == null && DiagnosisPvE.CanUse(out act)) return true;
         return base.HealSingleGCD(out act);
     }
@@ -467,7 +463,7 @@ public sealed class SGE_Default : SageRotation
         if (DoEukrasianDosis(out act)) return true;
         if (DosisPvE.CanUse(out act)) return true;
 
-        if (OOCEukrasia && !InCombat && !Player.HasStatus(true, StatusID.Eukrasia) && EukrasiaPvE.CanUse(out act)) return true;
+        if (OOCEukrasia && !InCombat && !HasEukrasia && EukrasiaPvE.CanUse(out act)) return true;
         if (InCombat && !HasHostilesInRange && EukrasiaPvE.CanUse(out act)) return true;
         return base.GeneralGCD(out act);
     }

--- a/RotationSolver.Basic/Actions/ActionBasicInfo.cs
+++ b/RotationSolver.Basic/Actions/ActionBasicInfo.cs
@@ -10,6 +10,9 @@ namespace RotationSolver.Basic.Actions;
 /// </summary>
 public readonly struct ActionBasicInfo
 {
+    /// <summary>
+    /// Actions that do not require casting.
+    /// </summary>
     internal static readonly uint[] ActionsNoNeedCasting =
     [
         5,
@@ -20,78 +23,78 @@ public readonly struct ActionBasicInfo
     private readonly IBaseAction _action;
 
     /// <summary>
-    /// The name of the action.
+    /// Gets the name of the action.
     /// </summary>
     public readonly string Name => _action.Action.Name.ExtractText();
 
     /// <summary>
-    /// The ID of the action.
+    /// Gets the unique identifier of the action.
     /// </summary>
     public readonly uint ID => _action.Action.RowId;
 
     /// <summary>
-    /// The Range of the action.
+    /// Gets the range of the action.
     /// </summary>
     public readonly sbyte Range => _action.Action.Range;
 
     /// <summary>
-    /// The EffectRange of the action.
+    /// Gets the effect range of the action.
     /// </summary>
     public readonly byte EffectRange => _action.Action.EffectRange;
 
     /// <summary>
-    /// The icon of the action.
+    /// Gets the icon ID of the action.
     /// </summary>
     public readonly uint IconID => ID == (uint)ActionID.SprintPvE ? 104u : _action.Action.Icon;
 
     /// <summary>
-    /// The adjust id of this action.
+    /// Gets the adjusted ID of the action, considering any modifications.
     /// </summary>
     public readonly uint AdjustedID => (uint)Service.GetAdjustedActionId((ActionID)ID);
 
     /// <summary>
-    /// The attack type of this action.
+    /// Gets the attack type of the action.
     /// </summary>
     public readonly AttackType AttackType => (AttackType)(_action.Action.AttackType.RowId != 0 ? _action.Action.AttackType.RowId : byte.MaxValue);
 
     /// <summary>
-    /// The aspect of this action.
+    /// Gets the aspect of the action.
     /// </summary>
     public Aspect Aspect { get; }
 
     /// <summary>
-    /// The animation lock time of this action.
+    /// Gets the animation lock time of the action.
     /// </summary>
     [Obsolete("Use ActionManagerHelper.GetCurrentAnimationLock()")]
     public readonly float AnimationLockTime => ActionManagerHelper.GetCurrentAnimationLock();
 
     /// <summary>
-    /// The level of this action.
+    /// Gets the level required to use the action.
     /// </summary>
     public readonly byte Level => _action.Action.ClassJobLevel;
 
     /// <summary>
-    /// If this action is enough level to use.
+    /// Determines whether the player's level is sufficient to use the action.
     /// </summary>
     public readonly bool EnoughLevel => Player.Level >= Level;
 
     /// <summary>
-    /// If this action a pvp action.
+    /// Determines whether the action is a PvP action.
     /// </summary>
     public readonly bool IsPvP => _action.Action.IsPvP;
 
     /// <summary>
-    /// If this action a pvp action.
+    /// Gets the cast type of the action.
     /// </summary>
     public readonly byte CastType => _action.Action.CastType;
 
     /// <summary>
-    /// Casting time.
+    /// Gets the casting time of the action.
     /// </summary>
     public readonly unsafe float CastTime => ((ActionID)AdjustedID).GetCastTime();
 
     /// <summary>
-    /// How many mp does this action needs.
+    /// Gets the MP required to use the action.
     /// </summary>
     public readonly unsafe uint MPNeed
     {
@@ -110,7 +113,7 @@ public readonly struct ActionBasicInfo
     }
 
     /// <summary>
-    /// Is this action on the slot.
+    /// Determines whether the action is on the player's hotbar or slot.
     /// </summary>
     public readonly bool IsOnSlot
     {
@@ -131,30 +134,30 @@ public readonly struct ActionBasicInfo
     }
 
     /// <summary>
-    /// Is this action is a lb action.
+    /// Determines whether the action is a limit break action.
     /// </summary>
     public bool IsLimitBreak { get; }
 
     /// <summary>
-    /// Is this action a general gcd.
+    /// Determines whether the action is a general global cooldown (GCD) action.
     /// </summary>
     public bool IsGeneralGCD { get; }
 
     /// <summary>
-    /// Is this action a real gcd.
+    /// Determines whether the action is a real global cooldown (GCD) action.
     /// </summary>
     public bool IsRealGCD { get; }
 
     /// <summary>
-    /// Is this action a duty action.
+    /// Determines whether the action is a duty action.
     /// </summary>
     public bool IsDutyAction { get; }
 
     /// <summary>
-    /// The basic way to create a basic info
+    /// Initializes a new instance of the <see cref="ActionBasicInfo"/> struct.
     /// </summary>
-    /// <param name="action">the action</param>
-    /// <param name="isDutyAction">if it is a duty action.</param>
+    /// <param name="action">The base action.</param>
+    /// <param name="isDutyAction">Indicates whether the action is a duty action.</param>
     public ActionBasicInfo(IBaseAction action, bool isDutyAction)
     {
         _action = action;
@@ -166,6 +169,13 @@ public readonly struct ActionBasicInfo
         Aspect = (Aspect)_action.Action.Aspect;
     }
 
+    /// <summary>
+    /// Performs a basic check to determine whether the action can be used.
+    /// </summary>
+    /// <param name="skipStatusProvideCheck">Whether to skip the status provide check.</param>
+    /// <param name="skipComboCheck">Whether to skip the combo check.</param>
+    /// <param name="skipCastingCheck">Whether to skip the casting check.</param>
+    /// <returns>True if the action passes the basic check; otherwise, false.</returns>
     internal readonly bool BasicCheck(bool skipStatusProvideCheck, bool skipComboCheck, bool skipCastingCheck)
     {
         if (Player.Object == null) return false;
@@ -185,7 +195,7 @@ public readonly struct ActionBasicInfo
     }
 
     /// <summary>
-    /// Whether the spell is unlocked by the player
+    /// Determines whether the spell is unlocked for the player.
     /// </summary>
     public unsafe bool SpellUnlocked => _action.Action.UnlockLink.RowId <= 0 || UIState.Instance()->IsUnlockLinkUnlockedOrQuestCompleted(_action.Action.UnlockLink.RowId);
 

--- a/RotationSolver.Basic/Rotations/Basic/SageRotation.cs
+++ b/RotationSolver.Basic/Rotations/Basic/SageRotation.cs
@@ -55,6 +55,13 @@ partial class SageRotation
     }
     #endregion
 
+    #region Status Tracking
+    /// <summary>
+    /// Player has Kardia.
+    /// </summary>
+    public static bool HasKardia => Player.HasStatus(true, StatusID.Kardia);
+    #endregion
+
     #region PvE Actions
     private protected sealed override IBaseAction Raise => EgeiroPvE;
 
@@ -156,6 +163,7 @@ partial class SageRotation
     {
         setting.StatusProvide = [StatusID.Soteria];
         setting.TargetType = TargetType.Self;
+        setting.ActionCheck = () => DataCenter.PartyMembers.Any(m => m.HasStatus(true, StatusID.Kardion));
     }
 
     static partial void ModifyIcarusPvE(ref ActionSetting setting)


### PR DESCRIPTION
- Kardia no longer checks for in combat or not, and does not reapply if Player already has Kardia status
- Soteria now requires a party member to have Kardia applied to them by Player
- Updated XML comments on ActionBasicInfo because i was bored