### PR TITLE
Countdown, teaching mode, WAR update, threadsafe consistency

### DIFF
--- a/BasicRotations/Tank/WAR_Default.cs
+++ b/BasicRotations/Tank/WAR_Default.cs
@@ -25,6 +25,9 @@ public sealed class WAR_Default : WarriorRotation
     [RotationConfig(CombatType.PvE, Name = "Use a stack of Onslaught during when its about to overcap while standing still")]
     public bool YEETCooldown { get; set; } = false;
 
+    [RotationConfig(CombatType.PvE, Name = "Take targets hitbox size into account for Primal Rend distance calculation. (Beta)")]
+    public bool YEETBeta { get; set; } = false;
+
     [Range(1, 20, ConfigUnitType.Yalms)]
     [RotationConfig(CombatType.PvE, Name = "Max distance you can be from the boss for Primal Rend use (Danger, setting too high will get you killed)")]
     public float PrimalRendDistance2 { get; set; } = 3.5f;
@@ -182,7 +185,8 @@ public sealed class WAR_Default : WarriorRotation
         {
             if ((YEET || (!YEET && !IsMoving)) && PrimalRendPvE.CanUse(out act, skipAoeCheck: true))
             {
-                if (PrimalRendPvE.Target.Target?.DistanceToPlayer() < PrimalRendDistance2) return true;
+                if (!YEETBeta && PrimalRendPvE.Target.Target?.DistanceToPlayer() < PrimalRendDistance2) return true;
+                if (YEETBeta && PrimalRendPvE.Target.Target?.DistanceToPlayer() + PrimalRendPvE.Target.Target?.HitboxRadius < PrimalRendDistance2) return true;
             }
             if (PrimalRuinationPvE.CanUse(out act)) return true;
         }

--- a/RotationSolver.Basic/Actions/ActionBasicInfo.cs
+++ b/RotationSolver.Basic/Actions/ActionBasicInfo.cs
@@ -178,7 +178,6 @@ public readonly struct ActionBasicInfo
     /// <returns>True if the action passes the basic check; otherwise, false.</returns>
     internal readonly bool BasicCheck(bool skipStatusProvideCheck, bool skipComboCheck, bool skipCastingCheck)
     {
-        if (Player.Object == null) return false;
         if (Player.Object.StatusList == null) return false;
 
         if (!IsActionEnabled() || !IsOnSlot) return false;
@@ -207,14 +206,12 @@ public readonly struct ActionBasicInfo
 
     private bool IsStatusNeeded()
     {
-        if (Player.Object == null) return false;
         if (Player.Object.StatusList == null) return false;
         return _action.Setting.StatusNeed != null && Player.Object.WillStatusEndGCD(_action.Config.StatusGcdCount, 0, _action.Setting.StatusFromSelf, _action.Setting.StatusNeed);
     }
 
     private bool IsStatusProvided(bool skipStatusProvideCheck)
     {
-        if (Player.Object == null) return false;
         if (Player.Object.StatusList == null) return false;
         return !skipStatusProvideCheck && _action.Setting.StatusProvide != null && !Player.Object.WillStatusEndGCD(_action.Config.StatusGcdCount, 0, _action.Setting.StatusFromSelf, _action.Setting.StatusProvide);
     }

--- a/RotationSolver.Basic/Actions/ActionTargetInfo.cs
+++ b/RotationSolver.Basic/Actions/ActionTargetInfo.cs
@@ -171,7 +171,7 @@ public struct ActionTargetInfo(IBaseAction action)
     private unsafe bool CanUseTo(IGameObject tar)
     {
         if (tar == null) return false;
-        if (!Player.Available) return false;
+        if (!Player.AvailableThreadSafe) return false;
         if (tar.GameObjectId == 0) return false;
         if (tar.Struct() == null) return false;
 
@@ -379,11 +379,6 @@ public struct ActionTargetInfo(IBaseAction action)
     {
         var range = Range;
 
-        if (Player.Object == null)
-        {
-            return null;
-        }
-
         if (action == null || action.Setting == null || action.Config == null)
         {
             return null;
@@ -500,8 +495,6 @@ public struct ActionTargetInfo(IBaseAction action)
     /// </returns>
     private TargetResult? FindTargetAreaMove(float range)
     {
-        if (Player.Object == null) return null;
-
         if (Service.Config.MoveAreaActionFarthest)
         {
             Vector3 pPosition = Player.Object.Position;
@@ -558,7 +551,6 @@ public struct ActionTargetInfo(IBaseAction action)
     /// </returns>
     private TargetResult? FindTargetAreaFriend(float range, IEnumerable<IBattleChara> canAffects, IPlayerCharacter player)
     {
-        if (Player.Object == null) return null;
         if (canAffects == null) return null;
 
         // Check if the action's range is zero and handle it as targeting self
@@ -704,7 +696,6 @@ public struct ActionTargetInfo(IBaseAction action)
     /// </returns>
     private IEnumerable<IBattleChara> GetAffectsVector(Vector3? point, IEnumerable<IBattleChara> canAffects)
     {
-        if (Player.Object == null) yield break;
         if (canAffects == null) yield break;
         if (point == null) yield break;
 
@@ -727,7 +718,6 @@ public struct ActionTargetInfo(IBaseAction action)
     /// </returns>
     private IEnumerable<IBattleChara> GetAffectsTarget(IBattleChara tar, IEnumerable<IBattleChara> canAffects)
     {
-        if (Player.Object == null) yield break;
         if (tar == null) yield break;
         if (canAffects == null) yield break;
 
@@ -869,8 +859,6 @@ public struct ActionTargetInfo(IBaseAction action)
     /// <returns></returns>
     public static IBattleChara? FindTargetByType(IEnumerable<IBattleChara> IGameObjects, TargetType type, float healRatio, SpecialActionType actionType)
     {
-        if (!Player.AvailableThreadSafe) return null;
-        if (Player.Object == null) return null;
         if (IGameObjects == null) return null;
 
         if (type == TargetType.Self) return Player.Object;
@@ -1139,7 +1127,7 @@ public struct ActionTargetInfo(IBaseAction action)
 
         IBattleChara? FindTargetForMoving()
         {
-            if (Service.Config == null || Player.Object == null || IGameObjects == null)
+            if (Service.Config == null || IGameObjects == null)
             {
                 return null;
             }

--- a/RotationSolver.Basic/Actions/BaseAction.cs
+++ b/RotationSolver.Basic/Actions/BaseAction.cs
@@ -200,7 +200,7 @@ public class BaseAction : IBaseAction
 
             var loc = target.Position.Value;
 
-            if (Player.Object == null || ActionManager.Instance() == null)
+            if (ActionManager.Instance() == null)
             {
                 return false;
             }

--- a/RotationSolver.Basic/Actions/HpPotionItem.cs
+++ b/RotationSolver.Basic/Actions/HpPotionItem.cs
@@ -12,7 +12,7 @@ internal class HpPotionItem : BaseItem
     {
         get
         {
-            if (!Player.Available) return 0;
+            if (!Player.AvailableThreadSafe) return 0;
             return Math.Min((uint)(Player.Object.MaxHp * _percent), _maxHp);
         }
     }
@@ -29,7 +29,7 @@ internal class HpPotionItem : BaseItem
     public override bool CanUse(out IAction item, bool clippingCheck)
     {
         item = this;
-        if (!Player.Available) return false;
+        if (!Player.AvailableThreadSafe) return false;
         if (Player.Object.GetHealthRatio() > Service.Config.HealthSingleAbilityHot) return false;
         if (Player.Object.MaxHp - Player.Object.CurrentHp < MaxHp) return false;
         return base.CanUse(out item);

--- a/RotationSolver.Basic/Actions/MpPotionItem.cs
+++ b/RotationSolver.Basic/Actions/MpPotionItem.cs
@@ -17,7 +17,7 @@ internal class MpPotionItem : BaseItem
     public override bool CanUse(out IAction item, bool clippingCheck)
     {
         item = this;
-        if (!Player.Available) return false;
+        if (!Player.AvailableThreadSafe) return false;
         if (Player.Object.MaxMp - DataCenter.CurrentMp < MaxMp) return false;
         return base.CanUse(out item);
     }

--- a/RotationSolver.Basic/Configuration/Conditions/DelayCondition.cs
+++ b/RotationSolver.Basic/Configuration/Conditions/DelayCondition.cs
@@ -54,7 +54,7 @@ internal abstract class DelayCondition : ICondition
 
     public virtual bool CheckBefore(ICustomRotation rotation)
     {
-        return Player.Available;
+        return Player.AvailableThreadSafe;
     }
 
     internal static bool CheckBaseAction(ICustomRotation rotation, ActionID id, ref IBaseAction? action)

--- a/RotationSolver.Basic/Configuration/Conditions/TraitCondition.cs
+++ b/RotationSolver.Basic/Configuration/Conditions/TraitCondition.cs
@@ -20,7 +20,7 @@ internal class TraitCondition : DelayCondition
 
     protected override bool IsTrueInside(ICustomRotation rotation)
     {
-        if (_trait == null || !Player.Available) return false;
+        if (_trait == null || !Player.AvailableThreadSafe) return false;
 
         var result = _trait.EnoughLevel;
         return result;

--- a/RotationSolver.Basic/Configuration/Configs.cs
+++ b/RotationSolver.Basic/Configuration/Configs.cs
@@ -548,7 +548,7 @@ internal partial class Configs : IPluginConfiguration
     [UI("Clicking actions random delay range.",
         Filter = BasicTimer)]
     [Range(0.00f, 0.25f, ConfigUnitType.Seconds, 0.002f)]
-    public Vector2 ClickingDelay { get; set; } = new(0.01f, 0.1f);
+    public Vector2 ClickingDelay { get; set; } = new(0.1f, 0.2f);
 
     [UI("Downtime healing delay range.", Parent = nameof(HealWhenNothingTodo))]
     [Range(0, 5, ConfigUnitType.Seconds, 0.05f)]
@@ -645,7 +645,7 @@ internal partial class Configs : IPluginConfiguration
 
     [Range(0, 5, ConfigUnitType.None, 1)]
     [UI("Random range of simulated presses per action", Parent = nameof(KeyBoardNoise))]
-    public Vector2Int KeyboardNoise { get; set; } = new(1, 2);
+    public Vector2Int KeyboardNoise { get; set; } = new(2, 3);
 
     [Range(0, 10, ConfigUnitType.None)]
     public int TargetingIndex { get; set; }

--- a/RotationSolver.Basic/DataCenter.cs
+++ b/RotationSolver.Basic/DataCenter.cs
@@ -22,7 +22,7 @@ internal static class DataCenter
 
     public static bool ResetActionConfigs { get; set; } = false;
 
-    public static bool IsActivated() => Player.Available && (State || IsManual || Service.Config.TeachingMode);
+    public static bool IsActivated() => Player.AvailableThreadSafe && (State || IsManual || Service.Config.TeachingMode);
 
     internal static IBattleChara? HostileTarget
     {
@@ -491,7 +491,7 @@ internal static class DataCenter
         get
         {
             float radius = 25;
-            if (!Player.Available) return radius;
+            if (!Player.AvailableThreadSafe) return radius;
 
             switch (DataCenter.Role)
             {
@@ -837,7 +837,7 @@ internal static class DataCenter
 
     internal static unsafe void AddActionRec(Action act)
     {
-        if (!Player.Available) return;
+        if (!Player.AvailableThreadSafe) return;
 
         var id = (ActionID)act.RowId;
 
@@ -901,7 +901,7 @@ internal static class DataCenter
     {
         return IsCastingVfx(VfxDataQueue, s =>
         {
-            if (!Player.Available) return false;
+            if (!Player.AvailableThreadSafe) return false;
             if (Player.Object.IsJobCategory(JobRole.Tank) && s.ObjectId != Player.Object.GameObjectId) return false;
 
             if (!s.Path.StartsWith("vfx/lockon/eff/tank_lockon")
@@ -914,7 +914,7 @@ internal static class DataCenter
     {
         return IsCastingVfx(VfxDataQueue, s =>
         {
-            if (!Player.Available) return false;
+            if (!Player.AvailableThreadSafe) return false;
 
             if (!s.Path.StartsWith("vfx/lockon/eff/coshare")
             && !s.Path.StartsWith("vfx/lockon/eff/share_laser")

--- a/RotationSolver.Basic/Helpers/ObjectHelper.cs
+++ b/RotationSolver.Basic/Helpers/ObjectHelper.cs
@@ -172,7 +172,6 @@ public static class ObjectHelper
     internal static bool IsSpecialExecptionImmune(this IBattleChara obj)
     {
         if (obj == null) return false;
-        if (Player.Object == null) return false;
 
         if (obj.NameId == 9441) return true; // Special case for Bottom gate in CLL
         return false;
@@ -207,8 +206,6 @@ public static class ObjectHelper
     internal static bool IsParty(this IGameObject gameObject)
     {
         if (gameObject == null) return false;
-
-        if (Player.Object == null) return false;
 
         if (gameObject.GameObjectId == Player.Object.GameObjectId) return true;
 
@@ -317,7 +314,6 @@ public static class ObjectHelper
 
         if (obj is IBattleChara b)
         {
-            if (Player.Object == null) return false;
             // Check IBattleChara against the priority target list of OIDs
             if (PriorityTargetHelper.IsPriorityTarget(b.DataId)) return true;
 
@@ -421,9 +417,6 @@ public static class ObjectHelper
     /// <returns>True if the target is immune due to any special mechanic; otherwise, false.</returns>
     public static bool IsSpecialImmune(this IBattleChara obj)
     {
-        if (obj == null) return false;
-        if (Player.Object == null) return false;
-
         return obj.IsWolfImmune()
             || obj.IsJeunoBossImmune()
             || obj.IsCODBossImmune()
@@ -736,7 +729,6 @@ public static class ObjectHelper
     public static bool IsBossFromTTK(this IBattleChara obj)
     {
         if (obj == null) return false;
-        if (Player.Object == null) return false;
 
         if (obj.IsDummy()) return true;
 
@@ -752,7 +744,6 @@ public static class ObjectHelper
     public static bool IsBossFromIcon(this IBattleChara obj)
     {
         if (obj == null) return false;
-        if (Player.Object == null) return false;
 
         if (obj.IsDummy()) return true;
 
@@ -769,7 +760,6 @@ public static class ObjectHelper
     public static bool IsDying(this IBattleChara obj)
     {
         if (obj == null) return false;
-        if (Player.Object == null) return false;
 
         if (obj.IsDummy()) return false;
         return obj.GetTTK() <= Service.Config.DyingTimeToKill || obj.GetHealthRatio() < Service.Config.IsDyingConfig;
@@ -785,7 +775,6 @@ public static class ObjectHelper
     internal static unsafe bool InCombat(this IBattleChara obj)
     {
         if (obj == null) return false;
-        if (Player.Object == null) return false;
         if (obj.Struct() == null) return false;
 
         return obj.Struct()->Character.InCombat;
@@ -868,7 +857,6 @@ public static class ObjectHelper
     internal static float TimeAlive(this IBattleChara obj)
     {
         if (obj == null) return float.NaN;
-        if (Player.Object == null) return float.NaN;
 
         // If the character is dead, reset their alive time
         if (obj.IsDead || Svc.Condition[ConditionFlag.BetweenAreas])
@@ -898,7 +886,6 @@ public static class ObjectHelper
     internal static float TimeDead(this IBattleChara obj)
     {
         if (obj == null) return float.NaN;
-        if (Player.Object == null) return float.NaN;
 
         // If the character is alive, reset their dead time
         if (!obj.IsDead)
@@ -926,7 +913,6 @@ public static class ObjectHelper
     internal static bool IsAttacked(this IBattleChara obj)
     {
         if (obj == null) return false;
-        if (Player.Object == null) return false;
         var now = DateTime.Now;
         foreach (var (id, time) in DataCenter.AttackedTargets)
         {
@@ -948,7 +934,6 @@ public static class ObjectHelper
     internal static unsafe bool CanSee(this IGameObject obj)
     {
         if (obj == null) return false;
-        if (Player.Object == null) return false;
         if (obj.Struct() == null) return false;
 
         const uint specificEnemyId = 3830; // Bioculture Node in Aetherial Chemical Research Facility
@@ -978,7 +963,6 @@ public static class ObjectHelper
     public static float GetHealthRatio(this IGameObject obj)
     {
         if (obj == null) return 0;
-        if (Player.Object == null) return 0;
         if (obj is not IBattleChara b) return 0;
 
         if (DataCenter.RefinedHP.TryGetValue(b.GameObjectId, out var hp)) return hp;
@@ -996,7 +980,6 @@ public static class ObjectHelper
     public static EnemyPositional FindEnemyPositional(this IGameObject enemy)
     {
         if (enemy == null) return EnemyPositional.None;
-        if (Player.Object == null) return EnemyPositional.None;
         if (enemy is not IBattleChara b) return EnemyPositional.None;
 
         Vector3 pPosition = enemy.Position;
@@ -1028,7 +1011,6 @@ public static class ObjectHelper
     internal static Vector3 GetFaceVector(this IGameObject obj)
     {
         if (obj == null) return Vector3.Zero;
-        if (Player.Object == null) return Vector3.Zero;
         if (obj is not IBattleChara b) return Vector3.Zero;
 
         float rotation = obj.Rotation;
@@ -1060,7 +1042,6 @@ public static class ObjectHelper
     public static float DistanceToPlayer(this IGameObject? obj)
     {
         if (obj == null) return float.MaxValue;
-        if (Player.Object == null) return float.MaxValue;
         if (obj is not IBattleChara b) return float.MaxValue;
 
         var distance = Vector3.Distance(Player.Object.Position, obj.Position) - (Player.Object.HitboxRadius + obj.HitboxRadius);

--- a/RotationSolver.Basic/Helpers/StatusHelper.cs
+++ b/RotationSolver.Basic/Helpers/StatusHelper.cs
@@ -388,7 +388,6 @@ public static class StatusHelper
     /// <returns>An enumerable of all statuses.</returns>
     private static IEnumerable<Status> GetAllStatus(this IGameObject obj, bool isFromSelf)
     {
-        if (Player.Object == null) return Enumerable.Empty<Status>();
         if (obj == null) return Enumerable.Empty<Status>();
         if (obj is not IBattleChara b) return Enumerable.Empty<Status>();
 

--- a/RotationSolver/UI/HighlightTeachingMode/HotbarHighlightManager.cs
+++ b/RotationSolver/UI/HighlightTeachingMode/HotbarHighlightManager.cs
@@ -1,6 +1,4 @@
-﻿using Dalamud.Game.ClientState.Conditions;
-using ECommons.DalamudServices;
-using ECommons.Logging;
+﻿using ECommons.Logging;
 using RotationSolver.UI.HighlightTeachingMode.ElementSpecial;
 using RotationSolver.Updaters;
 
@@ -33,7 +31,7 @@ internal static class HotbarHighlightManager
     public static void UpdateSettings()
     {
         //UseTaskToAccelerate = Service.Config.UseTasksForOverlay;
-        Enable = !Svc.Condition[ConditionFlag.OccupiedInCutSceneEvent] && Service.Config.TeachingMode && MajorUpdater.IsValid;
+        Enable = Service.Config.TeachingMode && MajorUpdater.IsValid;
         HighlightColor = Service.Config.TeachingModeColor;
     }
 

--- a/RotationSolver/UI/RotationConfigWindow.cs
+++ b/RotationSolver/UI/RotationConfigWindow.cs
@@ -174,7 +174,7 @@ public partial class RotationConfigWindow : Window
             }
         }
 
-        if (Player.Object != null && (Player.Job == Job.CRP || Player.Job == Job.BSM || Player.Job == Job.ARM || Player.Job == Job.GSM ||
+        if (Player.AvailableThreadSafe && (Player.Job == Job.CRP || Player.Job == Job.BSM || Player.Job == Job.ARM || Player.Job == Job.GSM ||
         Player.Job == Job.LTW || Player.Job == Job.WVR || Player.Job == Job.ALC || Player.Job == Job.CUL ||
         Player.Job == Job.MIN || Player.Job == Job.FSH || Player.Job == Job.BTN))
         {
@@ -281,10 +281,10 @@ public partial class RotationConfigWindow : Window
 
         if (enabledIncompatiblePlugin.Name != null)
         {
-            errorText = $"Disable {enabledIncompatiblePlugin.Name}, can cause conflicts.";
+            errorText = $"Disable {enabledIncompatiblePlugin.Name}, can cause conflicts/crashes.";
         }
 
-        if (Player.Object != null && (Player.Job == Job.CRP || Player.Job == Job.BSM || Player.Job == Job.ARM || Player.Job == Job.GSM ||
+        if (Player.AvailableThreadSafe && (Player.Job == Job.CRP || Player.Job == Job.BSM || Player.Job == Job.ARM || Player.Job == Job.GSM ||
         Player.Job == Job.LTW || Player.Job == Job.WVR || Player.Job == Job.ALC || Player.Job == Job.CUL ||
         Player.Job == Job.MIN || Player.Job == Job.FSH || Player.Job == Job.BTN))
         {
@@ -1429,7 +1429,6 @@ public partial class RotationConfigWindow : Window
     {
         var rotation = DataCenter.CurrentRotation;
         if (rotation == null) return;
-        if (Player.Object == null) return;
         if (!Player.AvailableThreadSafe) return;
 
         var enable = rotation.IsEnabled;
@@ -1544,7 +1543,7 @@ public partial class RotationConfigWindow : Window
             ImGuiHelper.ReactPopup(key, command, Reset, false);
         }
 
-        if (Player.Object != null && DataCenter.PartyMembers != null && Player.Object.IsJobs(Job.DNC))
+        if (Player.AvailableThreadSafe && DataCenter.PartyMembers != null && Player.Object.IsJobs(Job.DNC))
         {
             ImGui.Spacing();
             ImGui.Text("Dance Partner Priority");
@@ -1596,7 +1595,7 @@ public partial class RotationConfigWindow : Window
             }
         }
 
-        if (Player.Object != null && DataCenter.PartyMembers != null && Player.Object.IsJobs(Job.SGE))
+        if (Player.AvailableThreadSafe && DataCenter.PartyMembers != null && Player.Object.IsJobs(Job.SGE))
         {
             ImGui.Spacing();
             ImGui.Text("Kardia Tank Priority");
@@ -1652,7 +1651,7 @@ public partial class RotationConfigWindow : Window
             }
         }
 
-        if (Player.Object != null && DataCenter.PartyMembers != null && Player.Object.IsJobs(Job.AST))
+        if (Player.AvailableThreadSafe && DataCenter.PartyMembers != null && Player.Object.IsJobs(Job.AST))
         {
             ImGui.Spacing();
 
@@ -1998,7 +1997,7 @@ public partial class RotationConfigWindow : Window
 
         static void DrawActionDebug()
         {
-            if (!Player.AvailableThreadSafe || !Player.Available || !Service.Config.InDebug) return;
+            if (!Player.AvailableThreadSafe || !Service.Config.InDebug) return;
 
             if (_activeAction is IBaseAction action)
             {
@@ -2901,7 +2900,7 @@ public partial class RotationConfigWindow : Window
                 OtherConfiguration.BeneficialPositions[territoryId] = pts = [];
             }
 
-            if (ImGui.Button(UiString.ConfigWindow_List_AddPosition.GetDescription()) && Player.Available) unsafe
+            if (ImGui.Button(UiString.ConfigWindow_List_AddPosition.GetDescription()) && Player.AvailableThreadSafe) unsafe
                 {
                     var point = Player.Object.Position;
                     var pointMathed = point + Vector3.UnitY * 5;
@@ -2974,7 +2973,7 @@ public partial class RotationConfigWindow : Window
     {
         _allSearchable.DrawItems(Configs.Debug);
 
-        if (!Player.AvailableThreadSafe || !Player.Available || !Service.Config.InDebug) return;
+        if (!Player.AvailableThreadSafe || !Service.Config.InDebug) return;
 
         _debugHeader?.Draw();
 

--- a/RotationSolver/Updaters/MiscUpdater.cs
+++ b/RotationSolver/Updaters/MiscUpdater.cs
@@ -111,7 +111,7 @@ internal static class MiscUpdater
 
     private static unsafe void UpdateCancelCast()
     {
-        if (Player.Object == null || !Player.Object.IsCasting) return;
+        if (!Player.Object.IsCasting) return;
 
         var tarDead = Service.Config.UseStopCasting
             && Svc.Objects.SearchById(Player.Object.CastTargetObjectId) is IBattleChara b

--- a/RotationSolver/Updaters/MovingUpdater.cs
+++ b/RotationSolver/Updaters/MovingUpdater.cs
@@ -18,7 +18,7 @@ internal static class MovingUpdater
         }
 
         // Casting the action in list.
-        if (Svc.Condition?[ConditionFlag.Casting] == true && Player.Available == true)
+        if (Svc.Condition?[ConditionFlag.Casting] == true && Player.AvailableThreadSafe == true)
         {
             Service.CanMove = ActionBasicInfo.ActionsNoNeedCasting.Contains(Player.Object?.CastActionId ?? 0);
             return;


### PR DESCRIPTION
- Added `YEETBeta` property for hitbox size consideration in `Primal Rend` distance calculations.
- Updated conditions for using `Primal Rend` to incorporate `YEETBeta`.
- Replaced `Player.Object` checks with `Player.AvailableThreadSafe` in multiple classes to improve thread safety.
- Changed default values for `KeyboardNoise` and `ClickingDelay` in `Configs`.
- Fixed MajorUpdater order of operations, fixing teaching mode and countdown logic.