### PR TITLE
UI clarity on targeting logic and refactor Watcher methods for performance

### DIFF
--- a/RotationSolver.Basic/Actions/ActionTargetInfo.cs
+++ b/RotationSolver.Basic/Actions/ActionTargetInfo.cs
@@ -284,7 +284,7 @@ public struct ActionTargetInfo(IBaseAction action)
             return false;
         }
 
-        if (!battleChara.IsAttackable())
+        if (battleChara.IsEnemy() && !battleChara.IsAttackable())
         {
             return false;
         }

--- a/RotationSolver.Basic/Configuration/Configs.cs
+++ b/RotationSolver.Basic/Configuration/Configs.cs
@@ -308,7 +308,7 @@ internal partial class Configs : IPluginConfiguration
         Filter = TargetConfig, Section = 1)]
     private static readonly bool _targetHuntingRelicLevePriority = true;
 
-    [ConditionBool, UI("Target quest priority.",
+    [ConditionBool, UI("Target quest priority (Overrides engage setting).",
         Filter = TargetConfig, Section = 1)]
     private static readonly bool _targetQuestPriority = true;
 

--- a/RotationSolver.Basic/Data/TargetHostileType.cs
+++ b/RotationSolver.Basic/Data/TargetHostileType.cs
@@ -20,7 +20,7 @@ public enum TargetHostileType : byte
     /// <summary>
     /// All targets when solo in duty, or previously engaged.
     /// </summary>
-    [Description("All targets when solo in duty, or previously engaged.")]
+    [Description("All targets when solo in duty (includes Occult Crescent), or previously engaged.")]
     AllTargetsWhenSoloInDuty,
 
     /// <summary>

--- a/RotationSolver/Watcher.cs
+++ b/RotationSolver/Watcher.cs
@@ -32,29 +32,16 @@ public static class Watcher
     {
         try
         {
-            // Check Source.
-            if (set.Source is not IBattleChara battle)
+            // Validate source is an enemy battle character
+            if (set.Source is not IBattleChara battle ||
+                battle is IPlayerCharacter ||
+                battle.SubKind == 9) // Friend!
             {
                 return;
             }
 
-            if (battle is IPlayerCharacter)
-            {
-                return;
-            }
-
-            const int FriendSubKind = 9;
-            if (battle.SubKind == FriendSubKind)
-            {
-                return; // Friend!
-            }
-
-            if (Svc.Objects.SearchById(battle.GameObjectId) is not IBattleChara obj)
-            {
-                return;
-            }
-
-            if (obj is IPlayerCharacter)
+            if (Svc.Objects.SearchById(battle.GameObjectId) is not IBattleChara obj ||
+                obj is IPlayerCharacter)
             {
                 return;
             }
@@ -64,37 +51,32 @@ public static class Watcher
             {
                 return;
             }
+            ulong playerId = playerObject.GameObjectId;
 
+            // Calculate damage ratio to player
             float damageRatio = 0;
-            foreach (TargetEffect effect in set.TargetEffects)
+            foreach (var effect in set.TargetEffects)
             {
-                if (effect.TargetID == playerObject.GameObjectId)
+                if (effect.TargetID != playerId) continue;
+                for (int i = 0; i < 8; i++)
                 {
-                    for (int i = 0; i < 8; i++)
+                    var entry = effect[i];
+                    if (entry.type == ActionEffectType.Damage)
                     {
-                        EffectEntry entry = effect[i];
-                        if (entry.type == ActionEffectType.Damage)
-                        {
-                            damageRatio += (float)entry.value / playerObject.MaxHp;
-                        }
+                        damageRatio += (float)entry.value / playerObject.MaxHp;
                     }
                 }
             }
-
             DataCenter.AddDamageRec(damageRatio);
-
             ShowStrEnemy = $"Damage Ratio: {damageRatio}\n{set}";
 
-            foreach (TargetEffect effect in set.TargetEffects)
+            // Knockback detection (only need to check player's effect)
+            foreach (var effect in set.TargetEffects)
             {
-                if (effect.TargetID != playerObject.GameObjectId)
+                if (effect.TargetID != playerId) continue;
+                if (effect.GetSpecificTypeEffect(ActionEffectType.Knockback, out var entry))
                 {
-                    continue;
-                }
-
-                if (effect.GetSpecificTypeEffect(ActionEffectType.Knockback, out EffectEntry entry))
-                {
-                    Knockback? knock = Svc.Data.GetExcelSheet<Knockback>()?.GetRow(entry.value);
+                    var knock = Svc.Data.GetExcelSheet<Knockback>()?.GetRow(entry.value);
                     if (knock != null)
                     {
                         DataCenter.KnockbackStart = DateTime.Now;
@@ -102,46 +84,56 @@ public static class Watcher
                         {
                             DataCenter.KnockbackFinished = DateTime.Now + TimeSpan.FromSeconds(knock.Value.Distance / (float)knock.Value.Speed);
                         }
-                        if (set.Action.HasValue && !OtherConfiguration.HostileCastingKnockback.Contains(set.Action.Value.RowId) && Service.Config.RecordKnockbackies)
+                        if (set.Action.HasValue &&
+                            !OtherConfiguration.HostileCastingKnockback.Contains(set.Action.Value.RowId) &&
+                            Service.Config.RecordKnockbackies)
                         {
                             _ = OtherConfiguration.HostileCastingKnockback.Add(set.Action.Value.RowId);
                             _ = OtherConfiguration.Save();
                         }
                     }
-                    break;
+                    break; // Only need first knockback
                 }
             }
 
-            if (set.Header.ActionType == ActionType.Action && DataCenter.PartyMembers.Count >= 4 && set.Action?.Cast100ms > 0)
+            // Area effect detection for party
+            if (set.Header.ActionType == ActionType.Action &&
+                DataCenter.PartyMembers.Count >= 4 &&
+                set.Action?.Cast100ms > 0)
             {
-                ActionCate? type = set.Action?.GetActionCate();
-
+                var type = set.Action?.GetActionCate();
                 if (type is ActionCate.Spell or ActionCate.Weaponskill or ActionCate.Ability)
                 {
-                    int partyMemberCount = DataCenter.PartyMembers.Count;
+                    var partyMembers = DataCenter.PartyMembers;
+                    int partyMemberCount = partyMembers.Count;
                     int damageEffectCount = 0;
 
-                    foreach (TargetEffect effect in set.TargetEffects)
+                    // Build a HashSet for fast lookup if party is large
+                    HashSet<ulong>? partyIds = null;
+                    if (partyMemberCount > 4)
                     {
-                        foreach (IBattleChara partyMember in DataCenter.PartyMembers)
+                        partyIds = [.. partyMembers.Select(m => m.GameObjectId)];
+                    }
+
+                    foreach (var effect in set.TargetEffects)
+                    {
+                        bool isPartyMember = partyIds != null
+                            ? partyIds.Contains(effect.TargetID)
+                            : partyMembers.Any(m => m.GameObjectId == effect.TargetID);
+
+                        if (!isPartyMember) continue;
+
+                        if (effect.GetSpecificTypeEffect(ActionEffectType.Damage, out var damageEffect) &&
+                            (damageEffect.value > 0 || (damageEffect.param0 & 6) == 6))
                         {
-                            if (partyMember.GameObjectId == effect.TargetID &&
-                                effect.GetSpecificTypeEffect(ActionEffectType.Damage, out EffectEntry damageEffect) &&
-                                (damageEffect.value > 0 || (damageEffect.param0 & 6) == 6))
-                            {
-                                damageEffectCount++;
-                                break;
-                            }
+                            damageEffectCount++;
                         }
                     }
 
-                    if (damageEffectCount == partyMemberCount)
+                    if (damageEffectCount == partyMemberCount && Service.Config.RecordCastingArea)
                     {
-                        if (Service.Config.RecordCastingArea)
-                        {
-                            _ = OtherConfiguration.HostileCastingArea.Add(set.Action!.Value.RowId);
-                            _ = OtherConfiguration.SaveHostileCastingArea();
-                        }
+                        _ = OtherConfiguration.HostileCastingArea.Add(set.Action!.Value.RowId);
+                        _ = OtherConfiguration.SaveHostileCastingArea();
                     }
                 }
             }
@@ -157,64 +149,34 @@ public static class Watcher
     {
         try
         {
-            IPlayerCharacter playerObject = Player.Object;
-            if (set.Source == null || playerObject == null)
-            {
-                return;
-            }
+            var playerObject = Player.Object;
+            if (set.Source == null || playerObject == null) return;
+            if (set.Source.GameObjectId != playerObject.GameObjectId) return;
+            if (set.Header.ActionType is not ActionType.Action and not ActionType.Item) return;
+            if (set.Action is not { } action) return;
+            if (action.ActionCategory.Value.RowId == (uint)ActionCate.Autoattack) return;
+            if (set.TargetEffects.Length == 0) return;
 
-            if (set.Source.GameObjectId != playerObject.GameObjectId)
-            {
-                return;
-            }
-
-            if (set.Header.ActionType is not ActionType.Action and not ActionType.Item)
-            {
-                return;
-            }
-
-            if (set.Action == null)
-            {
-                return;
-            }
-
-            if (set.Action?.ActionCategory.Value.RowId == (uint)ActionCate.Autoattack)
-            {
-                return;
-            }
-
-            if (set.TargetEffects.Length == 0)
-            {
-                return;
-            }
-
-            Lumina.Excel.Sheets.Action? action = set.Action;
-            IGameObject? tar = set.Target;
+            var tar = set.Target;
 
             // Record
-            DataCenter.AddActionRec(action!.Value);
+            DataCenter.AddActionRec(action);
             ShowStrSelf = set.ToString();
 
             DataCenter.HealHP = set.GetSpecificTypeEffect(ActionEffectType.Heal);
             DataCenter.ApplyStatus = set.GetSpecificTypeEffect(ActionEffectType.ApplyStatusEffectTarget);
-            Dictionary<ulong, uint> effects = set.GetSpecificTypeEffect(ActionEffectType.ApplyStatusEffectSource);
-            try
+
+            var effects = set.GetSpecificTypeEffect(ActionEffectType.ApplyStatusEffectSource);
+            if (effects is { Count: > 0 })
             {
-                if (effects != null)
+                foreach (var effect in effects)
                 {
-                    foreach (KeyValuePair<ulong, uint> effect in effects)
-                    {
-                        DataCenter.ApplyStatus[effect.Key] = effect.Value;
-                    }
+                    DataCenter.ApplyStatus[effect.Key] = effect.Value;
                 }
-            }
-            catch (Exception ex)
-            {
-                PluginLog.Error($"Error updating ApplyStatus: {ex}");
             }
 
             uint mpGain = 0;
-            foreach (KeyValuePair<ulong, uint> effect in set.GetSpecificTypeEffect(ActionEffectType.MpGain))
+            foreach (var effect in set.GetSpecificTypeEffect(ActionEffectType.MpGain))
             {
                 if (effect.Key == playerObject.GameObjectId)
                 {
@@ -226,61 +188,35 @@ public static class Watcher
             DataCenter.EffectTime = DateTime.Now;
             DataCenter.EffectEndTime = DateTime.Now.AddSeconds(set.Header.AnimationLockTime + 1);
 
-            Queue<(ulong id, DateTime time)> attackedTargets = DataCenter.AttackedTargets;
+            var attackedTargets = DataCenter.AttackedTargets;
             int attackedTargetsCount = DataCenter.AttackedTargetsCount;
 
-            foreach (TargetEffect effect in set.TargetEffects)
+            // Build a HashSet for fast lookup
+            var attackedIds = new HashSet<ulong>(attackedTargets.Select(t => t.id));
+
+            foreach (var effect in set.TargetEffects)
             {
-                if (!effect.GetSpecificTypeEffect(ActionEffectType.Damage, out _))
-                {
-                    continue;
-                }
+                if (!effect.GetSpecificTypeEffect(ActionEffectType.Damage, out _)) continue;
+                if (attackedIds.Contains(effect.TargetID)) continue;
 
-                // Check if the target is already in the attacked targets list
-                bool targetExists = false;
-                foreach ((ulong id, DateTime time) target in attackedTargets)
-                {
-                    if (target.id == effect.TargetID)
-                    {
-                        targetExists = true;
-                        break;
-                    }
-                }
-                if (targetExists)
-                {
-                    continue;
-                }
-
-                // Ensure the current target is not dequeued
+                // Maintain queue size and uniqueness
                 while (attackedTargets.Count >= attackedTargetsCount)
                 {
-                    (ulong id, DateTime time) oldestTarget = attackedTargets.Peek();
-                    if (oldestTarget.id == effect.TargetID)
-                    {
-                        // If the oldest target is the current target, break the loop to avoid dequeuing it
-                        break;
-                    }
-                    _ = attackedTargets.Dequeue();
+                    var (id, time) = attackedTargets.Peek();
+                    if (id == effect.TargetID) break;
+                    attackedIds.Remove(attackedTargets.Dequeue().id);
                 }
 
-                // Enqueue the new target
                 attackedTargets.Enqueue((effect.TargetID, DateTime.Now));
+                attackedIds.Add(effect.TargetID);
             }
 
             // Macro
-            RegexOptions regexOptions = RegexOptions.Compiled | RegexOptions.IgnoreCase;
-            List<ActionEventInfo> events = Service.Config.Events;
-            foreach (ActionEventInfo item in events)
+            var regexOptions = RegexOptions.Compiled | RegexOptions.IgnoreCase;
+            foreach (var item in Service.Config.Events)
             {
-                if (!Regex.IsMatch(action.Value.Name.ExtractText(), item.Name, regexOptions))
-                {
-                    continue;
-                }
-
-                if (item.AddMacro(tar))
-                {
-                    break;
-                }
+                if (!Regex.IsMatch(action.Name.ExtractText(), item.Name, regexOptions)) continue;
+                if (item.AddMacro(tar)) break;
             }
         }
         catch (Exception ex)


### PR DESCRIPTION
- Updated `ActionTargetInfo` to check if a character is an enemy before attackability, woops.
- Clarified `_targetQuestPriority` UI label to indicate it overrides engage settings.
- Expanded description for `AllTargetsWhenSoloInDuty` enum to include "includes Occult Crescent."
- Refactored `ActionFromEnemy` for improved readability and efficiency in enemy validation and damage ratio calculation.
- Streamlined `ActionFromSelf` for better clarity and performance in handling player actions and effects.
- Optimized attacked targets handling using a HashSet for faster lookups.