### PR TITLE
Refactor combat checks and enhance casting logic

### DIFF
--- a/BasicRotations/Duty/PhantomDefault.cs
+++ b/BasicRotations/Duty/PhantomDefault.cs
@@ -604,12 +604,12 @@ public sealed class PhantomDefault : PhantomRotation
             return true;
         }
 
-        if (HolyCannonPvE.CanUse(out act))
+        if (SilverCannonPvE.CanUse(out act))
         {
             return true;
         }
 
-        if (SilverCannonPvE.CanUse(out act))
+        if (HolyCannonPvE.CanUse(out act))
         {
             return true;
         }

--- a/RotationSolver/Updaters/MiscUpdater.cs
+++ b/RotationSolver/Updaters/MiscUpdater.cs
@@ -124,6 +124,13 @@ internal static class MiscUpdater
             && Svc.Objects.SearchById(Player.Object.CastTargetObjectId) is IBattleChara b
             && b.IsEnemy() && b.CurrentHp == 0;
 
+        // Cancel raise cast if target already has Raise status
+        bool tarHasRaise = false;
+        if (Svc.Objects.SearchById(Player.Object.CastTargetObjectId) is IBattleChara battleChara)
+        {
+            tarHasRaise = battleChara.HasStatus(false, StatusID.Raise);
+        }
+
         float[] statusTimes = GetStatusTimes();
 
         float minStatusTime = float.MaxValue;
@@ -137,7 +144,7 @@ internal static class MiscUpdater
 
         bool stopDueStatus = statusTimes.Length > 0 && minStatusTime > Player.Object.TotalCastTime - Player.Object.CurrentCastTime && minStatusTime < 5;
 
-        if (_tarStopCastDelay.Delay(tarDead) || stopDueStatus)
+        if (_tarStopCastDelay.Delay(tarDead) || stopDueStatus || tarHasRaise)
         {
             UIState* uiState = UIState.Instance();
             if (uiState != null)


### PR DESCRIPTION
Swapped the order of ability checks for `HolyCannonPvE` and `SilverCannonPvE` in the `PhantomDefault` class.

Introduced a new variable `tarHasRaise` in the `MiscUpdater` class to check if the target has the "Raise" status, updating the casting cancellation logic accordingly.