### PR TITLE
Enhance healing logic and target management

### DIFF
--- a/BasicRotations/Healer/SCH_Default.cs
+++ b/BasicRotations/Healer/SCH_Default.cs
@@ -241,7 +241,8 @@ public sealed class SCH_Default : ScholarRotation
         // Deployment Tactics is modified in the base rotation to only use if they have galvanize so can trust that targets are at least valid?
         // The number of times that we adlo to heal a DPS and then would like to use this is actually reasonably high in dungeons
         // TODO: This is typically skipping because the target it's trying to cast the area defense on isn't the galvanized target
-        if (DeploymentTacticsPvE.CanUse(out act)) return true;
+        if ((!RecitationPvE.EnoughLevel || RecitationPvE.Cooldown.IsCoolingDown || PartyMembers.Any(member => member.HasStatus(true, StatusID.Catalyze))) 
+            && DeploymentTacticsPvE.CanUse(out act)) return true;
 
         // Consolation is great if Seraph is up
         if (ConsolationPvE.CanUse(out act, usedUp: true)) return true;

--- a/BasicRotations/Magical/BLM_Default.cs
+++ b/BasicRotations/Magical/BLM_Default.cs
@@ -301,7 +301,7 @@ public class BLM_Default : BlackMageRotation
         if (AddThunder(out act, 0) && Player.WillStatusEndGCD(1, 0, true,
             StatusID.Thundercloud)) return true;
 
-        if (UmbralHearts < 2 && FlarePvE.CanUse(out act)) return true;
+        if (UmbralHearts < 2 && AstralSoulStacks <= 3 && FlarePvE.CanUse(out act)) return true;
         if (FireIiPvE.CanUse(out act)) return true;
 
         if (CurrentMp >= FirePvE.Info.MPNeed + 800)

--- a/BasicRotations/Magical/BLM_zAlpha.cs
+++ b/BasicRotations/Magical/BLM_zAlpha.cs
@@ -301,7 +301,7 @@ public class BLM_zAlpha : BlackMageRotation
 
         if (AddThunder(out act)) return true;
 
-        if (UmbralHearts < 2 && FlarePvE.CanUse(out act)) return true;
+        if (UmbralHearts < 2 && AstralSoulStacks <= 3 && FlarePvE.CanUse(out act)) return true;
         if (FireIiPvE.CanUse(out act)) return true;
 
         if (CurrentMp >= FirePvE.Info.MPNeed + 800)

--- a/RotationSolver.Basic/Helpers/ObjectHelper.cs
+++ b/RotationSolver.Basic/Helpers/ObjectHelper.cs
@@ -430,7 +430,7 @@ public static class ObjectHelper
             || obj.IsResistanceImmune()
             || obj.IsOmegaImmune()
             || obj.IsLimitlessBlue()
-            || obj.IsHanselorGretelSheilded();
+            || obj.IsHanselorGretelShielded();
     }
 
     /// <summary>
@@ -709,7 +709,7 @@ public static class ObjectHelper
     /// </summary>
     /// <param name="obj">the object.</param>
     /// <returns></returns>
-    public static bool IsHanselorGretelSheilded(this IBattleChara obj)
+    public static bool IsHanselorGretelShielded(this IBattleChara obj)
     {
         var strongOfShieldPositional = EnemyPositional.Front;
         var strongOfShieldStatus = StatusID.StrongOfShield;

--- a/RotationSolver.Basic/Rotations/Basic/BlackMageRotation.cs
+++ b/RotationSolver.Basic/Rotations/Basic/BlackMageRotation.cs
@@ -370,7 +370,7 @@ partial class BlackMageRotation
 
     static partial void ModifyFlarePvE(ref ActionSetting setting)
     {
-        setting.ActionCheck = () => InAstralFire && AstralSoulStacks <= 3;
+        setting.ActionCheck = () => InAstralFire;
         setting.UnlockedByQuestID = 66614;
         setting.CreateConfig = () => new ActionConfig()
         {

--- a/RotationSolver.Basic/Rotations/Basic/ScholarRotation.cs
+++ b/RotationSolver.Basic/Rotations/Basic/ScholarRotation.cs
@@ -231,7 +231,7 @@ partial class ScholarRotation
 
     static partial void ModifyDeploymentTacticsPvE(ref ActionSetting setting)
     {
-        setting.TargetStatusNeed = [StatusID.Galvanize];
+        setting.TargetType = TargetType.Deployment;
         setting.UnlockedByQuestID = 67210;
         setting.CreateConfig = () => new ActionConfig()
         {


### PR DESCRIPTION
- Updated `SCH_Default` to improve checks Deployment Tactics
- Modified `BLM_Default` and `BLM_zAlpha` to limit Flare usage to 3 or fewer Astral Soul Stacks.
- Added `FindDeploymentTacticsTarget` method in `ActionTargetInfo` for better target selection.
- Updated `TargetType` enum to include Deployment for precise targeting.
- Fixed typo in `ObjectHelper` method name for consistency.
- Adjusted `BlackMageRotation` to allow more flexible Flare usage.
- Revised `ModifyDeploymentTacticsPvE` in `ScholarRotation` to align with new targeting logic.