### PR TITLE
Misc Updates, Update to Shake It Off on WAR

### DIFF
--- a/BasicRotations/Melee/DRG_Default.cs
+++ b/BasicRotations/Melee/DRG_Default.cs
@@ -1,6 +1,6 @@
 namespace RebornRotations.Melee;
 
-[Rotation("Default", CombatType.PvE, GameVersion = "7.21")]
+[Rotation("Default", CombatType.PvE, GameVersion = "7.25")]
 [SourceCode(Path = "main/BasicRotations/Melee/DRG_Default.cs")]
 [Api(4)]
 
@@ -54,42 +54,55 @@ public sealed class DRG_Default : DragoonRotation
     {
         if (IsBurst && InCombat)
         {
-            bool lifeSurgeReady = ((Player.HasStatus(true, StatusID.BattleLitany) || Player.HasStatus(true, StatusID.LanceCharge)
-            || LOTDEndAfter(1000)) && nextGCD.IsTheSameTo(true, HeavensThrustPvE, DrakesbanePvE))
-            || (Player.HasStatus(true, StatusID.BattleLitany) && Player.HasStatus(true, StatusID.LanceCharge) && LOTDEndAfter(1000) && nextGCD.IsTheSameTo(true, ChaoticSpringPvE, LanceBarragePvE, WheelingThrustPvE, FangAndClawPvE))
-            || (nextGCD.IsTheSameTo(true, HeavensThrustPvE, DrakesbanePvE) && (LanceChargePvE.IsInCooldown || BattleLitanyPvE.IsInCooldown));
+            bool lifeSurgeReady =
+                ((Player.HasStatus(true, StatusID.BattleLitany) || Player.HasStatus(true, StatusID.LanceCharge) || LOTDEndAfter(1000))
+                    && nextGCD.IsTheSameTo(true, HeavensThrustPvE, DrakesbanePvE))
+                || (Player.HasStatus(true, StatusID.BattleLitany)
+                    && Player.HasStatus(true, StatusID.LanceCharge)
+                    && LOTDEndAfter(1000)
+                    && nextGCD.IsTheSameTo(true, ChaoticSpringPvE, LanceBarragePvE, WheelingThrustPvE, FangAndClawPvE))
+                || (nextGCD.IsTheSameTo(true, HeavensThrustPvE, DrakesbanePvE)
+                    && (LanceChargePvE.IsInCooldown || BattleLitanyPvE.IsInCooldown));
 
-            if ((!BattleLitanyPvE.Cooldown.ElapsedAfter(60) || !BattleLitanyPvE.EnoughLevel) && LanceChargePvE.CanUse(out act))
-            {
-                return true;
-            }
-
-            if (Player.HasStatus(true, StatusID.LanceCharge) && BattleLitanyPvE.CanUse(out act))
-            {
-                return true;
-            }
-
-            if (((Player.HasStatus(true, StatusID.BattleLitany) || Player.HasStatus(true, StatusID.LanceCharge) || LOTDEndAfter(1000)) && nextGCD.IsTheSameTo(true, HeavensThrustPvE, DrakesbanePvE))
-            || (Player.HasStatus(true, StatusID.BattleLitany) && Player.HasStatus(true, StatusID.LanceCharge) && LOTDEndAfter(1000) && !HeavensThrustPvE.EnoughLevel && !DrakesbanePvE.EnoughLevel && nextGCD.IsTheSameTo(true, ChaoticSpringPvE, LanceBarragePvE, WheelingThrustPvE, FangAndClawPvE))
-            || (nextGCD.IsTheSameTo(true, HeavensThrustPvE, DrakesbanePvE) && (LanceChargePvE.IsInCooldown || BattleLitanyPvE.IsInCooldown)))
-            {
-                if (LifeSurgePvE.CanUse(out act, usedUp: true))
+            if ((!BattleLitanyPvE.Cooldown.ElapsedAfter(60) || !BattleLitanyPvE.EnoughLevel) 
+                && LanceChargePvE.CanUse(out act))
                 {
                     return true;
                 }
-            }
+
+            if (Player.HasStatus(true, StatusID.LanceCharge) && BattleLitanyPvE.CanUse(out act))
+                {
+                    return true;
+                }
+
+            if (((Player.HasStatus(true, StatusID.BattleLitany) || Player.HasStatus(true, StatusID.LanceCharge) || LOTDEndAfter(1000)) 
+                && nextGCD.IsTheSameTo(true, HeavensThrustPvE, DrakesbanePvE))
+                || (Player.HasStatus(true, StatusID.BattleLitany) 
+                    && Player.HasStatus(true, StatusID.LanceCharge)
+                    && LOTDEndAfter(1000)
+                    && !HeavensThrustPvE.EnoughLevel
+                    && !DrakesbanePvE.EnoughLevel
+                    && nextGCD.IsTheSameTo(true, ChaoticSpringPvE, LanceBarragePvE, WheelingThrustPvE, FangAndClawPvE))
+                || (nextGCD.IsTheSameTo(true, HeavensThrustPvE, DrakesbanePvE)
+                    && (LanceChargePvE.IsInCooldown || BattleLitanyPvE.IsInCooldown)))
+                    {
+                        if (LifeSurgePvE.CanUse(out act, usedUp: true))
+                        {
+                            return true;
+                        }
+                    }
 
             if (lifeSurgeReady
                 || (!DisembowelPvE.EnoughLevel && nextGCD.IsTheSameTo(true, VorpalThrustPvE))
                 || (!FullThrustPvE.EnoughLevel && nextGCD.IsTheSameTo(true, VorpalThrustPvE, DisembowelPvE))
                 || (!LanceChargePvE.EnoughLevel && nextGCD.IsTheSameTo(true, DisembowelPvE, FullThrustPvE))
                 || (!BattleLitanyPvE.EnoughLevel && nextGCD.IsTheSameTo(true, ChaosThrustPvE, FullThrustPvE)))
-            {
-                if (LifeSurgePvE.CanUse(out act, usedUp: true))
-                {
-                    return true;
-                }
-            }
+                    {
+                        if (LifeSurgePvE.CanUse(out act, usedUp: true))
+                        {
+                            return true;
+                        }
+                    }
         }
 
         return base.EmergencyAbility(nextGCD, out act);

--- a/BasicRotations/PVPRotations/Ranged/BRD_Default.PVP.cs
+++ b/BasicRotations/PVPRotations/Ranged/BRD_Default.PVP.cs
@@ -13,7 +13,7 @@ public sealed class BRD_DefaultPvP : BardRotation
     [RotationConfig(CombatType.PvP, Name = "Stop attacking while in Guard.")]
     public bool RespectGuard { get; set; } = true;
 
-    [RotationConfig(CombatType.PvE, Name = "Use Warden's Paean on other players")]
+    [RotationConfig(CombatType.PvP, Name = "Use Warden's Paean on other players")]
     public bool BRDEsuna { get; set; } = true;
     #endregion
 

--- a/BasicRotations/Tank/WAR_Default.cs
+++ b/BasicRotations/Tank/WAR_Default.cs
@@ -177,6 +177,17 @@ public sealed class WAR_Default : WarriorRotation
         return base.GeneralAbility(nextGCD, out act);
     }
 
+    [RotationDesc(ActionID.ShakeItOffPvE, ActionID.ReprisalPvE)]
+    protected override bool HealSingleAbility(IAction nextGCD, out IAction? act)
+    {
+        if (ShakeItOffPvE.CanUse(out act, skipAoeCheck: true))
+        {
+            return false;
+        }
+
+        return base.HealSingleAbility(nextGCD, out act);
+    }
+
     [RotationDesc(ActionID.RawIntuitionPvE, ActionID.VengeancePvE, ActionID.RampartPvE, ActionID.RawIntuitionPvE, ActionID.ReprisalPvE)]
     protected override bool DefenseSingleAbility(IAction nextGCD, out IAction? act)
     {
@@ -220,12 +231,6 @@ public sealed class WAR_Default : WarriorRotation
     protected override bool DefenseAreaAbility(IAction nextGCD, out IAction? act)
     {
         act = null;
-
-        if ((ShakeItOffPvE.Cooldown.IsCoolingDown && !ShakeItOffPvE.Cooldown.WillHaveOneCharge(60))
-            || (ReprisalPvE.Cooldown.IsCoolingDown && !ReprisalPvE.Cooldown.WillHaveOneCharge(50)))
-        {
-            return false;
-        }
 
         if (ShakeItOffPvE.CanUse(out act, skipAoeCheck: true))
         {

--- a/RotationSolver.Basic/Actions/ActionTargetInfo.cs
+++ b/RotationSolver.Basic/Actions/ActionTargetInfo.cs
@@ -5,6 +5,7 @@ using ECommons.GameFunctions;
 using ECommons.GameHelpers;
 using ECommons.Logging;
 using FFXIVClientStructs.FFXIV.Client.Game;
+using FFXIVClientStructs.FFXIV.Client.Game.Event;
 using FFXIVClientStructs.FFXIV.Client.Game.Object;
 using FFXIVClientStructs.FFXIV.Client.Graphics.Scene;
 using RotationSolver.Basic.Configuration;
@@ -1148,7 +1149,10 @@ public struct ActionTargetInfo(IBaseAction action)
 
             foreach (IBattleChara battlechara in DataCenter.AllHostileTargets)
             {
-                if (!battlechara.IsBossFromIcon() && ObjectHelper.DistanceToPlayer(battlechara) < 30)
+                if (!battlechara.IsBossFromIcon() 
+                    && battlechara.IsAttackable() 
+                    && battlechara.GetEventType() != EventHandlerContent.PublicContentDirector 
+                    && ObjectHelper.DistanceToPlayer(battlechara) < 30)
                 {
                     PluginLog.Debug($"FindPhantomDoom: {battlechara.Name} selected target.");
                     return battlechara;

--- a/RotationSolver.Basic/Configuration/Configs.cs
+++ b/RotationSolver.Basic/Configuration/Configs.cs
@@ -697,7 +697,7 @@ internal partial class Configs : IPluginConfiguration
     [UI("The minimum time between updating RSR information. (Setting too low will negatively affect framerate, setting too high will lead to poor performance)",
     Filter = BasicTimer)]
     [JobConfig, Range(0, 0.3f, ConfigUnitType.Seconds, 0.002f)]
-    public float MinUpdatingTime { get; set; } = 0.01f;
+    public float MinUpdatingTime { get; set; } = 0.00f;
 
     /// <markdown file="Basic" name="Action Ahead">
     /// Percent of your GCD time remaining on a GCD cycle before RSR will try to queue the next GCD.

--- a/RotationSolver.Basic/Helpers/ObjectHelper.cs
+++ b/RotationSolver.Basic/Helpers/ObjectHelper.cs
@@ -574,7 +574,8 @@ public static class ObjectHelper
             || battleChara.NameId == 8145
             || battleChara.NameId == 10259
             || battleChara.NameId == 12704
-            || battleChara.NameId == 13668)
+            || battleChara.NameId == 13668
+            || battleChara.NameId == 13815)
         {
             return true;
         }
@@ -584,7 +585,7 @@ public static class ObjectHelper
         //10259 Cinduruva in The Tower of Zot
         //12704 Crystalline Debris
         //13668 Mob in Calamity Unbound CE
-
+        //13668 Mob in With Extreme Prejudice CE
 
         return false;
     }


### PR DESCRIPTION
- Refactored emergency ability logic in `DRG_Default` for clarity.
- Added `HealSingleAbility` method in `WAR_Default` to check `ShakeItOffPvE`.
- Removed cooldown checks for `ShakeItOffPvE` and `ReprisalPvE` in `DefenseAreaAbility`.
- Enhanced target finding logic in `ActionTargetInfo.cs` with additional checks.
- Changed `MinUpdatingTime` in `Configs` from `0.01f` to `0.00f` to make it opt in.
- Added a new condition for `battleChara.NameId` in `ObjectHelper.cs`.