### PR TITLE
Smarter phantoms

### DIFF
--- a/BasicRotations/Duty/PhantomDefault.cs
+++ b/BasicRotations/Duty/PhantomDefault.cs
@@ -157,6 +157,18 @@ public sealed class PhantomDefault : PhantomRotation
         }
         #endregion Utility/Non-scaling abilities that don't care about burst
 
+        if (DeadlyBlowPvE.CanUse(out act, skipComboCheck: true)) // Ideally we want to use this in burst windows, but 30 second cooldown means we can use it outside of burst windows too
+        {
+            if (BerserkerLevel == 2)
+            {
+                return true;
+            }
+            if (BerserkerLevel >= 3 && (!RagePvE.IsEnabled || Player.WillStatusEndGCD(1, 0, true, StatusID.PentupRage) || (RagePvE.Cooldown.IsCoolingDown && !Player.HasStatus(true, StatusID.PentupRage))))
+            {
+                return true;
+            }
+        }
+
         #region Burst abilities
         if (ShouldHoldBurst())
         {
@@ -457,18 +469,6 @@ public sealed class PhantomDefault : PhantomRotation
             return false;
         }
 
-        if (DeadlyBlowPvE.CanUse(out act, skipComboCheck: true))
-        {
-            if (BerserkerLevel == 2)
-            {
-                return true;
-            }
-            if (BerserkerLevel >= 3 && (!RagePvE.IsEnabled || Player.WillStatusEndGCD(1, 0, true, StatusID.PentupRage) || (RagePvE.Cooldown.IsCoolingDown && !Player.HasStatus(true, StatusID.PentupRage))))
-            {
-                return true;
-            }
-        }
-
         if (InCombat && AetherialGainPvE.CanUse(out act))
         {
             return true;
@@ -479,14 +479,14 @@ public sealed class PhantomDefault : PhantomRotation
             return true;
         }
 
-        if (InCombat && PredictPvE.CanUse(out act))
-        {
-            return true;
-        }
-
         if (ShouldHoldBurst())
         {
             return false;
+        }
+
+        if (InCombat && PredictPvE.CanUse(out act))
+        {
+            return true;
         }
 
         if (SilverCannonPvE.CanUse(out act))

--- a/BasicRotations/Duty/PhantomDefault.cs
+++ b/BasicRotations/Duty/PhantomDefault.cs
@@ -13,6 +13,9 @@ public sealed class PhantomDefault : PhantomRotation
     [RotationConfig(CombatType.PvE, Name = "Save Phantom Attacks for class specific damage bonus?")]
     public bool SaveForBurstWindow { get; set; } = true;
 
+    [RotationConfig(CombatType.PvE, Name = "Use Dark over Shock")]
+    public bool PreferDarkCannon { get; set; }
+
     [Range(0, 1, ConfigUnitType.Percent)]
     [RotationConfig(CombatType.PvE, Name = "Average party HP percent to predict to heal with judgement instead of damage things")]
     public float PredictJudgementThreshold { get; set; } = 0.7f;
@@ -95,7 +98,7 @@ public sealed class PhantomDefault : PhantomRotation
             return false;
         }
 
-        if (BattleBellPvE.CanUse(out act))
+        if (BattleBellPvE.CanUse(out act) && !BattleBellPvE.Target.Target.HasStatus(false, StatusID.BattleBell) && !BattleBellPvE.Target.Target.HasStatus(true, StatusID.BattleBell))
         {
             return true;
         }
@@ -501,8 +504,8 @@ public sealed class PhantomDefault : PhantomRotation
             return true;
         }
 
-        // Only one of shock or dark can be used, prioritize Shock
-        if (ShockCannonPvE.CanUse(out act))
+        // Only one of shock or dark can be used, prioritize Shock unless PreferDarkCannon is set
+        if (ShockCannonPvE.CanUse(out act) && !PreferDarkCannon)
         {
             return true;
         }

--- a/RotationSolver.Basic/Rotations/Duties/DutyRotation.cs
+++ b/RotationSolver.Basic/Rotations/Duties/DutyRotation.cs
@@ -175,22 +175,22 @@ public partial class DutyRotation : IDisposable
         {
             return Player.HasStatus(true, StatusID.LeyLines); // Should also check enochian but don't want to get their gauge from here; they should have it by the time they use leylines
         }
-        if (DataCenter.Job == Job.GNB)
-        {
-            return Player.HasStatus(true, StatusID.NoMercy);
-        }
-        if (IsPLD)
-        {
-            return Player.HasStatus(true, StatusID.FightOrFlight);
-        }
+        //if (DataCenter.Job == Job.GNB)
+        //{
+        //    return Player.HasStatus(true, StatusID.NoMercy);
+        //}
+        //if (IsPLD)
+        //{
+        //    return Player.HasStatus(true, StatusID.FightOrFlight);
+        //}
         if (DataCenter.Job == Job.SAM)
         {
             return Player.HasStatus(true, StatusID.Fugetsu) && Player.HasStatus(true, StatusID.Fuka);
         }
-        if (DataCenter.Job == Job.WHM)
-        {
-            return Player.HasStatus(true, StatusID.PresenceOfMind);
-        }
+        //if (DataCenter.Job == Job.WHM)
+        //{
+        //    return Player.HasStatus(true, StatusID.PresenceOfMind);
+        //}
 
         return true; // We haven't added other jobs yet, so assume we are in burst window.
     }

--- a/RotationSolver.Basic/Rotations/Duties/PhantomRotation.cs
+++ b/RotationSolver.Basic/Rotations/Duties/PhantomRotation.cs
@@ -791,6 +791,7 @@ public partial class DutyRotation
     static partial void ModifyBattleBellPvE(ref ActionSetting setting)
     {
         setting.ActionCheck = () => GeomancerLevel >= 1;
+        setting.TargetStatusProvide = [StatusID.BattleBell]; // This doesn't actually do anything with the custom targeting
         setting.TargetType = TargetType.PhantomBell;
     }
 


### PR DESCRIPTION
Move oracle predictions into burst window
Burst windows are now only enabled for jobs that can maintain 100% uptime; will revisit the others.
More oracle updates to include raidwide check and to not clear cards when porting