### PR TITLE
Update WAR and enhance Dalamud branch caching

### DIFF
--- a/BasicRotations/Tank/WAR_Default.cs
+++ b/BasicRotations/Tank/WAR_Default.cs
@@ -182,7 +182,7 @@ public sealed class WAR_Default : WarriorRotation
     {
         if (ShakeItOffPvE.CanUse(out act, skipAoeCheck: true))
         {
-            return false;
+            return true;
         }
 
         return base.HealSingleAbility(nextGCD, out act);

--- a/RotationSolver.Basic/Actions/ActionTargetInfo.cs
+++ b/RotationSolver.Basic/Actions/ActionTargetInfo.cs
@@ -5,7 +5,6 @@ using ECommons.GameFunctions;
 using ECommons.GameHelpers;
 using ECommons.Logging;
 using FFXIVClientStructs.FFXIV.Client.Game;
-using FFXIVClientStructs.FFXIV.Client.Game.Event;
 using FFXIVClientStructs.FFXIV.Client.Game.Object;
 using FFXIVClientStructs.FFXIV.Client.Graphics.Scene;
 using RotationSolver.Basic.Configuration;

--- a/RotationSolver.Basic/Rotations/Duties/PhantomRotation.cs
+++ b/RotationSolver.Basic/Rotations/Duties/PhantomRotation.cs
@@ -49,6 +49,7 @@ public partial class DutyRotation
     private static readonly BaseItem OccultElixirItem = new(47743);
     private static readonly BaseItem OccultPotionItem = new(47741);
     #endregion
+
     #region Status Tracking
 
     /// <summary>
@@ -177,7 +178,6 @@ public partial class DutyRotation
         setting.CreateConfig = () => new ActionConfig()
         {
             AoeCount = 1,
-            IsEnabled = false,
         };
     }
 


### PR DESCRIPTION
Modified `HealSingleAbility` in `WAR_Default.cs` to always return `true` for `ShakeItOffPvE`.

In `Watcher.cs`, added caching for branch information with a new `DalamudBranch` method, utilizing `System.Text.Json` for parsing.

Re-enabled Occult Counter by default