### PR TITLE
Fix for raise action when Chemist level 3 on healer, and NIN action f…

### DIFF
--- a/BasicRotations/Duty/PhantomDefault.cs
+++ b/BasicRotations/Duty/PhantomDefault.cs
@@ -604,7 +604,7 @@ public sealed class PhantomDefault : PhantomRotation
             return true;
         }
 
-        if (SilverCannonPvE.CanUse(out act))
+        if (SilverCannonPvE.CanUse(out act, skipStatusProvideCheck: SilverCannonPvE.Target.Target.WillStatusEnd(11, true, StatusID.SilverSickness)))
         {
             return true;
         }

--- a/BasicRotations/Melee/NIN_Default.cs
+++ b/BasicRotations/Melee/NIN_Default.cs
@@ -339,7 +339,7 @@ public sealed class NIN_Default : NinjaRotation
                 return false;
             }
         }
-        else if (TenPvE.CanUse(out _, usedUp: InTrickAttack))
+        else if (TenPvE.CanUse(out _, usedUp: InTrickAttack || (TenPvE.Cooldown.CurrentCharges == 1 && TenPvE.Cooldown.WillHaveXChargesGCD(2, 1, 0))))
         {
             // Chooses buffs or AoE actions based on combat conditions and cooldowns.
             // For instance, setting Huton for speed buff or choosing AoE Ninjutsu like Katon or Doton based on enemy positioning.
@@ -1357,4 +1357,14 @@ public sealed class NIN_Default : NinjaRotation
         return base.GeneralGCD(out act);
     }
     #endregion
+
+    /// <inheritdoc/>
+    public override bool IsBursting()
+    {
+        if (InTrickAttack)
+        {
+            return true;
+        }
+        return false;
+    }
 }

--- a/BasicRotations/Ranged/MCH_Default.cs
+++ b/BasicRotations/Ranged/MCH_Default.cs
@@ -213,23 +213,27 @@ public sealed class MCH_Default : MachinistRotation
         if (!SpreadShotPvE.CanUse(out _))
         {
             // use AirAnchor if possible
-            if (HotShotMasteryTrait.EnoughLevel && AirAnchorPvE.CanUse(out act))
+            if (HotShotMasteryTrait.EnoughLevel 
+                && AirAnchorPvE.CanUse(out act))
             {
                 return true;
             }
 
             // for opener: only use the first charge of Drill after AirAnchor when there are two
-            if (EnhancedMultiweaponTrait.EnoughLevel && DrillPvE.CanUse(out act, usedUp: false))
+            if (EnhancedMultiweaponTrait.EnoughLevel 
+                && DrillPvE.CanUse(out act, usedUp: false || (DrillPvE.Cooldown.CurrentCharges == 1 && DrillPvE.Cooldown.WillHaveXChargesGCD(2, 1, 0))))
             {
                 return true;
             }
 
-            if (!EnhancedMultiweaponTrait.EnoughLevel && DrillPvE.CanUse(out act, usedUp: true))
+            if (!EnhancedMultiweaponTrait.EnoughLevel 
+                && DrillPvE.CanUse(out act, usedUp: true))
             {
                 return true;
             }
 
-            if (!AirAnchorPvE.EnoughLevel && HotShotPvE.CanUse(out act))
+            if (!AirAnchorPvE.EnoughLevel 
+                && HotShotPvE.CanUse(out act))
             {
                 return true;
             }

--- a/RotationSolver.Basic/Actions/ActionTargetInfo.cs
+++ b/RotationSolver.Basic/Actions/ActionTargetInfo.cs
@@ -1147,7 +1147,6 @@ public struct ActionTargetInfo(IBaseAction action)
             TargetType.Physical => battleChara != null ? RandomPhysicalTarget(battleChara) : null,
             TargetType.DarkCannon => FindDarkCannonTarget(),
             TargetType.ShockCannon => FindShockCannonTarget(),
-            TargetType.HolyCannon => FindHolyCannon(),
             TargetType.PhantomBell => FindPhantomBell(),
             TargetType.PhantomRespite => FindPhantomRespite(),
             TargetType.DancePartner => FindDancePartner(),
@@ -1190,28 +1189,6 @@ public struct ActionTargetInfo(IBaseAction action)
                     if (!hostile.IsOCParalysisImmuneTarget() && hostile.InCombat())
                     {
                         return hostile;
-                    }
-                }
-            }
-            return null;
-        }
-
-        IBattleChara? FindHolyCannon()
-        {
-            if (DataCenter.AllHostileTargets != null)
-            {
-                if (PhantomRotation.CannoneerLevel < 6)
-                {
-                    return FindHostile();
-                }
-                else
-                {
-                    foreach (var hostile in DataCenter.AllHostileTargets)
-                    {
-                        if (hostile != null && hostile.IsOCUndeadTarget() && hostile.InCombat())
-                        {
-                            return hostile;
-                        }
                     }
                 }
             }
@@ -2407,7 +2384,6 @@ public enum TargetType : byte
     Deployment,
     PhantomBell,
     PhantomRespite,
-    HolyCannon,
     DarkCannon,
     ShockCannon
 }

--- a/RotationSolver.Basic/Rotations/CustomRotation_GCD.cs
+++ b/RotationSolver.Basic/Rotations/CustomRotation_GCD.cs
@@ -273,7 +273,22 @@ public partial class CustomRotation
         if (DataCenter.CommandStatus.HasFlag(AutoStatus.Raise))
         {
             IBaseAction.ShouldEndSpecial = true;
-            if (DataCenter.CurrentDutyRotation?.RaiseGCD(out act) == true || RaiseGCD(out act) || RaiseAction(out act, false))
+            if (DataCenter.CurrentDutyRotation?.RaiseGCD(out act) == true)
+            {
+                return true;
+            }
+            if (Player.HasStatus(true, StatusID.PhantomChemist))
+            {
+                if (Player.StatusStack(true, StatusID.PhantomChemist) > 2)
+                {
+                    return false;
+                }
+            }
+            if (RaiseGCD(out act))
+            {
+                return true;
+            }
+            if (RaiseAction(out act, false))
             {
                 return true;
             }
@@ -289,6 +304,14 @@ public partial class CustomRotation
         {
             return true;
         }
+        if (Player.HasStatus(true, StatusID.PhantomChemist))
+        {
+            if (Player.StatusStack(true, StatusID.PhantomChemist) > 2)
+            {
+                return false;
+            }
+        }
+
         if (RaiseGCD(out act))
         {
             return true;
@@ -350,13 +373,6 @@ public partial class CustomRotation
     protected virtual bool RaiseGCD(out IAction? act)
     {
         act = null;
-        if (Player.HasStatus(true, StatusID.PhantomChemist))
-        {
-            if (Player.StatusStack(true, StatusID.PhantomChemist) > 2)
-            {
-                return false;
-            }
-        }
 
         if (DataCenter.CommandStatus.HasFlag(AutoStatus.Raise))
         {

--- a/RotationSolver.Basic/Rotations/Duties/PhantomRotation.cs
+++ b/RotationSolver.Basic/Rotations/Duties/PhantomRotation.cs
@@ -61,6 +61,8 @@ public partial class DutyRotation
         StatusID.Overheated,
         StatusID.InnerRelease,
         StatusID.Eukrasia,
+        StatusID.Mudra,
+        StatusID.TenChiJin
     };
 
     /// <summary>
@@ -389,7 +391,6 @@ public partial class DutyRotation
     static partial void ModifyHolyCannonPvE(ref ActionSetting setting)
     {
         setting.ActionCheck = () => CannoneerLevel >= 2;
-        setting.TargetType = TargetType.HolyCannon;
         setting.CreateConfig = () => new ActionConfig()
         {
             AoeCount = 1,


### PR DESCRIPTION
…ix for phantom actions.

- Updated Silver Cannon to ensure buff/debuff does not fall off during cooldown.
- Modified `NIN_Default` to include cooldown checks for `TenPvE` for bump caps, and added `IsBursting` method.
- Improved action conditions in `MCH_Default` for `AirAnchorPvE` and `DrillPvE` to prevent bump caps.
- Removed `FindHolyCannon` method and `HolyCannon` type from `ActionTargetInfo`.
- Updated `ModifyHolyCannonPvE` to exclude `HolyCannon` from action settings.
- Enhanced raising action logic in `CustomRotation_GCD` with `PhantomChemist` checks.
- Added new status IDs `Mudra` and `TenChiJin` in `DutyRotation` LockoutStatus list to prevent phantom actions during mudra and tenchijin.