### PR TITLE
Performance and Clarity for internals

### DIFF
--- a/RotationSolver.Basic/Actions/ActionTargetInfo.cs
+++ b/RotationSolver.Basic/Actions/ActionTargetInfo.cs
@@ -63,36 +63,40 @@ public struct ActionTargetInfo(IBaseAction action)
             return [];
         }
 
-        List<IBattleChara> validTargets = new(TargetFilter.GetObjectInRadius(DataCenter.AllTargets, Range).Count());
-
-        foreach (IBattleChara target in TargetFilter.GetObjectInRadius(DataCenter.AllTargets, Range))
+        List<IBattleChara> validTargets = [];
+        foreach (IBattleChara target in TargetHelper.GetTargetsByRange(Range))
         {
             if (type == TargetType.Heal && target.GetHealthRatio() == 1)
             {
                 continue;
             }
 
-            if (!GeneralCheck(target, skipStatusProvideCheck, skipTargetStatusNeedCheck))
-            {
-                continue;
-            }
+            var statusCheck = CheckStatus(target, skipStatusProvideCheck, skipTargetStatusNeedCheck);
+            var ttkCheck = CheckTimeToKill(target);
+            var resistanceCheck = CheckResistance(target);
 
-            validTargets.Add(target);
-        }
-
-        List<IBattleChara> result = [];
-        foreach (IBattleChara b in validTargets)
-        {
-            if (!DataCenter.IsManual || IsTargetFriendly || b.GameObjectId == Svc.Targets.Target?.GameObjectId || b.GameObjectId == Player.Object?.GameObjectId)
+            if (statusCheck && ttkCheck && resistanceCheck)
             {
-                if (InViewTarget(b) && CanUseTo(b) && action.Setting.CanTarget(b))
+                // If auto targeting is enabled
+                // or the skill is friendly
+                // or the target is the currently selected hard-target
+                // or the target is ourselves
+                // then => Check target is in the view && ActionManager.CanUse on target && CanSee Target && action.setting predicate is true of target
+                if (!DataCenter.IsManual || IsTargetFriendly || target.GameObjectId == Svc.Targets.Target?.GameObjectId || target.GameObjectId == Player.Object?.GameObjectId)
                 {
-                    result.Add(b);
+                    var view = InViewTarget(target);
+                    var canUse = CanUseTo(target);
+                    var asCanTarget = action.Setting.CanTarget(target);
+
+                    if (view && canUse && asCanTarget)
+                    {
+                        validTargets.Add(target);
+                    }
                 }
             }
         }
 
-        return result;
+        return validTargets;
     }
 
     /// <summary>
@@ -118,35 +122,21 @@ public struct ActionTargetInfo(IBaseAction action)
             return [];
         }
 
-        IEnumerable<IBattleChara> items = TargetFilter.GetObjectInRadius(action.Setting.IsFriendly
-            ? DataCenter.PartyMembers
-            : DataCenter.AllHostileTargets, Range + EffectRange);
-
-        if (type == TargetType.Heal)
-        {
-            List<IBattleChara> filteredItems = [];
-            foreach (IBattleChara i in items)
-            {
-                if (i.GetHealthRatio() < 1)
-                {
-                    filteredItems.Add(i);
-                }
-            }
-            items = filteredItems;
-        }
+        IEnumerable<IBattleChara> items = TargetHelper.GetTargetsByRange(Range + EffectRange, action.Setting.IsFriendly);
 
         List<IBattleChara> validTargets = new(items.Count());
-
-        foreach (IBattleChara obj in items)
+        foreach (IBattleChara tar in items)
         {
-            if (!GeneralCheck(obj, skipStatusProvideCheck, skipTargetStatusNeedCheck))
+            if (type == TargetType.Heal && tar.GetHealthRatio() >= 1)
             {
                 continue;
             }
 
-            validTargets.Add(obj);
+            if (CheckStatus(tar, skipStatusProvideCheck, skipTargetStatusNeedCheck) && CheckTimeToKill(tar) && CheckResistance(tar))
+            {
+                validTargets.Add(tar);
+            }
         }
-
         return validTargets;
     }
 
@@ -206,10 +196,26 @@ public struct ActionTargetInfo(IBaseAction action)
             return false;
         }
 
-        return tar.GameObjectId != 0 && tar.Struct() != null &&
-               (IsSpecialAbility(action.Info.ID) ||
-                ActionManager.CanUseActionOnTarget(action.Info.AdjustedID, (GameObject*)tar.Struct())) &&
-               tar.CanSee();
+        if (!(tar.GameObjectId != 0 && tar.Struct() != null))
+        {
+            return false;
+        }
+
+        var specialAbilityCheck = IsSpecialAbility(action.Info.ID);
+        var actionmanagerCheck = ActionManager.CanUseActionOnTarget(action.Info.AdjustedID, (GameObject*)tar.Struct());
+
+        if (!(specialAbilityCheck || actionmanagerCheck))
+        {
+            return false;
+        }
+        if (!IsTargetFriendly) // canSee check is already done as part of finding hostile targets
+        {
+            return DataCenter.AllHostileTargets.Contains(tar);
+        }
+        else // For friendly targets we still need to check CanSee
+        {
+            return tar.CanSee();
+        }
     }
 
     private readonly List<ActionID> _specialActions =
@@ -227,82 +233,6 @@ public struct ActionTargetInfo(IBaseAction action)
     private readonly bool IsSpecialAbility(uint iD)
     {
         return _specialActions.Contains((ActionID)iD);
-    }
-
-    /// <summary>
-    /// Performs a general check on the specified battle character to determine if it meets the criteria for targeting.
-    /// </summary>
-    /// <param name="battleChara">The battle character to check.</param>
-    /// <param name="skipStatusProvideCheck">If set to <c>true</c>, skips the status provide check.</param>
-    /// <param name="skipTargetStatusNeedCheck">If set to <c>true</c>, skips the target status need check.</param>
-    /// <returns>
-    /// <c>true</c> if the battle character meets the criteria for targeting; otherwise, <c>false</c>.
-    /// </returns>
-    public readonly bool GeneralCheck(IBattleChara battleChara, bool skipStatusProvideCheck, bool skipTargetStatusNeedCheck)
-    {
-        if (battleChara == null)
-        {
-            return false;
-        }
-
-        unsafe
-        {
-            if (battleChara.Struct() == null)
-            {
-                return false;
-            }
-        }
-
-        if (!battleChara.IsTargetable)
-        {
-            return false;
-        }
-
-        try
-        {
-            if (battleChara.StatusList == null)
-            {
-                return false;
-            }
-        }
-        catch (Exception ex)
-        {
-            PluginLog.Error($"Exception accessing StatusList for {battleChara?.NameId}: {ex.Message}");
-            return false;
-        }
-
-        bool isBlacklisted = false;
-        foreach (uint id in DataCenter.BlacklistedNameIds)
-        {
-            if (id == battleChara.NameId)
-            {
-                isBlacklisted = true;
-                break;
-            }
-        }
-        if (isBlacklisted)
-        {
-            return false;
-        }
-
-        if (battleChara.IsEnemy() && !battleChara.IsAttackable())
-        {
-            return false;
-        }
-
-        bool isStopTarget = false;
-        long[] stopTargets = MarkingHelper.GetStopTargets();
-        foreach (long stopId in stopTargets)
-        {
-            if (stopId == (long)battleChara.GameObjectId)
-            {
-                isStopTarget = true;
-                break;
-            }
-        }
-        return (!isStopTarget || !Service.Config.FilterStopMark) && CheckStatus(battleChara, skipStatusProvideCheck, skipTargetStatusNeedCheck)
-            && CheckTimeToKill(battleChara)
-            && CheckResistance(battleChara);
     }
 
     /// <summary>
@@ -431,14 +361,12 @@ public struct ActionTargetInfo(IBaseAction action)
     /// </returns>
     internal readonly TargetResult? FindTarget(bool skipAoeCheck, bool skipStatusProvideCheck, bool skipTargetStatusNeedCheck)
     {
-        float range = Range;
-
         if (action == null || action.Setting == null || action.Config == null)
         {
             return null;
         }
 
-        if (range == 0 && EffectRange == 0)
+        if (Range == 0 && EffectRange == 0)
         {
             return new TargetResult(Player.Object, [], Player.Object.Position);
         }
@@ -455,7 +383,7 @@ public struct ActionTargetInfo(IBaseAction action)
 
         if (IsTargetArea)
         {
-            return FindTargetArea(canTargets, canAffects, range, Player.Object);
+            return FindTargetArea(canTargets, canAffects, Range, Player.Object);
         }
 
         List<IBattleChara> targetsList = [.. GetMostCanTargetObjects(canTargets, canAffects, skipAoeCheck ? 0 : action.Config.AoeCount)];
@@ -478,10 +406,7 @@ public struct ActionTargetInfo(IBaseAction action)
             List<IBattleChara> affectsList = [];
             if (affectsEnum != null)
             {
-                foreach (var a in affectsEnum)
-                {
-                    affectsList.Add(a);
-                }
+                affectsList.AddRange(affectsEnum);
             }
             affectedTargets = [.. affectsList];
         }
@@ -1160,7 +1085,7 @@ public struct ActionTargetInfo(IBaseAction action)
 
         IBattleChara? FindDarkCannonTarget()
         {
-            if (DataCenter.AllHostileTargets != null)
+            if (battleChara != null)
             {
                 if (PhantomRotation.CannoneerLevel < 4)
                 {
@@ -1168,7 +1093,7 @@ public struct ActionTargetInfo(IBaseAction action)
                 }
                 else
                 {
-                    foreach (var hostile in DataCenter.AllHostileTargets)
+                    foreach (var hostile in battleChara)
                     {
                         if (!hostile.IsOCBlindImmuneTarget() && hostile.InCombat())
                         {
@@ -1182,9 +1107,9 @@ public struct ActionTargetInfo(IBaseAction action)
 
         IBattleChara? FindShockCannonTarget()
         {
-            if (DataCenter.AllHostileTargets != null)
+            if (battleChara != null)
             {
-                foreach (var hostile in DataCenter.AllHostileTargets)
+                foreach (var hostile in battleChara)
                 {
                     if (!hostile.IsOCParalysisImmuneTarget() && hostile.InCombat())
                     {

--- a/RotationSolver.Basic/Actions/BaseAction.cs
+++ b/RotationSolver.Basic/Actions/BaseAction.cs
@@ -165,15 +165,14 @@ public class BaseAction : IBaseAction
 
         if (!skipTTKCheck)
         {
-            switch (DataCenter.IsPvP)
+            if (!DataCenter.IsPvP || !Service.Config.IgnorePvPttk)
             {
-                case true when Service.Config.IgnorePvPttk:
-                    break;
-                case false when !IsTimeToKillValid():
+                if (!IsTimeToKillValid())
+                {
                     return false;
+                }
             }
         }
-
         PreviewTarget = TargetInfo.FindTarget(skipAoeCheck, skipStatusProvideCheck, skipTargetStatusNeedCheck);
         if (PreviewTarget == null)
         {

--- a/RotationSolver.Basic/Helpers/ObjectHelper.cs
+++ b/RotationSolver.Basic/Helpers/ObjectHelper.cs
@@ -1348,7 +1348,7 @@ public static class ObjectHelper
     private static readonly TimeSpan CheckSpan = TimeSpan.FromSeconds(2.5);
 
     /// <summary>
-    /// Calculates the estimated time to kill the specified battle character.
+    /// Calculates the estimated time to kill the specified battle character. Only applicable after the first 2.5 seconds, and uses a moving average of the last 15 seconds of health ratios
     /// </summary>
     /// <param name="battleChara">The battle character to calculate the time to kill for.</param>
     /// <param name="wholeTime">If set to <c>true</c>, calculates the total time to kill; otherwise, calculates the remaining time to kill.</param>
@@ -1371,33 +1371,45 @@ public static class ObjectHelper
         float initialHpRatio = 0;
 
         // Use a snapshot of the RecordedHP collection to avoid modification during enumeration
-        (DateTime time, SortedList<ulong, float> hpRatios)[] recordedHPCopy = [.. DataCenter.RecordedHP];
+        (DateTime time, Dictionary<ulong, float> hpRatios)[] recordedHPCopy = [.. DataCenter.RecordedHP];
 
         // Calculate a moving average of HP ratios
-        const int movingAverageWindow = 5;
-        Queue<float> hpRatios = new();
+        const int movingAverageWindow = 5; // TODO: Possibly this should be configurable?
+        if (recordedHPCopy.Length == 0)
+        {
+            return float.NaN; // No recorded HP data available
+        }
 
-        foreach ((DateTime time, SortedList<ulong, float> hpRatiosDict) in recordedHPCopy)
+        List<float> hpRatios = new(movingAverageWindow);
+
+        // We just need the first injured entry and last movingAverageWindow entries
+        foreach ((DateTime time, Dictionary<ulong, float> hpRatiosDict) in recordedHPCopy)
         {
             if (hpRatiosDict != null && hpRatiosDict.TryGetValue(battleChara.GameObjectId, out float ratio) && ratio != 1)
             {
-                if (startTime == DateTime.MinValue)
-                {
-                    startTime = time;
-                    initialHpRatio = ratio;
-                }
-
-                hpRatios.Enqueue(ratio);
-                if (hpRatios.Count > movingAverageWindow)
-                {
-                    _ = hpRatios.Dequeue();
-                }
+                startTime = time;
+                initialHpRatio = ratio;
+                break;
             }
         }
 
         if (startTime == DateTime.MinValue || (DateTime.Now - startTime) < CheckSpan)
         {
             return float.NaN;
+        }
+
+        // Skip to just the last movingAverageWindow entries
+        if (recordedHPCopy.Length > movingAverageWindow)
+        {
+            recordedHPCopy = recordedHPCopy[^movingAverageWindow..];
+        }
+
+        foreach ((_, Dictionary<ulong, float> hpRatiosDict) in recordedHPCopy)
+        {
+            if (hpRatiosDict != null && hpRatiosDict.TryGetValue(battleChara.GameObjectId, out float ratio) && ratio != 1)
+            {
+                hpRatios.Add(ratio);
+            }
         }
 
         float currentHealthRatio = battleChara.GetHealthRatio();

--- a/RotationSolver.Basic/Helpers/TargetHelper.cs
+++ b/RotationSolver.Basic/Helpers/TargetHelper.cs
@@ -1,0 +1,157 @@
+﻿using ECommons.GameFunctions;
+using ECommons.Logging;
+
+namespace RotationSolver.Basic.Helpers
+{
+    /// <summary>
+    /// Target helper to get calculated targets within range with additional caching within a data refresh interval.
+    /// </summary>
+    public static class TargetHelper
+    {
+        /// <summary>
+        /// Retrieves a collection of valid battle characters that can be targeted based on the specified criteria.
+        /// </summary>
+        /// <param name="range">The range to check for targets.</param>
+        /// <param name="getFriendly">If set to <c>true</c>, gets party members; if set to <c>false</c> gets hostiles. Set to null gets all.</param>
+        /// <returns>
+        /// A <see cref="List{IBattleChara}"/> containing the valid targets.
+        /// </returns>
+        public static List<IBattleChara> GetTargetsByRange(float range, bool? getFriendly = false)
+        {
+            if (DataCenter.AllTargets == null)
+            {
+                return [];
+            }
+
+            List<IBattleChara> targets = [];
+            float searchRange = range;
+            if (getFriendly == true)
+            {
+                range += 1000; // Store party with flag 1000
+            }
+            else if (getFriendly == false)
+            {
+                range += 2000; // Store hostiles with flag 2000
+            }
+
+            if (DataCenter.TargetsByRange.TryGetValue(float.Round(range, 0), out List<IBattleChara>? cachedTargets))
+            {
+                targets = cachedTargets;
+            }
+            else
+            {
+                if (getFriendly == true)
+                {
+                    foreach (IBattleChara target in DataCenter.PartyMembers.GetObjectInRadius(searchRange))
+                    {
+                        if (!ValidityCheck(target))
+                        {
+                            continue;
+                        }
+
+                        targets.Add(target);
+                    }
+                }
+                else if (getFriendly == false)
+                {
+                    foreach (IBattleChara target in DataCenter.AllHostileTargets.GetObjectInRadius(searchRange))
+                    {
+                        if (!ValidityCheck(target))
+                        {
+                            continue;
+                        }
+
+                        targets.Add(target);
+                    }
+                }
+                else
+                {
+                    foreach (IBattleChara target in DataCenter.AllTargets.GetObjectInRadius(searchRange))
+                    {
+                        if (!ValidityCheck(target))
+                        {
+                            continue;
+                        }
+
+                        targets.Add(target);
+                    }
+                }
+
+                DataCenter.TargetsByRange[float.Round(range, 0)] = targets;
+            }
+
+            return targets;
+        }
+
+        /// <summary>
+        /// Performs a general check on the specified battle character to determine if it meets the criteria for targeting.
+        /// </summary>
+        /// <param name="battleChara">The battle character to check.</param>
+        /// <returns>
+        /// <c>true</c> if the battle character meets the criteria for targeting; otherwise, <c>false</c>.
+        /// </returns>
+        private static bool ValidityCheck(IBattleChara battleChara)
+        {
+            if (battleChara == null)
+            {
+                return false;
+            }
+
+            unsafe
+            {
+                if (battleChara.Struct() == null)
+                {
+                    return false;
+                }
+            }
+
+            if (!battleChara.IsTargetable)
+            {
+                return false;
+            }
+
+            try
+            {
+                if (battleChara.StatusList == null)
+                {
+                    return false;
+                }
+            }
+            catch (Exception ex)
+            {
+                PluginLog.Error($"Exception accessing StatusList for {battleChara?.NameId}: {ex.Message}");
+                return false;
+            }
+
+            bool isBlacklisted = false;
+            foreach (uint id in DataCenter.BlacklistedNameIds)
+            {
+                if (id == battleChara.NameId)
+                {
+                    isBlacklisted = true;
+                    break;
+                }
+            }
+            if (isBlacklisted)
+            {
+                return false;
+            }
+
+            if (battleChara.IsEnemy() && !battleChara.IsAttackable())
+            {
+                return false;
+            }
+
+            bool isStopTarget = false;
+            foreach (long stopId in MarkingHelper.GetStopTargets())
+            {
+                if (stopId == (long)battleChara.GameObjectId)
+                {
+                    isStopTarget = true;
+                    break;
+                }
+            }
+            return !isStopTarget || !Service.Config.FilterStopMark;
+        }
+    }
+}

--- a/RotationSolver.Basic/Rotations/CustomRotation_BasicInfo.cs
+++ b/RotationSolver.Basic/Rotations/CustomRotation_BasicInfo.cs
@@ -61,9 +61,6 @@ public partial class CustomRotation : ICustomRotation
     bool ICustomRotation.IsInBurstWindow => IsBursting();
 
     /// <inheritdoc/>
-    public static Vector3? MoveTarget { get; internal set; }
-
-    /// <inheritdoc/>
     public string Description => _description ??= GetType().GetCustomAttribute<RotationAttribute>()?.Description ?? string.Empty;
 
     /// <inheritdoc/>

--- a/RotationSolver.Basic/Rotations/CustomRotation_Invoke.cs
+++ b/RotationSolver.Basic/Rotations/CustomRotation_Invoke.cs
@@ -15,10 +15,12 @@ public partial class CustomRotation
 
         try
         {
-            UpdateInfo();
-
+            UpdateInfo(); // Rotation specific info updates
             IBaseAction.ActionPreview = true;
-            UpdateActions(Role);
+            if (DataCenter.DrawingActions)
+            {
+                UpdateActions(Role);
+            }
             IBaseAction.ActionPreview = false;
 
             CountingOfLastUsing = CountingOfCombatTimeUsing = 0;
@@ -177,48 +179,8 @@ public partial class CustomRotation
         IBaseAction.TargetOverride = null;
         ActionMoveForwardAbility = movingTarget ? act : null;
 
-        if (movingTarget && act is IBaseAction a)
-        {
-            UpdateMoveTarget(a);
-        }
-        else
-        {
-            MoveTarget = null;
-        }
-
         ActionMoveBackAbility = MoveBackAbility(AddlePvE, out act) ? act : null;
         ActionSpeedAbility = SpeedAbility(AddlePvE, out act) ? act : null;
-    }
-
-    private static void UpdateMoveTarget(IBaseAction a)
-    {
-        if (a.PreviewTarget.HasValue && a.PreviewTarget.Value.Target != Player
-            && a.PreviewTarget.Value.Target != null)
-        {
-            Vector3? dir = Player.Position - a.PreviewTarget.Value.Position;
-            float length = dir?.Length() ?? 0;
-            if (length != 0 && dir.HasValue)
-            {
-                Vector3 d = dir.Value / length;
-                MoveTarget = a.PreviewTarget.Value.Position + (d * MathF.Min(length, Player.HitboxRadius + a.PreviewTarget.Value.Target.HitboxRadius));
-            }
-            else
-            {
-                MoveTarget = a.PreviewTarget.Value.Position;
-            }
-        }
-        else
-        {
-            if ((ActionID)a.ID == ActionID.EnAvantPvE)
-            {
-                Vector3 dir = new(MathF.Sin(Player.Rotation), 0, MathF.Cos(Player.Rotation));
-                MoveTarget = Player.Position + (dir * 10); // Consider defining 10 as a constant
-            }
-            else
-            {
-                MoveTarget = a.PreviewTarget?.Position == a.PreviewTarget?.Target?.Position ? null : a.PreviewTarget?.Position;
-            }
-        }
     }
 
     private IAction? Invoke(out IAction? gcdAction)

--- a/RotationSolver/UI/ControlWindow.cs
+++ b/RotationSolver/UI/ControlWindow.cs
@@ -13,12 +13,28 @@ namespace RotationSolver.UI;
 internal class ControlWindow : CtrlWindow
 {
     public static DateTime DidTime { get; set; }
+    private static bool _isOpen = false;
+    public static bool Opened { get => _isOpen; }
 
     public ControlWindow()
         : base(nameof(ControlWindow))
     {
         Size = new Vector2(570f, 300f);
         SizeCondition = ImGuiCond.FirstUseEver;
+    }
+
+    public override void OnOpen()
+    {
+        _isOpen = true;
+        DataCenter.DrawingActions = true;
+        base.OnOpen();
+    }
+
+    public override void OnClose()
+    {
+        _isOpen = false;
+        DataCenter.DrawingActions = false;
+        base.OnClose();
     }
 
     public override unsafe void Draw()

--- a/RotationSolver/UI/RotationConfigWindow.cs
+++ b/RotationSolver/UI/RotationConfigWindow.cs
@@ -3552,7 +3552,6 @@ public partial class RotationConfigWindow : Window
                 ImGui.Separator();
                 ImGui.Text(DataCenter.Role.ToString());
             } },
-        {() => "Performance", DrawPerf },
     });
 
     private static void DrawDebugRotationStatus()
@@ -3867,29 +3866,6 @@ public partial class RotationConfigWindow : Window
         ImGui.Text($"GCD Elapsed: {DataCenter.DefaultGCDElapsed}");
         ImGui.Text($"Calculated Action Ahead: {DataCenter.CalculatedActionAhead}");
         ImGui.Text($"Animation Lock Delay: {DataCenter.AnimationLock}");
-    }
-
-    private static void DrawPerf()
-    {
-        for (int i = 0; i < MajorUpdater.Ticks.Count; i++)
-        {
-            if (MajorUpdater.Ticks[i].Count == 0)
-            {
-                ImGui.Text($"{MajorUpdater.Ticknames[i]}: No data");
-                continue;
-            }
-            ImGui.Text($"{MajorUpdater.Ticknames[i]}: {Math.Round(MajorUpdater.Ticks[i].Average(), 0)}");
-        }
-
-        if (ImGui.Button("Reset Perf Timers"))
-        {
-            foreach (List<long> tick in MajorUpdater.Ticks)
-            {
-                tick.Clear();
-            }
-        }
-        ImGui.Separator();
-        ImGui.Spacing();
     }
 
     private static void DrawLastAction()

--- a/RotationSolver/UI/RotationConfigWindow.cs
+++ b/RotationSolver/UI/RotationConfigWindow.cs
@@ -3552,6 +3552,7 @@ public partial class RotationConfigWindow : Window
                 ImGui.Separator();
                 ImGui.Text(DataCenter.Role.ToString());
             } },
+        {() => "Performance", DrawPerf },
     });
 
     private static void DrawDebugRotationStatus()
@@ -3866,6 +3867,29 @@ public partial class RotationConfigWindow : Window
         ImGui.Text($"GCD Elapsed: {DataCenter.DefaultGCDElapsed}");
         ImGui.Text($"Calculated Action Ahead: {DataCenter.CalculatedActionAhead}");
         ImGui.Text($"Animation Lock Delay: {DataCenter.AnimationLock}");
+    }
+
+    private static void DrawPerf()
+    {
+        for (int i = 0; i < MajorUpdater.Ticks.Count; i++)
+        {
+            if (MajorUpdater.Ticks[i].Count == 0)
+            {
+                ImGui.Text($"{MajorUpdater.Ticknames[i]}: No data");
+                continue;
+            }
+            ImGui.Text($"{MajorUpdater.Ticknames[i]}: {Math.Round(MajorUpdater.Ticks[i].Average(), 0)}");
+        }
+
+        if (ImGui.Button("Reset Perf Timers"))
+        {
+            foreach (List<long> tick in MajorUpdater.Ticks)
+            {
+                tick.Clear();
+            }
+        }
+        ImGui.Separator();
+        ImGui.Spacing();
     }
 
     private static void DrawLastAction()

--- a/RotationSolver/Updaters/MajorUpdater.cs
+++ b/RotationSolver/Updaters/MajorUpdater.cs
@@ -43,23 +43,14 @@ internal static class MajorUpdater
             bool anyCondition = false;
             foreach (var conditionFlag in Svc.Condition.AsReadOnlySet())
             {
-                if (Svc.Condition.AsReadOnlySet().Contains(conditionFlag))
+                if (conditionFlag == ConditionFlag.BetweenAreas || conditionFlag == ConditionFlag.BetweenAreas51 || conditionFlag == ConditionFlag.LoggingOut)
                 {
-                    anyCondition = true;
-                    break;
+                    return false;
                 }
+                anyCondition = true; // foreach doesn't execute on an empty enumerable, so this will only be true if there are conditions
             }
-            if (!anyCondition)
-                return false;
 
-            if (Svc.Condition[ConditionFlag.BetweenAreas])
-                return false;
-            if (Svc.Condition[ConditionFlag.BetweenAreas51])
-                return false;
-            if (Svc.Condition[ConditionFlag.LoggingOut])
-                return false;
-
-            return true;
+            return anyCondition;
         }
     }
 

--- a/RotationSolver/Updaters/MajorUpdater.cs
+++ b/RotationSolver/Updaters/MajorUpdater.cs
@@ -6,6 +6,7 @@ using ECommons.Logging;
 using Lumina.Excel.Sheets;
 using RotationSolver.Commands;
 using RotationSolver.UI.HighlightTeachingMode;
+using System.Diagnostics;
 using static FFXIVClientStructs.FFXIV.Client.UI.Misc.RaptureHotbarModule;
 
 namespace RotationSolver.Updaters;
@@ -13,6 +14,24 @@ namespace RotationSolver.Updaters;
 internal static class MajorUpdater
 {
     private static TimeSpan _timeSinceUpdate = TimeSpan.Zero;
+    private static List<long> curTicks = [];
+    public static List<List<long>> Ticks = [[], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], []];
+    public static List<string> Ticknames = [ "teaching mode", "isValid check", "UpdateRotationState", "AU ClearNextAction", "MU Update1", "DC Active", "AU CanDo", "Update Can Move", "RS DoAction", "Update Macro",
+                                              "Update Targets", "Update State", "Update Sequencer", "AU Update Next Action", "Update Combat Info", "Update Display Windows", "Handle Warnings", "Clear VFX",
+                                              "Check Local Rotations", "Update Rotations", "Update Rotation State", "MU Update2"];
+    private static void UpdateCounter(long entry, int index, bool end = false)
+    {
+        long toAdd = entry - curTicks.LastOrDefault(0);
+        curTicks.Add(entry);
+
+        Ticks[index].Add(toAdd);
+
+        if (end)
+        {
+            curTicks.Clear();
+        }
+    }
+
     public static bool IsValid
     {
         get
@@ -63,6 +82,9 @@ internal static class MajorUpdater
             _timeSinceUpdate = TimeSpan.Zero;
         }
 
+        var _sw = new Stopwatch();
+        _sw.Start();
+
         if (Service.Config.TeachingMode)
         {
             try
@@ -82,15 +104,20 @@ internal static class MajorUpdater
                 }
             }
         }
+        UpdateCounter(_sw.ElapsedTicks, 0);
 
         // Transistion safe commands
         if (!IsValid)
         {
             try
             {
+                UpdateCounter(_sw.ElapsedTicks, 1);
                 RSCommands.UpdateRotationState();
+                UpdateCounter(_sw.ElapsedTicks, 2);
                 ActionUpdater.ClearNextAction();
+                UpdateCounter(_sw.ElapsedTicks, 3);
                 MiscUpdater.UpdateEntry();
+                UpdateCounter(_sw.ElapsedTicks, 4);
                 CustomRotation.MoveTarget = null;
                 ActionUpdater.NextAction = ActionUpdater.NextGCDAction = null;
                 return;
@@ -108,24 +135,34 @@ internal static class MajorUpdater
                 }
             }
         }
+        UpdateCounter(_sw.ElapsedTicks, 1);
 
         if (DataCenter.IsActivated())
         {
+            UpdateCounter(_sw.ElapsedTicks, 5);
             try
             {
                 bool canDoAction = ActionUpdater.CanDoAction();
+                UpdateCounter(_sw.ElapsedTicks, 6);
                 MovingUpdater.UpdateCanMove(canDoAction);
+                UpdateCounter(_sw.ElapsedTicks, 7);
 
                 if (canDoAction)
                 {
                     RSCommands.DoAction();
+                    UpdateCounter(_sw.ElapsedTicks, 8);
                 }
 
                 MacroUpdater.UpdateMacro();
+                UpdateCounter(_sw.ElapsedTicks, 9);
                 TargetUpdater.UpdateTargets();
+                UpdateCounter(_sw.ElapsedTicks, 10);
                 StateUpdater.UpdateState();
+                UpdateCounter(_sw.ElapsedTicks, 11);
                 ActionSequencerUpdater.UpdateActionSequencerAction();
+                UpdateCounter(_sw.ElapsedTicks, 12);
                 ActionUpdater.UpdateNextAction();
+                UpdateCounter(_sw.ElapsedTicks, 13);
             }
             catch (Exception ex)
             {
@@ -183,9 +220,11 @@ internal static class MajorUpdater
             // Update various combat tracking perameters,
             // combat time, blue mage/dutyaction slot info, player movement time, player dead status and MP timer.
             ActionUpdater.UpdateCombatInfo();
+            UpdateCounter(_sw.ElapsedTicks, 14);
 
             // Update displaying the additional UI windows
             RotationSolverPlugin.UpdateDisplayWindow();
+            UpdateCounter(_sw.ElapsedTicks, 15);
 
             // Handle system warnings
             if (DataCenter.SystemWarnings.Count > 0)
@@ -206,24 +245,29 @@ internal static class MajorUpdater
                     _ = DataCenter.SystemWarnings.Remove(key);
                 }
             }
+            UpdateCounter(_sw.ElapsedTicks, 16);
 
             // Clear old VFX data
             if (DataCenter.VfxDataQueue.Count > 0)
             {
                 _ = DataCenter.VfxDataQueue.RemoveAll(vfx => vfx.TimeDuration > TimeSpan.FromSeconds(6));
             }
+            UpdateCounter(_sw.ElapsedTicks, 17);
 
             // Check local rotation files
             if (Service.Config.AutoReloadRotations)
             {
                 RotationUpdater.LocalRotationWatcher();
             }
+            UpdateCounter(_sw.ElapsedTicks, 18);
 
             // Change loaded rotation based on job
             RotationUpdater.UpdateRotation();
+            UpdateCounter(_sw.ElapsedTicks, 19);
 
             // Change RS state
             RSCommands.UpdateRotationState();
+            UpdateCounter(_sw.ElapsedTicks, 20);
 
             if (Service.Config.TeachingMode)
             {
@@ -246,6 +290,8 @@ internal static class MajorUpdater
             }
 
             MiscUpdater.UpdateMisc();
+            _sw.Stop();
+            UpdateCounter(_sw.ElapsedTicks, 21, true);
         }
         catch (Exception ex)
         {

--- a/RotationSolver/Updaters/RotationUpdater.cs
+++ b/RotationSolver/Updaters/RotationUpdater.cs
@@ -704,20 +704,26 @@ internal static class RotationUpdater
         }
 
         Job nowJob = Player.Job;
+        CombatType curCombatType = DataCenter.IsPvP ? CombatType.PvP : CombatType.PvE;
 
-        if (!CustomRotationsLookup.TryGetValue(nowJob, out Dictionary<CombatType, List<ICustomRotation>>? validCustomRotations))
+        if (DataCenter.CurrentRotation?.Job == nowJob && DataCenter.CurrentRotation?.GetAttributes()?.Type == curCombatType)
+        {
+            return; // Nothing has changed, so we don't need to try and find a new rotation
+        }
+
+        if (!CustomRotationsLookup.TryGetValue(nowJob, out _))
         {
             InitReferenceDict(nowJob);
         }
-        if (CustomRotationsLookup.TryGetValue(nowJob, out validCustomRotations)) // Because default rotations exist, this *should* always have something; if not, no rotations
+
+        if (CustomRotationsLookup.TryGetValue(nowJob, out Dictionary<CombatType, List<ICustomRotation>>? validCustomRotations)) // Because default rotations exist, this *should* always have something; if not, no rotations
         {
-            if (validCustomRotations.Count == 0) // We'll still check
+            if (validCustomRotations.Count == 0) // We successfully got something, but we'll still check if there are any valid rotations
             {
                 PluginLog.Warning($"No valid rotations found for {nowJob}");
                 return;
             }
 
-            CombatType curCombatType = DataCenter.IsPvP ? CombatType.PvP : CombatType.PvE;
             if (validCustomRotations.TryGetValue(curCombatType, out List<ICustomRotation>? validCustomRotationsList))
             {
                 string desiredRotationName = DataCenter.IsPvP ? Service.Config.PvPRotationChoice : Service.Config.RotationChoice;
@@ -745,7 +751,6 @@ internal static class RotationUpdater
             }
         }
 
-        CustomRotation.MoveTarget = null;
         DataCenter.CurrentRotation = null;
         CurrentRotationActions = [];
     }

--- a/RotationSolver/Updaters/RotationUpdater.cs
+++ b/RotationSolver/Updaters/RotationUpdater.cs
@@ -25,6 +25,7 @@ internal static class RotationUpdater
     private static DateTime LastRunTime;
 
     private static bool _isLoading = false;
+    private static string _curDutyRotationName = string.Empty;
 
     public static Task ResetToDefaults()
     {
@@ -669,11 +670,17 @@ internal static class RotationUpdater
 
         _ = Service.Config.DutyRotationChoice.TryGetValue(Svc.ClientState.TerritoryType, out string? value);
         string name = value ?? string.Empty;
+        if (name == _curDutyRotationName && DataCenter.CurrentDutyRotation != null)
+        {
+            return; // No change, so we don't need to update
+        }
+
         Type? type = GetChosenType(rotations, name);
         if (type != DataCenter.CurrentDutyRotation?.GetType())
         {
             DataCenter.CurrentDutyRotation?.Dispose();
             DataCenter.CurrentDutyRotation = GetRotation(type);
+            _curDutyRotationName = name;
         }
 
         static DutyRotation? GetRotation(Type? t)


### PR DESCRIPTION
This should be a test release. I don't use teaching mode or a variety of other features, and while I've made an effort to at least verify they at least seem to work it would be good to verify.

Notably, this removes MoveTarget which is currently being calculated but does not appear to be used anywhere, I believe it is replaced by the logic used in `FindTargetForMoving`, and while it is not part of the ICustomRotation interface may be used in some fashion in custom repos.

- Adds caching for targets within range during the same RSR tick; calling multiple checks will filter the enemies per ability, but won't recalculate which enemies are within 25 yards each time.
- Reworked CanUseTo vision check to avoid re-calculating vision.
- Consolidated many of the structural checks that were done in `ActionTargetInfo.GeneralCheck` into a validity check performed as part of the range filter and split out the additional checks related to Statuses, TTK, and Resistance.
- Shock and Dark Cannon now compare against the previously filtered list of hostile enemies which should make them both more performant and better at maximizing their AoE potential.
- Average TTK of mobs in the current combat is now cached per tick rather than being re-calculated.
- Improved performance of TTK calculation, especially in long fights or fights with many mobs.
- Now checks whether the control window is opened before calculating next action of each category for it.
- More performance optimizations for per-frame updates being done in RotationUpdater
- Minor performance optimizations for `MajorUpdater.IsValid`