### PR TITLE
Add special case for Dohn Meg and update conditions

### DIFF
--- a/RotationSolver.Basic/Helpers/ObjectHelper.cs
+++ b/RotationSolver.Basic/Helpers/ObjectHelper.cs
@@ -508,7 +508,12 @@ public static class ObjectHelper
     {
         if (obj.NameId == 10259)
         {
-            return true; // Special case Cinduruva in The Tower of Zot
+            return true; // Special case; Cinduruva in The Tower of Zot
+        }
+
+        if (obj.NameId == 8145)
+        {
+            return true; // Special case; Root in Dohn Meg boss 2
         }
 
         return false;

--- a/RotationSolver/Updaters/MajorUpdater.cs
+++ b/RotationSolver/Updaters/MajorUpdater.cs
@@ -59,7 +59,7 @@ internal static class MajorUpdater
                && !Svc.Condition[ConditionFlag.PlayingMiniGame]
                && !Svc.Condition[ConditionFlag.Performing]
                && !Svc.Condition[ConditionFlag.Fishing]
-               && !Svc.Condition[ConditionFlag.Transformed]
+               //&& !Svc.Condition[ConditionFlag.Transformed] Dhon Meg boss enlarges you, making you transformed
                && !Svc.Condition[ConditionFlag.UsingHousingFunctions]
                && !Svc.Condition[ConditionFlag.Jumping61]
                && !Svc.Condition[ConditionFlag.SufferingStatusAffliction2]


### PR DESCRIPTION
- Updated `IsSpecialInclusionPriority` in `ObjectHelper.cs` to include a new check for `NameId` 8145 (Root in Dohn Meg boss 2) and clarified comments for Cinduruva.
- Commented out the `ConditionFlag.Transformed` check in `MajorUpdater.cs` with a note regarding the transformation effect from the Dhon Meg boss.