### PR TITLE
Various Phantom Action fixes and enhancements for Raise logic, misc fixes

### DIFF
--- a/BasicRotations/Duty/PhantomDefault.cs
+++ b/BasicRotations/Duty/PhantomDefault.cs
@@ -1,5 +1,4 @@
-﻿using Dalamud.Game.Text.SeStringHandling.Payloads;
-using RotationSolver.Basic.Rotations.Duties;
+﻿using RotationSolver.Basic.Rotations.Duties;
 
 namespace RebornRotations.Duty;
 
@@ -40,6 +39,16 @@ public sealed class PhantomDefault : PhantomRotation
         }
 
         return base.AttackAbility(nextGCD, out act);
+    }
+
+    public override bool DefenseSingleAbility(IAction nextGCD, out IAction? act)
+    {
+        if (PhantomGuardPvE.CanUse(out act))
+        {
+            return true;
+        }
+
+        return base.DefenseSingleAbility(nextGCD, out act);
     }
 
     public override bool DefenseAreaAbility(IAction nextGCD, out IAction? act)

--- a/BasicRotations/Tank/WAR_Default.cs
+++ b/BasicRotations/Tank/WAR_Default.cs
@@ -1,6 +1,6 @@
 namespace RebornRotations.Tank;
 
-[Rotation("Default", CombatType.PvE, GameVersion = "7.15")]
+[Rotation("Default", CombatType.PvE, GameVersion = "7.25")]
 [SourceCode(Path = "main/BasicRotations/Tank/WAR_Default.cs")]
 [Api(4)]
 public sealed class WAR_Default : WarriorRotation
@@ -274,7 +274,7 @@ public sealed class WAR_Default : WarriorRotation
                     return true;
                 }
 
-                if (YEETBeta && PrimalRendPvE.Target.Target?.DistanceToPlayer() + PrimalRendPvE.Target.Target?.HitboxRadius < PrimalRendDistance2)
+                if (YEETBeta && PrimalRendPvE.Target.Target?.DistanceToPlayer() - PrimalRendPvE.Target.Target?.HitboxRadius < PrimalRendDistance2)
                 {
                     return true;
                 }

--- a/RotationSolver.Basic/DataCenter.cs
+++ b/RotationSolver.Basic/DataCenter.cs
@@ -310,7 +310,7 @@ internal static class DataCenter
 
     public static uint[] BluSlots { get; internal set; } = new uint[24];
 
-    public static uint[] DutyActions { get; internal set; } = new uint[2];
+    public static uint[] DutyActions { get; internal set; } = new uint[5];
 
     private static DateTime _specialStateStartTime = DateTime.MinValue;
     private static double SpecialTimeElapsed => (DateTime.Now - _specialStateStartTime).TotalSeconds;

--- a/RotationSolver.Basic/Helpers/ObjectHelper.cs
+++ b/RotationSolver.Basic/Helpers/ObjectHelper.cs
@@ -508,13 +508,14 @@ public static class ObjectHelper
 
     internal static bool IsSpecialInclusionPriority(this IBattleChara obj)
     {
-        if (obj.NameId == 10259 || obj.NameId == 8145 || obj.NameId == 12704)
+        if (obj.NameId == 10259 || obj.NameId == 8145 || obj.NameId == 12704 || obj.NameId == 13668)
         {
             return true;
         }
         //10259 Cinduruva in The Tower of Zot
         //8145 Root in Dohn Meg boss 2
-        //12704 Crystalline Debris 
+        //12704 Crystalline Debris
+        //13668 Mob in Calamity Unbound CE
 
         return false;
     }

--- a/RotationSolver.Basic/Rotations/Duties/DutyRotation.cs
+++ b/RotationSolver.Basic/Rotations/Duties/DutyRotation.cs
@@ -145,7 +145,7 @@ public partial class DutyRotation : IDisposable
     /// <summary>
     /// Gets the hostile target.
     /// </summary>
-    public IBattleChara? HostileTarget => DataCenter.HostileTarget;
+    public static IBattleChara? HostileTarget => DataCenter.HostileTarget;
 
     /// <summary>
     /// Check if in combat.
@@ -304,7 +304,7 @@ public partial class DutyRotation : IDisposable
                 }
             }
 
-            return actionsList.ToArray();
+            return [.. actionsList];
         }
     }
 }

--- a/RotationSolver.Basic/Rotations/Duties/PhantomRotation.cs
+++ b/RotationSolver.Basic/Rotations/Duties/PhantomRotation.cs
@@ -133,7 +133,7 @@ public partial class DutyRotation
     static partial void ModifyPrayPvE(ref ActionSetting setting)
     {
         setting.ActionCheck = () => KnightLevel >= 2;
-        setting.StatusProvide = [StatusID.EnduringFortitude];
+        setting.StatusProvide = [StatusID.Pray];
     }
 
     /// <summary>

--- a/RotationSolver/Updaters/TargetUpdater.cs
+++ b/RotationSolver/Updaters/TargetUpdater.cs
@@ -201,8 +201,8 @@ internal static partial class TargetUpdater
                         }
                     }
                 }
-                List<IBattleChara> deathAllianceHealers = [.. deathParty];
-                List<IBattleChara> deathAllianceSupports = [.. deathParty];
+                List<IBattleChara> deathAllianceHealers = [];
+                List<IBattleChara> deathAllianceSupports = [];
 
                 if (DataCenter.AllianceMembers != null)
                 {
@@ -219,30 +219,30 @@ internal static partial class TargetUpdater
                     }
                 }
 
-                List<IBattleChara> raisePartyAndAllianceSupports = [.. deathParty, .. deathAllianceSupports];
-
-                List<IBattleChara> raisePartyAndAllianceHealers = [.. deathParty, .. deathAllianceHealers];
-
                 RaiseType raisetype = Service.Config.RaiseType;
 
-                List<IBattleChara> validRaiseTargets = [];
+                List<IBattleChara> validRaiseTargets = [.. deathParty];
 
-                if (raisetype == RaiseType.PartyOnly)
+                if (raisetype == RaiseType.PartyAndAllianceSupports)
                 {
-                    validRaiseTargets.AddRange(deathParty);
-                }
-                else if (raisetype == RaiseType.PartyAndAllianceSupports)
-                {
-                    validRaiseTargets.AddRange(raisePartyAndAllianceSupports);
+                    validRaiseTargets.AddRange(deathAllianceSupports);
                 }
                 else if (raisetype == RaiseType.PartyAndAllianceHealers)
                 {
-                    validRaiseTargets.AddRange(raisePartyAndAllianceHealers);
+                    validRaiseTargets.AddRange(deathAllianceHealers);
                 }
                 else if (raisetype == RaiseType.All)
                 {
-                    validRaiseTargets.AddRange(deathAll);
+                    // Add all non-party deaths except those already in party
+                    foreach (var target in deathAll)
+                    {
+                        if (!deathParty.Contains(target))
+                        {
+                            validRaiseTargets.Add(target);
+                        }
+                    }
                 }
+                // For PartyOnly, validRaiseTargets is just deathParty
 
                 foreach (RaiseType type in Enum.GetValues<RaiseType>())
                 {


### PR DESCRIPTION
Added PhantomGuard logic
Adjust Primal Rend logic
Adjust Raise logic to prioritize party members before moving on to other lists for non-RaisePartyOnly logic Added CalamityUnbound mob to prioritzation
Fix to Phantom Action Pray
Fix to Phantom Actions not appering in Action List