### PR TITLE
Enhance ObjectHelper checks and add Dalamud warnings

### DIFF
--- a/RotationSolver.Basic/Helpers/ObjectHelper.cs
+++ b/RotationSolver.Basic/Helpers/ObjectHelper.cs
@@ -14,6 +14,7 @@ using FFXIVClientStructs.FFXIV.Client.Graphics;
 using FFXIVClientStructs.FFXIV.Common.Component.BGCollision;
 using RotationSolver.Basic.Configuration;
 using System.Collections.Concurrent;
+using System.Drawing;
 using System.Text;
 using System.Text.RegularExpressions;
 
@@ -506,15 +507,13 @@ public static class ObjectHelper
 
     internal static bool IsSpecialInclusionPriority(this IBattleChara obj)
     {
-        if (obj.NameId == 10259)
+        if (obj.NameId == 10259 || obj.NameId == 8145 || obj.NameId == 12704)
         {
-            return true; // Special case; Cinduruva in The Tower of Zot
+            return true;
         }
-
-        if (obj.NameId == 8145)
-        {
-            return true; // Special case; Root in Dohn Meg boss 2
-        }
+        //10259 Cinduruva in The Tower of Zot
+        //8145 Root in Dohn Meg boss 2
+        //12704 Crystalline Debris 
 
         return false;
     }

--- a/RotationSolver/UI/RotationConfigWindow.cs
+++ b/RotationSolver/UI/RotationConfigWindow.cs
@@ -281,12 +281,22 @@ public partial class RotationConfigWindow : Window
     private void DrawErrorZone()
     {
         string errorText = "No internal errors.";
-        //string cautionText;
         float availableWidth = ImGui.GetContentRegionAvail().X; // Get the available width dynamically
+
+        // Dalamud branch warning
+        string branch = DalamudBranch();
+        if (!string.Equals(branch, "release", StringComparison.OrdinalIgnoreCase))
+        {
+            ImGui.PushTextWrapPos(ImGui.GetCursorPos().X + availableWidth);
+            ImGui.PushStyleColor(ImGuiCol.Text, ImGuiColors.DalamudOrange);
+            ImGui.TextWrapped($"Warning: You are running the '{branch}' branch of Dalamud. For best compatibility, use /xlbranch and switch back to 'release' branch if available for your current version of FFXIV.");
+            ImGui.PopStyleColor();
+            ImGui.PopTextWrapPos();
+            ImGui.Spacing();
+        }
 
         IncompatiblePlugin[] incompatiblePlugins = DownloadHelper.IncompatiblePlugins ?? Array.Empty<IncompatiblePlugin>();
         IncompatiblePlugin enabledIncompatiblePlugin = incompatiblePlugins.FirstOrDefault(p => p.IsEnabled && (int)p.Type == 5);
-        //var installedCautionaryPlugin = incompatiblePlugins.FirstOrDefault(p => p.IsInstalled && (int)p.Type != 5);
 
         if (enabledIncompatiblePlugin.Name != null)
         {


### PR DESCRIPTION
Updated `IsSpecialInclusionPriority` in `ObjectHelper.cs` to include checks for additional `NameId` values (10259, 8145, 12704) and simplified logic.

In `RotationConfigWindow.cs`, added a warning for users on non-release Dalamud branches.