### PR TITLE
Reworked Viper entirely, adjusted AST and MCH, misc pot change

### DIFF
--- a/BasicRotations/Healer/AST_Default.cs
+++ b/BasicRotations/Healer/AST_Default.cs
@@ -163,14 +163,6 @@ public sealed class AST_Default : AstrologianRotation
             return true;
         }
 
-        if (Player.WillStatusEndGCD(2, 0, true, StatusID.Suntouched))
-        {
-            if (SunSignPvE.CanUse(out act))
-            {
-                return true;
-            }
-        }
-
         return base.EmergencyAbility(nextGCD, out act);
     }
 
@@ -339,6 +331,14 @@ public sealed class AST_Default : AstrologianRotation
         if (BubbleProtec && HasCollectiveUnconscious)
         {
             return false;
+        }
+
+        if (Player.WillStatusEndGCD(2, 0, true, StatusID.Suntouched))
+        {
+            if (SunSignPvE.CanUse(out act))
+            {
+                return true;
+            }
         }
 
         if (PartyMembersAverHP < LadyOfHeals && LadyOfCrownsPvE.CanUse(out act))

--- a/BasicRotations/Melee/VPR_Default.cs
+++ b/BasicRotations/Melee/VPR_Default.cs
@@ -35,8 +35,8 @@ public sealed class VPR_Default : ViperRotation
     [RotationConfig(CombatType.PvE, Name = "Experimental Pot Usage(used up to 5 seconds before SerpentsIre comes off cooldown)")]
     public bool BurstMed { get; set; } = false;
 
-    [RotationConfig(CombatType.PvE, Name = "Restrict GCD use if oGCDs can be used (Experimental)")]
-    public bool AbilityPrio { get; set; } = false;
+    [RotationConfig(CombatType.PvE, Name = "Restrict GCD use if Serpent's Tail, Twinblood, or Twinfang oGCDs can be used")]
+    public bool AbilityPrio2 { get; set; } = true;
 
     [RotationConfig(CombatType.PvE, Name = "Attempt to prevent regular combo from dropping (Experimental)")]
     public bool PreserveCombo { get; set; } = false;
@@ -47,40 +47,110 @@ public sealed class VPR_Default : ViperRotation
     protected override bool EmergencyAbility(IAction nextGCD, out IAction? act)
     {
         // Uncoiled Fury Combo
-        if (UncoiledTwinfangPvE.CanUse(out act))
+        switch ((HasPoisedFang, HasPoisedBlood))
+        {
+            case (true, _):
+                if (UncoiledTwinfangPvE.CanUse(out act))
+                    return true;
+                break;
+            case (_, true):
+                if (UncoiledTwinbloodPvE.CanUse(out act))
+                    return true;
+                break;
+            case (false, false):
+                if (TimeSinceLastAction.TotalSeconds < 2)
+                    break;
+                if (UncoiledTwinfangPvE.CanUse(out act))
+                    return true;
+                if (UncoiledTwinbloodPvE.CanUse(out act))
+                    return true;
+                break;
+        }
+
+        // AOE Dread Combo
+        switch ((HasFellHuntersVenom, HasFellSkinsVenom))
+        {
+            case (true, _):
+                if (TwinfangThreshPvE.CanUse(out act, skipAoeCheck: true))
+                    return true;
+                break;
+            case (_, true):
+                if (TwinbloodThreshPvE.CanUse(out act, skipAoeCheck: true))
+                    return true;
+                break;
+            case (false, false):
+                if (TimeSinceLastAction.TotalSeconds < 2)
+                    break;
+                if (TwinfangThreshPvE.CanUse(out act, skipAoeCheck: true))
+                    return true;
+                if (TwinbloodThreshPvE.CanUse(out act, skipAoeCheck: true))
+                    return true;
+                break;
+        }
+
+        // Single Target Dread Combo
+        switch ((HasHunterVenom, HasSwiftVenom))
+        {
+            case (true, _):
+                if (TwinfangBitePvE.CanUse(out act))
+                    return true;
+                break;
+            case (_, true):
+                if (TwinbloodBitePvE.CanUse(out act))
+                    return true;
+                break;
+            case (false, false):
+                if (TimeSinceLastAction.TotalSeconds < 2)
+                    break;
+                if (TwinfangBitePvE.CanUse(out act))
+                    return true;
+                if (TwinbloodBitePvE.CanUse(out act))
+                    return true;
+                break;
+        }
+
+        //Reawaken Combo
+        if (HasReawakenedActive)
+        {
+            if (FirstLegacyPvE.CanUse(out act))
+            {
+                return true;
+            }
+
+            if (SecondLegacyPvE.CanUse(out act))
+            {
+                return true;
+            }
+
+            if (ThirdLegacyPvE.CanUse(out act))
+            {
+                return true;
+            }
+
+            if (FourthLegacyPvE.CanUse(out act))
+            {
+                return true;
+            }
+        }
+
+        if (SerpentsIrePvE.CanUse(out act))
         {
             return true;
         }
 
-        if (UncoiledTwinbloodPvE.CanUse(out act))
+        ////Serpent Combo oGCDs
+        if (LastLashPvE.CanUse(out act))
         {
             return true;
         }
 
-        //AOE Dread Combo
-        if (TwinfangThreshPvE.CanUse(out act, skipAoeCheck: true))
-        {
-            return true;
-        }
-
-        if (TwinbloodThreshPvE.CanUse(out act, skipAoeCheck: true))
-        {
-            return true;
-        }
-
-        //Single Target Dread Combo
-        if (TwinfangBitePvE.CanUse(out act))
-        {
-            return true;
-        }
-
-        if (TwinbloodBitePvE.CanUse(out act))
+        if (DeathRattlePvE.CanUse(out act))
         {
             return true;
         }
 
         // Use burst medicine if cooldown for Serpents Ire has elapsed sufficiently
-        if (SerpentCombo == SerpentCombo.None && BurstMed && SerpentsIrePvE.EnoughLevel && SerpentsIrePvE.Cooldown.ElapsedAfter(115)
+        if (NoAbilityReady && BurstMed && SerpentsIrePvE.EnoughLevel && SerpentsIrePvE.Cooldown.ElapsedAfter(115)
             && UseBurstMedicine(out act))
         {
             return true;
@@ -102,12 +172,12 @@ public sealed class VPR_Default : ViperRotation
     [RotationDesc]
     protected override bool HealSingleAbility(IAction nextGCD, out IAction? act)
     {
-        if (SerpentCombo == SerpentCombo.None && SecondWindPvE.CanUse(out act))
+        if (NoAbilityReady && SecondWindPvE.CanUse(out act))
         {
             return true;
         }
 
-        if (SerpentCombo == SerpentCombo.None && BloodbathPvE.CanUse(out act))
+        if (NoAbilityReady && BloodbathPvE.CanUse(out act))
         {
             return true;
         }
@@ -118,7 +188,7 @@ public sealed class VPR_Default : ViperRotation
     [RotationDesc]
     protected sealed override bool DefenseAreaAbility(IAction nextGCD, out IAction? act)
     {
-        if (SerpentCombo == SerpentCombo.None && FeintPvE.CanUse(out act))
+        if (NoAbilityReady && FeintPvE.CanUse(out act))
         {
             return true;
         }
@@ -129,7 +199,7 @@ public sealed class VPR_Default : ViperRotation
     [RotationDesc]
     protected sealed override bool AntiKnockbackAbility(IAction nextGCD, out IAction? act)
     {
-        if (SerpentCombo == SerpentCombo.None && ArmsLengthPvE.CanUse(out act))
+        if (NoAbilityReady && ArmsLengthPvE.CanUse(out act))
         {
             return true;
         }
@@ -140,7 +210,7 @@ public sealed class VPR_Default : ViperRotation
     [RotationDesc]
     protected sealed override bool InterruptAbility(IAction nextGCD, out IAction? act)
     {
-        if (SerpentCombo == SerpentCombo.None && LegSweepPvE.CanUse(out act))
+        if (NoAbilityReady && LegSweepPvE.CanUse(out act))
         {
             return true;
         }
@@ -153,43 +223,6 @@ public sealed class VPR_Default : ViperRotation
 
     protected override bool AttackAbility(IAction nextGCD, out IAction? act)
     {
-        ////Reawaken Combo
-        if (FirstLegacyPvE.CanUse(out act))
-        {
-            return true;
-        }
-
-        if (SecondLegacyPvE.CanUse(out act))
-        {
-            return true;
-        }
-
-        if (ThirdLegacyPvE.CanUse(out act))
-        {
-            return true;
-        }
-
-        if (FourthLegacyPvE.CanUse(out act))
-        {
-            return true;
-        }
-
-        if (SerpentsIrePvE.CanUse(out act))
-        {
-            return true;
-        }
-
-        ////Serpent Combo oGCDs
-        if (LastLashPvE.CanUse(out act))
-        {
-            return true;
-        }
-
-        if (DeathRattlePvE.CanUse(out act))
-        {
-            return true;
-        }
-
         return base.AttackAbility(nextGCD, out act);
     }
     #endregion
@@ -198,10 +231,8 @@ public sealed class VPR_Default : ViperRotation
     protected override bool GeneralGCD(out IAction? act)
     {
         act = null;
-        if (AbilityPrio &&
-            (SerpentsTailPvE.AdjustedID != SerpentsTailPvE.ID
-            || TwinfangBitePvE.AdjustedID != TwinfangBitePvE.ID
-            || TwinbloodBitePvE.AdjustedID != TwinbloodBitePvE.ID))
+        if (AbilityPrio2 &&
+            !NoAbilityReady)
         {
             return false;
         }
@@ -233,15 +264,11 @@ public sealed class VPR_Default : ViperRotation
             return true;
         }
 
-        if ((SwiftTime > SwiftTimer &&
-            HuntersTime > HuntersTimer &&
-            !HasHunterVenom && !HasSwiftVenom &&
-            !HasPoisedBlood && !HasPoisedFang && SerpentsIrePvE.EnoughLevel && (!SerpentsIrePvE.Cooldown.ElapsedAfter(ReawakenDelayTimer) || SerpentOffering == 100)) ||
-            (SwiftTime > SwiftTimer &&
-            HuntersTime > HuntersTimer &&
-            !HasHunterVenom && !HasSwiftVenom &&
-            !HasPoisedBlood && !HasPoisedFang && !SerpentsIrePvE.EnoughLevel))
+        // Check if player meets Serpents Ire requirements, then check buff timers.
+        if (((SerpentsIrePvE.EnoughLevel && (!SerpentsIrePvE.Cooldown.ElapsedAfter(ReawakenDelayTimer) || SerpentOffering == 100)) || !SerpentsIrePvE.EnoughLevel)
+            && SwiftTime > SwiftTimer && HuntersTime > HuntersTimer)
         {
+            // If all above conditions are met, attempt to use Reawaken.
             if (ReawakenPvE.CanUse(out act, skipComboCheck: true))
             {
                 return true;
@@ -253,7 +280,7 @@ public sealed class VPR_Default : ViperRotation
             // Uncoiled Fury Overcap protection
             bool isTargetBoss = CurrentTarget?.IsBossFromTTK() ?? false;
             bool isTargetDying = CurrentTarget?.IsDying() ?? false;
-            if ((MaxRattling == RattlingCoilStacks || RattlingCoilStacks >= MaxUncoiledStacksUser || (isTargetBoss && isTargetDying && RattlingCoilStacks > 0)) && !Player.HasStatus(true, StatusID.ReadyToReawaken) && SerpentCombo == SerpentCombo.None)
+            if ((MaxRattling == RattlingCoilStacks || RattlingCoilStacks >= MaxUncoiledStacksUser || (isTargetBoss && isTargetDying && RattlingCoilStacks > 0)) && !HasReadyToReawaken && NoAbilityReady)
             {
                 if (UncoiledFuryPvE.CanUse(out act, usedUp: true))
                 {
@@ -261,7 +288,7 @@ public sealed class VPR_Default : ViperRotation
                 }
             }
 
-            if (MedicineUncoiledFury && Player.HasStatus(true, StatusID.Medicated) && !Player.HasStatus(true, StatusID.ReadyToReawaken) && SerpentCombo == SerpentCombo.None)
+            if (MedicineUncoiledFury && Player.HasStatus(true, StatusID.Medicated) && !HasReadyToReawaken && NoAbilityReady)
             {
                 if (UncoiledFuryPvE.CanUse(out act, usedUp: true))
                 {
@@ -272,8 +299,8 @@ public sealed class VPR_Default : ViperRotation
             if ((RattlingCoilStacks > 1
                 || !BurstUncoiledFuryHold)
                 && SerpentsIrePvE.Cooldown.JustUsedAfter(30)
-                && !Player.HasStatus(true, StatusID.ReadyToReawaken)
-                && SerpentCombo == SerpentCombo.None)
+                && !HasReadyToReawaken
+                && NoAbilityReady)
             {
                 if (UncoiledFuryPvE.CanUse(out act, usedUp: true))
                 {
@@ -283,14 +310,51 @@ public sealed class VPR_Default : ViperRotation
         }
 
         ////AOE Dread Combo
-        if (SwiftskinsDenPvE.CanUse(out act, skipComboCheck: true, skipAoeCheck: true))
+        if (PitActive)
         {
-            return true;
+            if (IsSwift && Player.WillStatusEndGCD(2, 0, true, StatusID.Swiftscaled))
+            {
+                if (SwiftskinsDenPvE.CanUse(out act, skipComboCheck: true, skipAoeCheck: true))
+                    return true;
+            }
+
+            if (IsHunter && Player.WillStatusEndGCD(2, 0, true, StatusID.HuntersInstinct))
+            {
+                if (HuntersDenPvE.CanUse(out act, skipComboCheck: true, skipAoeCheck: true))
+                    return true;
+            }
+
+            switch (HunterOrSwiftEndsFirst)
+            {
+                case "Hunter":
+                    if (HuntersDenPvE.CanUse(out act, skipComboCheck: true, skipAoeCheck: true))
+                        return true;
+                    break;
+                case "Swift":
+                    if (SwiftskinsDenPvE.CanUse(out act, skipComboCheck: true, skipAoeCheck: true))
+                        return true;
+                    break;
+                case "Equal":
+                case null:
+                    if (HuntersDenPvE.CanUse(out act, skipComboCheck: true, skipAoeCheck: true))
+                        return true;
+                    if (SwiftskinsDenPvE.CanUse(out act, skipComboCheck: true, skipAoeCheck: true))
+                        return true;
+                    break;
+            }
         }
 
-        if (HuntersDenPvE.CanUse(out act, skipComboCheck: true, skipAoeCheck: true))
+        if (!PitActive)
         {
-            return true;
+            if (SwiftskinsDenPvE.CanUse(out act, skipComboCheck: true, skipAoeCheck: true))
+            {
+                return true;
+            }
+
+            if (HuntersDenPvE.CanUse(out act, skipComboCheck: true, skipAoeCheck: true))
+            {
+                return true;
+            }
         }
 
         if ((PreserveCombo && LiveComboTime > GCDTime(3)) || !PreserveCombo)
@@ -309,25 +373,66 @@ public sealed class VPR_Default : ViperRotation
         }
 
         ////Single Target Dread Combo
-        // Try using Coil that player is in position for extra damage first
-        if (HuntersCoilPvE.CanUse(out act, skipComboCheck: true) && HuntersCoilPvE.Target.Target != null && CanHitPositional(EnemyPositional.Flank, HuntersCoilPvE.Target.Target))
+        // Try using Coil thats buff provided will end soon
+        // then try using Coil that you can hit positional on
+        // then try using Coil that will end first
+        if (DreadActive)
         {
-            return true;
+            if (IsSwift && Player.WillStatusEndGCD(2, 0, true, StatusID.Swiftscaled))
+            {
+                if (SwiftskinsCoilPvE.CanUse(out act, skipComboCheck: true))
+                    return true;
+            }
+
+            if (IsHunter && Player.WillStatusEndGCD(2, 0, true, StatusID.HuntersInstinct))
+            {
+                if (HuntersCoilPvE.CanUse(out act, skipComboCheck: true))
+                    return true;
+            }
+
+            if (HuntersCoilPvE.Target.Target != null && CanHitPositional(EnemyPositional.Flank, HuntersCoilPvE.Target.Target) &&
+                HuntersCoilPvE.CanUse(out act, skipComboCheck: true))
+            {
+                return true;
+            }
+
+            if (SwiftskinsCoilPvE.Target.Target != null && CanHitPositional(EnemyPositional.Rear, SwiftskinsCoilPvE.Target.Target) &&
+                SwiftskinsCoilPvE.CanUse(out act, skipComboCheck: true))
+            {
+                return true;
+            }
+
+            switch (HunterOrSwiftEndsFirst)
+            {
+                case "Hunter":
+                    if (HuntersCoilPvE.CanUse(out act, skipComboCheck: true))
+                        return true;
+                    break;
+                case "Swift":
+                    if (SwiftskinsCoilPvE.CanUse(out act, skipComboCheck: true))
+                        return true;
+                    break;
+                case "Equal":
+                case null:
+                    if (HuntersCoilPvE.CanUse(out act, skipComboCheck: true))
+                        return true;
+                    if (SwiftskinsCoilPvE.CanUse(out act, skipComboCheck: true))
+                        return true;
+                    break;
+            }
         }
 
-        if (SwiftskinsCoilPvE.CanUse(out act, skipComboCheck: true) && SwiftskinsCoilPvE.Target.Target != null && CanHitPositional(EnemyPositional.Rear, SwiftskinsCoilPvE.Target.Target))
+        if (!DreadActive)
         {
-            return true;
-        }
+            if (HuntersCoilPvE.CanUse(out act, skipComboCheck: true))
+            {
+                return true;
+            }
 
-        if (HuntersCoilPvE.CanUse(out act, skipComboCheck: true))
-        {
-            return true;
-        }
-
-        if (SwiftskinsCoilPvE.CanUse(out act, skipComboCheck: true))
-        {
-            return true;
+            if (SwiftskinsCoilPvE.CanUse(out act, skipComboCheck: true))
+            {
+                return true;
+            }
         }
 
         if ((PreserveCombo && LiveComboTime > GCDTime(3)) || !PreserveCombo)
@@ -345,14 +450,22 @@ public sealed class VPR_Default : ViperRotation
             }
         }
         //AOE Serpent Combo
-        if (JaggedMawPvE.CanUse(out act, skipAoeCheck: true))
+        switch ((HasGrimHunter, HasGrimSkin))
         {
-            return true;
-        }
-
-        if (BloodiedMawPvE.CanUse(out act, skipAoeCheck: true))
-        {
-            return true;
+            case (true, _):
+                if (JaggedMawPvE.CanUse(out act, skipAoeCheck: true))
+                    return true;
+                break;
+            case (false, true):
+                if (BloodiedMawPvE.CanUse(out act, skipAoeCheck: true))
+                    return true;
+                break;
+            case (false, false):
+                if (JaggedMawPvE.CanUse(out act, skipAoeCheck: true))
+                    return true;
+                if (BloodiedMawPvE.CanUse(out act, skipAoeCheck: true))
+                    return true;
+                break;
         }
 
         if (HuntersBitePvE.CanUse(out act, skipAoeCheck: true))
@@ -417,12 +530,12 @@ public sealed class VPR_Default : ViperRotation
         }
 
         //Ranged
-        if ((UFGhosting || (!UFGhosting && SerpentCombo == SerpentCombo.None)) && UncoiledFuryPvE.CanUse(out act, usedUp: true))
+        if ((UFGhosting || (!UFGhosting && NoAbilityReady)) && UncoiledFuryPvE.CanUse(out act, usedUp: true))
         {
             return true;
         }
 
-        if ((UFGhosting || (!UFGhosting && SerpentCombo == SerpentCombo.None)) && WrithingSnapPvE.CanUse(out act))
+        if ((UFGhosting || (!UFGhosting && NoAbilityReady)) && WrithingSnapPvE.CanUse(out act))
         {
             return true;
         }

--- a/BasicRotations/Ranged/MCH_Rework.cs
+++ b/BasicRotations/Ranged/MCH_Rework.cs
@@ -119,7 +119,10 @@ public sealed class MCH_Rework : MachinistRotation
         {
             if ((Heat >= 50 || HasHypercharged) && !LowLevelHyperCheck)
             {
-                if (WeaponRemain < GCDTime(1) / 2 && nextGCD.IsTheSameTo(false, FullMetalFieldPvE) && WildfirePvE.CanUse(out act))
+                if (WeaponRemain < GCDTime(1) / 2 
+                    && (nextGCD.IsTheSameTo(false, FullMetalFieldPvE)
+                    || (nextGCD.IsTheSameTo(false, DrillPvE, ChainSawPvE, AirAnchorPvE, ExcavatorPvE) && !HasFullMetalMachinist)) 
+                    && WildfirePvE.CanUse(out act))
                 {
                     return true;
                 }

--- a/RotationSolver.Basic/Rotations/Basic/ViperRotation.cs
+++ b/RotationSolver.Basic/Rotations/Basic/ViperRotation.cs
@@ -11,7 +11,7 @@ public partial class ViperRotation
     public static byte RattlingCoilStacks => JobGauge.RattlingCoilStacks;
 
     /// <summary>
-    /// Gets Max stacks of Anguine Tribute.
+    /// Gets Max stacks of Rattling Coil.
     /// </summary>
     public static byte MaxRattling => EnhancedVipersRattleTrait.EnoughLevel ? (byte)3 : (byte)2;
 
@@ -23,8 +23,14 @@ public partial class ViperRotation
     /// <summary>
     ///  Gets value indicating the use of 1st, 2nd, 3rd, 4th generation and Ouroboros.
     /// </summary>
-    public static byte AnguineTribute => JobGauge.AnguineTribute;
+    public static byte AnguineTributeStacks => JobGauge.AnguineTribute;
 
+    /// <summary>
+    /// Gets Max stacks of Anguine Tribute.
+    /// </summary>
+    public static byte MaxAnguine => EnhancedSerpentsLineageTrait.EnoughLevel ? (byte)5 : (byte)4;
+
+    #region DreadCombo
     /// <summary>
     /// Gets the last Weaponskill used in DreadWinder/Pit of Dread combo. Dreadwinder = 1, HuntersCoil, SwiftskinsCoil, PitOfDread, HuntersDen, SwiftskinsDen
     /// </summary>
@@ -36,43 +42,128 @@ public partial class ViperRotation
     public static bool NODREAD => JobGauge.DreadCombo == 0;
 
     /// <summary>
+    /// Indicates that the player has Dread Combo active and both HuntersCoil and SwiftskinsCoil available.
+    /// </summary>
+    public static bool DreadActive => (byte)JobGauge.DreadCombo == 1;
+
+    /// <summary>
+    /// Indicates that the player has Dread Combo active and only SwiftskinsCoil available.
+    /// </summary>
+    public static bool SwiftskinsCoilOnly => (byte)JobGauge.DreadCombo == 2;
+
+    /// <summary>
+    /// Indicates that the player has Dread Combo active and only HuntersCoil available.
+    /// </summary>
+    public static bool HuntersCoilOnly => (byte)JobGauge.DreadCombo == 3;
+
+    /// <summary>
+    /// Indicates that the player has Pit Combo active and both HuntersDen and SwiftskinsDen available.
+    /// </summary>
+    public static bool PitActive => (byte)JobGauge.DreadCombo == 4;
+
+    /// <summary>
+    /// Indicates that the player has Pit Combo active and only SwiftskinsDen available.
+    /// </summary>
+    public static bool SwiftskinsDenOnly => (byte)JobGauge.DreadCombo == 5;
+
+    /// <summary>
+    /// Indicates that the player has Pit Combo active and only HuntersDen available.
+    /// </summary>
+    public static bool HuntersDenOnly => (byte)JobGauge.DreadCombo == 6;
+    #endregion
+
+    #region SerpentAbilities
+    /// <summary>
     /// Gets current ability for Serpent's Tail. NONE = 0, DEATHRATTLE = 1, LASTLASH = 2, FIRSTLEGACY = 3, SECONDLEGACY = 4, THIRDLEGACY = 5, FOURTHLEGACY = 6, TWINSREADY = 7, THRESHREADY = 8, UNCOILEDREADY = 9
     /// </summary>
     public static SerpentCombo SerpentCombo => JobGauge.SerpentCombo;
 
     /// <summary>
-    /// Indicates if base Twins combo is ready.
+    /// Indicates if base no abilities are ready.
     /// </summary>
-    public static bool TWINSREADY => (byte)JobGauge.SerpentCombo == 7;
+    public static bool NoAbilityReady => (byte)JobGauge.SerpentCombo == 0;
 
     /// <summary>
-    /// Indicates if base Thresh combo is ready.
+    /// Indicates if base Death Rattle oGCD is ready.
     /// </summary>
-    public static bool THRESHREADY => (byte)JobGauge.SerpentCombo == 8;
+    public static bool DeathRattleReady => (byte)JobGauge.SerpentCombo == 1;
 
     /// <summary>
-    /// Indicates if base Uncoiled combo is ready.
+    /// Indicates if base Last Lash oGCD is ready.
     /// </summary>
-    public static bool UNCOILEDREADY => (byte)JobGauge.SerpentCombo == 9;
+    public static bool LastLashReady => (byte)JobGauge.SerpentCombo == 2;
 
     /// <summary>
-    /// Gets Max stacks of Anguine Tribute.
+    /// Indicates if base First Legacy oGCD is ready.
     /// </summary>
-    public static byte MaxAnguine => EnhancedSerpentsLineageTrait.EnoughLevel ? (byte)5 : (byte)4;
+    public static bool FirstLegacyReady => (byte)JobGauge.SerpentCombo == 3;
+
+    /// <summary>
+    /// Indicates if base Second Legacy oGCD is ready.
+    /// </summary>
+    public static bool SecondLegacyReady => (byte)JobGauge.SerpentCombo == 4;
+
+    /// <summary>
+    /// Indicates if base Third Legacy oGCD is ready.
+    /// </summary>
+    public static bool ThirdLegacyReady => (byte)JobGauge.SerpentCombo == 5;
+
+    /// <summary>
+    /// Indicates if base Fourth Legacy oGCD is ready.
+    /// </summary>
+    public static bool FourthLegacyReady => (byte)JobGauge.SerpentCombo == 6;
+
+    /// <summary>
+    /// Indicates if base Twins oGCDs are ready.
+    /// </summary>
+    public static bool TwinAbilityReady => (byte)JobGauge.SerpentCombo == 7;
+
+    /// <summary>
+    /// Indicates if base Thresh oGCDs are ready.
+    /// </summary>
+    public static bool ThreshAbilityReady => (byte)JobGauge.SerpentCombo == 8;
+
+    /// <summary>
+    /// Indicates if base Uncoiled oGCDs are ready.
+    /// </summary>
+    public static bool UncoiledAbilityReady => (byte)JobGauge.SerpentCombo == 9;
+    #endregion
 
     /// <inheritdoc/>
     public override void DisplayStatus()
     {
-        ImGui.Text("RattlingCoilStacks: " + RattlingCoilStacks.ToString());
-        ImGui.Text("MaxRattling: " + MaxRattling.ToString());
-        ImGui.Text("SerpentOffering: " + SerpentOffering.ToString());
-        ImGui.Text("AnguineTribute: " + AnguineTribute.ToString());
+        ImGui.Text($"SerpentOffering: {SerpentOffering}/100");
+        ImGui.Text($"RattlingCoilStacks: {RattlingCoilStacks}/{MaxRattling}");
+        ImGui.Text($"AnguineTributeStacks: {AnguineTributeStacks}/{MaxAnguine}");
+        ImGui.Spacing();
         ImGui.Text("DreadCombo: " + DreadCombo.ToString());
         ImGui.Text("NODREAD: " + NODREAD.ToString());
-        ImGui.Text("SerpentCombo: " + SerpentCombo.ToString());
-        ImGui.Text("TWINSREADY: " + TWINSREADY.ToString());
-        ImGui.Text("THRESHREADY: " + THRESHREADY.ToString());
-        ImGui.Text("UNCOILEDREADY: " + UNCOILEDREADY.ToString());
+        ImGui.Text("DreadActive: " + DreadActive.ToString());
+        ImGui.Text("SwiftskinsCoilOnly: " + SwiftskinsCoilOnly.ToString());
+        ImGui.Text("HuntersCoilOnly: " + HuntersCoilOnly.ToString());
+        ImGui.Text("PitActive: " + PitActive.ToString());
+        ImGui.Text("SwiftskinsDenOnly: " + SwiftskinsDenOnly.ToString());
+        ImGui.Text("HuntersDenOnly: " + HuntersDenOnly.ToString());
+        ImGui.Spacing();
+        ImGui.Text("SerpentCombo Raw Data: " + SerpentCombo.ToString());
+        ImGui.Text("NoAbilityReady: " + NoAbilityReady.ToString());
+        ImGui.Text("DeathRattleReady: " + DeathRattleReady.ToString());
+        ImGui.Text("LastLashReady: " + LastLashReady.ToString());
+        ImGui.Text("FirstLegacyReady: " + FirstLegacyReady.ToString());
+        ImGui.Text("SecondLegacyReady: " + SecondLegacyReady.ToString());
+        ImGui.Text("ThirdLegacyReady: " + ThirdLegacyReady.ToString());
+        ImGui.Text("FourthLegacyReady: " + FourthLegacyReady.ToString());
+        ImGui.Text("TwinAbilityReady: " + TwinAbilityReady.ToString());
+        ImGui.Text("ThreshAbilityReady: " + ThreshAbilityReady.ToString());
+        ImGui.Text("UncoiledAbilityReady: " + UncoiledAbilityReady.ToString());
+        ImGui.Spacing();
+        ImGui.Text("HasHunterAndSwift: " + HasHunterAndSwift.ToString());
+        ImGui.Text("IsSwift: " + IsSwift.ToString());
+        ImGui.Text("SwiftTime: " + SwiftTime.ToString());
+        ImGui.Text("IsHunter: " + IsHunter.ToString());
+        ImGui.Text("HuntersTime: " + HuntersTime.ToString());
+        ImGui.Text("HunterOrSwiftEndsFirst: " + (HunterOrSwiftEndsFirst?.ToString() ?? "null"));
+        ImGui.Spacing();
         ImGui.Text("MaxAnguine: " + MaxAnguine.ToString());
         ImGui.Text("HasSteel: " + HasSteel.ToString());
         ImGui.Text("HasReavers: " + HasReavers.ToString());
@@ -82,80 +173,34 @@ public partial class ViperRotation
         ImGui.Text("HasBane: " + HasBane.ToString());
         ImGui.Text("HasSting: " + HasSting.ToString());
         ImGui.Text("HasNoVenom: " + HasNoVenom.ToString());
-        ImGui.Text("HasReawakend: " + HasReawakend.ToString());
-        ImGui.Text("IsSwift: " + IsSwift.ToString());
-        ImGui.Text("IsHunter: " + IsHunter.ToString());
-        ImGui.Text("SwiftTime: " + SwiftTime.ToString());
-        ImGui.Text("HuntersTime: " + HuntersTime.ToString());
+        ImGui.Text("HasReadyToReawaken: " + HasReadyToReawaken.ToString());
         ImGui.Text("HasHunterVenom: " + HasHunterVenom.ToString());
         ImGui.Text("HasSwiftVenom: " + HasSwiftVenom.ToString());
         ImGui.Text("HasFellHuntersVenom: " + HasFellHuntersVenom.ToString());
-        ImGui.Text("HasFellskinsVenom: " + HasFellskinsVenom.ToString());
-        ImGui.Text("HasGrimHunter: " + HasGrimHunter.ToString());
-        ImGui.Text("HasGrimSkin: " + HasGrimSkin.ToString());
+        ImGui.Text("HasFellSkinsVenom: " + HasFellSkinsVenom.ToString());
         ImGui.Text("HasPoisedFang: " + HasPoisedFang.ToString());
         ImGui.Text("HasPoisedBlood: " + HasPoisedBlood.ToString());
-        ImGui.Text("HunterLessThanSwift: " + HunterLessThanSwift.ToString());
-        ImGui.Text("SwiftLessThanHunter: " + SwiftLessThanHunter.ToString());
+        ImGui.Text("HasGrimHunter: " + HasGrimHunter.ToString());
+        ImGui.Text("HasGrimSkin: " + HasGrimSkin.ToString());
     }
     #endregion
 
     #region Statuses
 
     /// <summary>
-    /// Indicates if the player has Honed Steel.
+    /// Indicates if both Hunters Instinct and Swiftscaled are active.
     /// </summary>
-    public static bool HasSteel => Player.HasStatus(true, StatusID.HonedSteel);
-
-    /// <summary>
-    /// Indicates if the player has Honed Reavers.
-    /// </summary>
-    public static bool HasReavers => Player.HasStatus(true, StatusID.HonedReavers);
-
-    /// <summary>
-    /// Indicates if the player does not have Honed Reavers or Honed Steel.
-    /// </summary>
-    public static bool NoHone => !Player.HasStatus(true, StatusID.HonedSteel) || !Player.HasStatus(true, StatusID.HonedReavers);
-
-    /// <summary>
-    /// Indicates if the player has upcoming Hind attack.
-    /// </summary>
-    public static bool HasHind => Player.HasStatus(true, StatusID.HindsbaneVenom) || Player.HasStatus(true, StatusID.HindstungVenom);
-
-    /// <summary>
-    /// Indicates if the player has upcoming Flanks attack.
-    /// </summary>
-    public static bool HasFlank => Player.HasStatus(true, StatusID.FlanksbaneVenom) || Player.HasStatus(true, StatusID.FlankstungVenom);
-
-    /// <summary>
-    /// Indicates if the player has upcoming Bane attack.
-    /// </summary>
-    public static bool HasBane => Player.HasStatus(true, StatusID.HindsbaneVenom) || Player.HasStatus(true, StatusID.FlanksbaneVenom);
-
-    /// <summary>
-    /// Indicates if the player has upcoming Bane attack.
-    /// </summary>
-    public static bool HasSting => Player.HasStatus(true, StatusID.HindstungVenom) || Player.HasStatus(true, StatusID.FlankstungVenom);
-
-    /// <summary>
-    /// Indicates if the player has no venom prepped.
-    /// </summary>
-    public static bool HasNoVenom => !Player.HasStatus(true, StatusID.HindstungVenom) && !Player.HasStatus(true, StatusID.FlankstungVenom) && !Player.HasStatus(true, StatusID.HindsbaneVenom) && !Player.HasStatus(true, StatusID.FlanksbaneVenom);
-
-    /// <summary>
-    /// Indicates if the player can use Reawakened.
-    /// </summary>
-    public static bool HasReawakend => Player.HasStatus(true, StatusID.ReadyToReawaken) || SerpentOffering >= 50;
+    public static bool HasHunterAndSwift => IsHunter && IsSwift;
 
     /// <summary>
     /// Indicates if the player has Swiftscaled.
     /// </summary>
-    public static bool IsSwift => Player.HasStatus(true, StatusID.Swiftscaled);
+    public static bool IsSwift => !Player.WillStatusEnd(0, true, StatusID.Swiftscaled);
 
     /// <summary>
     /// Indicates if the player has Hunters Instinct.
     /// </summary>
-    public static bool IsHunter => Player.HasStatus(true, StatusID.HuntersInstinct);
+    public static bool IsHunter => !Player.WillStatusEnd(0, true, StatusID.HuntersInstinct);
 
     /// <summary>
     /// Time left on Swiftscaled.
@@ -168,54 +213,114 @@ public partial class ViperRotation
     public static float? HuntersTime => Player.StatusTime(true, StatusID.HuntersInstinct);
 
     /// <summary>
-    /// Indicates if the player has Hunters Venom.
+    /// Returns which status will end first when both Hunters Instinct and Swiftscaled are active.
+    /// Returns "Hunter" if Hunters Instinct ends first, "Swift" if Swiftscaled ends first, or null if not both are active.
     /// </summary>
-    public static bool HasHunterVenom => Player.HasStatus(true, StatusID.HuntersVenom);
+    public static string? HunterOrSwiftEndsFirst
+    {
+        get
+        {
+            if (!HasHunterAndSwift)
+                return null;
+            if (HuntersTime == null || SwiftTime == null)
+                return null;
+            if (HuntersTime < SwiftTime)
+                return "Hunter";
+            if (SwiftTime < HuntersTime)
+                return "Swift";
+            return "Equal";
+        }
+    }
+
+    /// <summary>
+    /// Indicates if the player has Honed Steel.
+    /// </summary>
+    public static bool HasSteel => !Player.WillStatusEnd(0, true, StatusID.HonedSteel);
+
+    /// <summary>
+    /// Indicates if the player has Honed Reavers.
+    /// </summary>
+    public static bool HasReavers => !Player.WillStatusEnd(0, true, StatusID.HonedReavers);
+
+    /// <summary>
+    /// Indicates if the player does not have Honed Reavers or Honed Steel.
+    /// </summary>
+    public static bool NoHone => !Player.HasStatus(true, StatusID.HonedSteel) || !Player.HasStatus(true, StatusID.HonedReavers);
+
+    /// <summary>
+    /// Indicates if the player has upcoming Hind attack.
+    /// </summary>
+    public static bool HasHind => !Player.WillStatusEnd(0, true, StatusID.HindsbaneVenom) || !Player.WillStatusEnd(0, true, StatusID.HindstungVenom);
+
+    /// <summary>
+    /// Indicates if the player has upcoming Flanks attack.
+    /// </summary>
+    public static bool HasFlank => !Player.WillStatusEnd(0, true, StatusID.FlanksbaneVenom) || !Player.WillStatusEnd(0, true, StatusID.FlankstungVenom);
+
+    /// <summary>
+    /// Indicates if the player has upcoming Bane attack.
+    /// </summary>
+    public static bool HasBane => !Player.WillStatusEnd(0, true, StatusID.HindsbaneVenom) || !Player.WillStatusEnd(0, true, StatusID.FlanksbaneVenom);
+
+    /// <summary>
+    /// Indicates if the player has upcoming Bane attack.
+    /// </summary>
+    public static bool HasSting => !Player.WillStatusEnd(0, true, StatusID.HindstungVenom) || !Player.WillStatusEnd(0, true, StatusID.FlankstungVenom);
+
+    /// <summary>
+    /// Indicates if the player has no venom prepped.
+    /// </summary>
+    public static bool HasNoVenom => !Player.HasStatus(true, StatusID.HindstungVenom) && !Player.HasStatus(true, StatusID.FlankstungVenom) && !Player.HasStatus(true, StatusID.HindsbaneVenom) && !Player.HasStatus(true, StatusID.FlanksbaneVenom);
+
+    /// <summary>
+    /// Indicates if the player can use Reawakened.
+    /// </summary>
+    public static bool HasReadyToReawaken => !Player.WillStatusEnd(0, true, StatusID.ReadyToReawaken);
+
+    /// <summary>
+    /// Indicates if the player can use Reawakened.
+    /// </summary>
+    public static bool HasReawakenedActive => !Player.WillStatusEnd(0, true, StatusID.Reawakened);
 
     /// <summary>
     /// Indicates if the player has Hunters Venom.
     /// </summary>
-    public static bool HasSwiftVenom => Player.HasStatus(true, StatusID.SwiftskinsVenom);
+    public static bool HasHunterVenom => !Player.WillStatusEnd(0, true, StatusID.HuntersVenom);
+
+    /// <summary>
+    /// Indicates if the player has Hunters Venom.
+    /// </summary>
+    public static bool HasSwiftVenom => !Player.WillStatusEnd(0, true, StatusID.SwiftskinsVenom);
 
     /// <summary>
     /// Indicates if the player has Fellhunters Venom.
     /// </summary>
-    public static bool HasFellHuntersVenom => Player.HasStatus(true, StatusID.FellhuntersVenom);
+    public static bool HasFellHuntersVenom => !Player.WillStatusEnd(0, true, StatusID.FellhuntersVenom);
 
     /// <summary>
     /// Indicates if the player has Fellskins Venom.
     /// </summary>
-    public static bool HasFellskinsVenom => Player.HasStatus(true, StatusID.FellskinsVenom);
-
-    /// <summary>
-    /// Indicates if the player has Grimhunters Venom.
-    /// </summary>
-    public static bool HasGrimHunter => Player.HasStatus(true, StatusID.GrimhuntersVenom);
-
-    /// <summary>
-    /// Indicates if the player has Grimskins Venom.
-    /// </summary>
-    public static bool HasGrimSkin => Player.HasStatus(true, StatusID.GrimskinsVenom);
+    public static bool HasFellSkinsVenom => !Player.WillStatusEnd(0, true, StatusID.FellskinsVenom);
 
     /// <summary>
     /// Indicates if the player has Poised For Twinfang.
     /// </summary>
-    public static bool HasPoisedFang => Player.HasStatus(true, StatusID.PoisedForTwinfang);
+    public static bool HasPoisedFang => !Player.WillStatusEnd(0, true, StatusID.PoisedForTwinfang);
 
     /// <summary>
     /// Indicates if the player has Poised For Twinblood.
     /// </summary>
-    public static bool HasPoisedBlood => Player.HasStatus(true, StatusID.PoisedForTwinblood);
+    public static bool HasPoisedBlood => !Player.WillStatusEnd(0, true, StatusID.PoisedForTwinblood);
 
     /// <summary>
-    /// Indicates that Hunters Instinct is ending before Swiftscaled.
+    /// Indicates if the player has Grimhunters Venom.
     /// </summary>
-    public static bool HunterLessThanSwift => Player.StatusTime(true, StatusID.HuntersInstinct) < Player.StatusTime(true, StatusID.Swiftscaled);
+    public static bool HasGrimHunter => !Player.WillStatusEnd(0, true, StatusID.GrimhuntersVenom);
 
     /// <summary>
-    /// Indicates that Swiftscaled is ending before Hunters Instinct.
+    /// Indicates if the player has Grimskins Venom.
     /// </summary>
-    public static bool SwiftLessThanHunter => Player.StatusTime(true, StatusID.Swiftscaled) < Player.StatusTime(true, StatusID.HuntersInstinct);
+    public static bool HasGrimSkin => !Player.WillStatusEnd(0, true, StatusID.GrimskinsVenom);
     #endregion
 
     #region PvE Actions
@@ -232,12 +337,12 @@ public partial class ViperRotation
 
     static partial void ModifySteelFangsPvE(ref ActionSetting setting)
     {
-        setting.ActionCheck = () => NODREAD && !UNCOILEDREADY && !TWINSREADY && !THRESHREADY && HasSteel;
+        setting.ActionCheck = () => NODREAD && HasSteel;
     }
 
     static partial void ModifyHuntersStingPvE(ref ActionSetting setting)
     {
-        setting.ActionCheck = () => NODREAD && !UNCOILEDREADY && !TWINSREADY && !THRESHREADY && HasFlank;
+        setting.ActionCheck = () => NODREAD && HasFlank;
         setting.StatusProvide = [StatusID.HuntersInstinct];
         setting.CreateConfig = () => new ActionConfig()
         {
@@ -247,43 +352,43 @@ public partial class ViperRotation
 
     static partial void ModifyFlankstingStrikePvE(ref ActionSetting setting)
     {
-        setting.ActionCheck = () => NODREAD && !UNCOILEDREADY && !TWINSREADY && !THRESHREADY && HasFlank && HasSting;
+        setting.ActionCheck = () => NODREAD && HasFlank && HasSting;
         setting.StatusProvide = [StatusID.HindstungVenom];
     }
 
     static partial void ModifyFlanksbaneFangPvE(ref ActionSetting setting)
     {
-        setting.ActionCheck = () => NODREAD && !UNCOILEDREADY && !TWINSREADY && !THRESHREADY && HasFlank && HasBane;
+        setting.ActionCheck = () => NODREAD && HasFlank && HasBane;
         setting.StatusProvide = [StatusID.HindsbaneVenom];
     }
 
     static partial void ModifyReavingFangsPvE(ref ActionSetting setting)
     {
-        setting.ActionCheck = () => NODREAD && !UNCOILEDREADY && !TWINSREADY && !THRESHREADY && (HasReavers || NoHone);
+        setting.ActionCheck = () => NODREAD && (HasReavers || NoHone);
         setting.StatusProvide = [StatusID.HonedSteel];
     }
 
     static partial void ModifySwiftskinsStingPvE(ref ActionSetting setting)
     {
-        setting.ActionCheck = () => NODREAD && !UNCOILEDREADY && !TWINSREADY && !THRESHREADY && (HasNoVenom || HasHind);
+        setting.ActionCheck = () => NODREAD && (HasNoVenom || HasHind);
         setting.StatusProvide = [StatusID.Swiftscaled];
     }
 
     static partial void ModifyHindstingStrikePvE(ref ActionSetting setting)
     {
-        setting.ActionCheck = () => NODREAD && !UNCOILEDREADY && !TWINSREADY && !THRESHREADY && (HasNoVenom || (HasHind && HasSting));
+        setting.ActionCheck = () => NODREAD && (HasNoVenom || (HasHind && HasSting));
         setting.StatusProvide = [StatusID.FlanksbaneVenom];
     }
 
     static partial void ModifyHindsbaneFangPvE(ref ActionSetting setting)
     {
-        setting.ActionCheck = () => NODREAD && !UNCOILEDREADY && !TWINSREADY && !THRESHREADY && (HasNoVenom || (HasHind && HasBane));
+        setting.ActionCheck = () => NODREAD && (HasNoVenom || (HasHind && HasBane));
         setting.StatusProvide = [StatusID.FlankstungVenom];
     }
 
     static partial void ModifySteelMawPvE(ref ActionSetting setting)
     {
-        setting.ActionCheck = () => NODREAD && !UNCOILEDREADY && !TWINSREADY && !THRESHREADY && (HasSteel || NoHone);
+        setting.ActionCheck = () => NODREAD && (HasSteel || NoHone);
         setting.StatusProvide = [StatusID.HonedReavers];
         setting.CreateConfig = () => new ActionConfig()
         {
@@ -293,7 +398,7 @@ public partial class ViperRotation
 
     static partial void ModifyHuntersBitePvE(ref ActionSetting setting)
     {
-        setting.ActionCheck = () => NODREAD && !UNCOILEDREADY && !TWINSREADY && !THRESHREADY && !Player.HasStatus(true, StatusID.GrimskinsVenom);
+        setting.ActionCheck = () => NODREAD && !HasGrimSkin;
         setting.StatusProvide = [StatusID.HuntersInstinct];
         setting.CreateConfig = () => new ActionConfig()
         {
@@ -303,7 +408,7 @@ public partial class ViperRotation
 
     static partial void ModifyJaggedMawPvE(ref ActionSetting setting)
     {
-        setting.ActionCheck = () => NODREAD && !UNCOILEDREADY && !TWINSREADY && !THRESHREADY && !Player.HasStatus(true, StatusID.GrimskinsVenom);
+        setting.ActionCheck = () => NODREAD && !HasGrimSkin;
         setting.StatusProvide = [StatusID.GrimskinsVenom];
         setting.CreateConfig = () => new ActionConfig()
         {
@@ -313,7 +418,7 @@ public partial class ViperRotation
 
     static partial void ModifyReavingMawPvE(ref ActionSetting setting)
     {
-        setting.ActionCheck = () => NODREAD && !UNCOILEDREADY && !TWINSREADY && !THRESHREADY;
+        setting.ActionCheck = () => NODREAD;
         setting.StatusProvide = [StatusID.HonedSteel];
         setting.StatusNeed = [StatusID.HonedReavers];
         setting.CreateConfig = () => new ActionConfig()
@@ -324,7 +429,7 @@ public partial class ViperRotation
 
     static partial void ModifySwiftskinsBitePvE(ref ActionSetting setting)
     {
-        setting.ActionCheck = () => NODREAD && !UNCOILEDREADY && !TWINSREADY && !THRESHREADY && !Player.HasStatus(true, StatusID.GrimhuntersVenom);
+        setting.ActionCheck = () => NODREAD && !HasGrimHunter;
         setting.StatusProvide = [StatusID.Swiftscaled];
         setting.CreateConfig = () => new ActionConfig()
         {
@@ -334,7 +439,7 @@ public partial class ViperRotation
 
     static partial void ModifyBloodiedMawPvE(ref ActionSetting setting)
     {
-        setting.ActionCheck = () => NODREAD && !UNCOILEDREADY && !TWINSREADY && !THRESHREADY && !Player.HasStatus(true, StatusID.GrimhuntersVenom);
+        setting.ActionCheck = () => NODREAD && !HasGrimHunter;
         setting.StatusProvide = [StatusID.GrimhuntersVenom];
         setting.CreateConfig = () => new ActionConfig()
         {
@@ -349,12 +454,12 @@ public partial class ViperRotation
 
     static partial void ModifyDeathRattlePvE(ref ActionSetting setting)
     {
-        setting.ActionCheck = () => SerpentCombo == SerpentCombo.DeathRattle;
+        setting.ActionCheck = () => DeathRattleReady;
     }
 
     static partial void ModifyLastLashPvE(ref ActionSetting setting)
     {
-        setting.ActionCheck = () => SerpentCombo == SerpentCombo.LastLash;
+        setting.ActionCheck = () => LastLashReady;
         setting.CreateConfig = () => new ActionConfig()
         {
             AoeCount = 3,
@@ -363,22 +468,22 @@ public partial class ViperRotation
 
     static partial void ModifyVicewinderPvE(ref ActionSetting setting)
     {
-        setting.ActionCheck = () => SerpentOffering <= 90 && RattlingCoilStacks < MaxRattling && AnguineTribute == 0 && NODREAD && !THRESHREADY && !UNCOILEDREADY && !TWINSREADY;
+        setting.ActionCheck = () => SerpentOffering <= 90 && RattlingCoilStacks < MaxRattling && AnguineTributeStacks == 0 && NODREAD;
     }
 
     static partial void ModifyHuntersCoilPvE(ref ActionSetting setting)
     {
-        setting.ActionCheck = () => (DreadCombo == DreadCombo.Dreadwinder || DreadCombo == DreadCombo.SwiftskinsCoil) && SerpentCombo == SerpentCombo.None;
+        setting.ActionCheck = () => DreadActive || HuntersCoilOnly;
     }
 
     static partial void ModifySwiftskinsCoilPvE(ref ActionSetting setting)
     {
-        setting.ActionCheck = () => (DreadCombo == DreadCombo.Dreadwinder || DreadCombo == DreadCombo.HuntersCoil) && SerpentCombo == SerpentCombo.None;
+        setting.ActionCheck = () => DreadActive || SwiftskinsCoilOnly;
     }
 
     static partial void ModifyVicepitPvE(ref ActionSetting setting)
     {
-        setting.ActionCheck = () => SerpentOffering <= 90 && RattlingCoilStacks < MaxRattling && AnguineTribute == 0 && NODREAD && !THRESHREADY && !UNCOILEDREADY && !TWINSREADY;
+        setting.ActionCheck = () => SerpentOffering <= 90 && RattlingCoilStacks < MaxRattling && AnguineTributeStacks == 0 && NODREAD;
         setting.CreateConfig = () => new ActionConfig()
         {
             AoeCount = 3,
@@ -387,7 +492,7 @@ public partial class ViperRotation
 
     static partial void ModifyHuntersDenPvE(ref ActionSetting setting)
     {
-        setting.ActionCheck = () => DreadCombo == DreadCombo.PitOfDread && SerpentCombo == SerpentCombo.None;
+        setting.ActionCheck = () => PitActive || HuntersDenOnly;
         setting.CreateConfig = () => new ActionConfig()
         {
             AoeCount = 3,
@@ -396,7 +501,7 @@ public partial class ViperRotation
 
     static partial void ModifySwiftskinsDenPvE(ref ActionSetting setting)
     {
-        setting.ActionCheck = () => DreadCombo == DreadCombo.HuntersDen && SerpentCombo == SerpentCombo.None;
+        setting.ActionCheck = () => PitActive || SwiftskinsDenOnly;
         setting.CreateConfig = () => new ActionConfig()
         {
             AoeCount = 3,
@@ -415,18 +520,17 @@ public partial class ViperRotation
 
     static partial void ModifyTwinfangBitePvE(ref ActionSetting setting)
     {
-        setting.ActionCheck = () => HasHunterVenom && TWINSREADY;
+        setting.ActionCheck = () => TwinAbilityReady;
     }
 
     static partial void ModifyTwinbloodBitePvE(ref ActionSetting setting)
     {
-        setting.ActionCheck = () => HasSwiftVenom && TWINSREADY;
+        setting.ActionCheck = () => TwinAbilityReady;
     }
 
     static partial void ModifyTwinfangThreshPvE(ref ActionSetting setting)
     {
-        setting.ActionCheck = () => THRESHREADY & HasFellHuntersVenom;
-
+        setting.ActionCheck = () => ThreshAbilityReady;
         setting.CreateConfig = () => new ActionConfig()
         {
             AoeCount = 3,
@@ -435,7 +539,7 @@ public partial class ViperRotation
 
     static partial void ModifyTwinbloodThreshPvE(ref ActionSetting setting)
     {
-        setting.ActionCheck = () => THRESHREADY && HasFellskinsVenom;
+        setting.ActionCheck = () => ThreshAbilityReady;
         setting.CreateConfig = () => new ActionConfig()
         {
             AoeCount = 3,
@@ -454,7 +558,7 @@ public partial class ViperRotation
 
     static partial void ModifyUncoiledTwinfangPvE(ref ActionSetting setting)
     {
-        setting.ActionCheck = () => UNCOILEDREADY && HasPoisedFang;
+        setting.ActionCheck = () => UncoiledAbilityReady;
         setting.CreateConfig = () => new ActionConfig()
         {
             AoeCount = 1,
@@ -463,7 +567,7 @@ public partial class ViperRotation
 
     static partial void ModifyUncoiledTwinbloodPvE(ref ActionSetting setting)
     {
-        setting.ActionCheck = () => UNCOILEDREADY && HasPoisedBlood;
+        setting.ActionCheck = () => UncoiledAbilityReady;
         setting.CreateConfig = () => new ActionConfig()
         {
             AoeCount = 1,
@@ -478,7 +582,7 @@ public partial class ViperRotation
 
     static partial void ModifyReawakenPvE(ref ActionSetting setting)
     {
-        setting.ActionCheck = () => NODREAD && !UNCOILEDREADY && !TWINSREADY && !THRESHREADY && HasReawakend;
+        setting.ActionCheck = () => NODREAD && (HasReadyToReawaken || SerpentOffering >= 50);
         setting.CreateConfig = () => new ActionConfig()
         {
             AoeCount = 1,
@@ -487,7 +591,7 @@ public partial class ViperRotation
 
     static partial void ModifyFirstGenerationPvE(ref ActionSetting setting)
     {
-        setting.ActionCheck = () => ((MaxAnguine == 5 && AnguineTribute == 5) || (MaxAnguine == 4 && AnguineTribute == 4)) && SerpentCombo == SerpentCombo.None;
+        setting.ActionCheck = () => ((MaxAnguine == 5 && AnguineTributeStacks == 5) || (MaxAnguine == 4 && AnguineTributeStacks == 4));
         setting.CreateConfig = () => new ActionConfig()
         {
             AoeCount = 1,
@@ -496,7 +600,7 @@ public partial class ViperRotation
 
     static partial void ModifySecondGenerationPvE(ref ActionSetting setting)
     {
-        setting.ActionCheck = () => ((MaxAnguine == 5 && AnguineTribute == 4) || (MaxAnguine == 4 && AnguineTribute == 3)) && SerpentCombo == SerpentCombo.None;
+        setting.ActionCheck = () => ((MaxAnguine == 5 && AnguineTributeStacks == 4) || (MaxAnguine == 4 && AnguineTributeStacks == 3));
         setting.CreateConfig = () => new ActionConfig()
         {
             AoeCount = 1,
@@ -505,7 +609,7 @@ public partial class ViperRotation
 
     static partial void ModifyThirdGenerationPvE(ref ActionSetting setting)
     {
-        setting.ActionCheck = () => ((MaxAnguine == 5 && AnguineTribute == 3) || (MaxAnguine == 4 && AnguineTribute == 2)) && SerpentCombo == SerpentCombo.None;
+        setting.ActionCheck = () => ((MaxAnguine == 5 && AnguineTributeStacks == 3) || (MaxAnguine == 4 && AnguineTributeStacks == 2));
         setting.CreateConfig = () => new ActionConfig()
         {
             AoeCount = 1,
@@ -514,7 +618,7 @@ public partial class ViperRotation
 
     static partial void ModifyFourthGenerationPvE(ref ActionSetting setting)
     {
-        setting.ActionCheck = () => ((MaxAnguine == 5 && AnguineTribute == 2) || (MaxAnguine == 4 && AnguineTribute == 1)) && SerpentCombo == SerpentCombo.None;
+        setting.ActionCheck = () => ((MaxAnguine == 5 && AnguineTributeStacks == 2) || (MaxAnguine == 4 && AnguineTributeStacks == 1));
         setting.CreateConfig = () => new ActionConfig()
         {
             AoeCount = 1,
@@ -523,7 +627,7 @@ public partial class ViperRotation
 
     static partial void ModifyOuroborosPvE(ref ActionSetting setting)
     {
-        setting.ActionCheck = () => EnhancedSerpentsLineageTrait.EnoughLevel && AnguineTribute == 1;
+        setting.ActionCheck = () => EnhancedSerpentsLineageTrait.EnoughLevel && AnguineTributeStacks == 1;
         setting.CreateConfig = () => new ActionConfig()
         {
             AoeCount = 1,
@@ -532,7 +636,7 @@ public partial class ViperRotation
 
     static partial void ModifyFirstLegacyPvE(ref ActionSetting setting)
     {
-        setting.ActionCheck = () => SerpentCombo == SerpentCombo.FirstLegacy;
+        setting.ActionCheck = () => FirstLegacyReady;
         setting.CreateConfig = () => new ActionConfig()
         {
             AoeCount = 1,
@@ -541,7 +645,7 @@ public partial class ViperRotation
 
     static partial void ModifySecondLegacyPvE(ref ActionSetting setting)
     {
-        setting.ActionCheck = () => SerpentCombo == SerpentCombo.SecondLegacy;
+        setting.ActionCheck = () => SecondLegacyReady;
         setting.CreateConfig = () => new ActionConfig()
         {
             AoeCount = 1,
@@ -550,7 +654,7 @@ public partial class ViperRotation
 
     static partial void ModifyThirdLegacyPvE(ref ActionSetting setting)
     {
-        setting.ActionCheck = () => SerpentCombo == SerpentCombo.ThirdLegacy;
+        setting.ActionCheck = () => ThirdLegacyReady;
         setting.CreateConfig = () => new ActionConfig()
         {
             AoeCount = 1,
@@ -559,7 +663,7 @@ public partial class ViperRotation
 
     static partial void ModifyFourthLegacyPvE(ref ActionSetting setting)
     {
-        setting.ActionCheck = () => SerpentCombo == SerpentCombo.FourthLegacy;
+        setting.ActionCheck = () => FourthLegacyReady;
         setting.CreateConfig = () => new ActionConfig()
         {
             AoeCount = 1,

--- a/RotationSolver.Basic/Rotations/CustomRotation_Items.cs
+++ b/RotationSolver.Basic/Rotations/CustomRotation_Items.cs
@@ -50,7 +50,7 @@ public partial class CustomRotation
     /// <param name="act">The action to be performed.</param>
     /// <param name="clippingCheck">Indicates whether to perform a clipping check.</param>
     /// <returns>True if a burst medicine was used; otherwise, false.</returns>
-    protected bool UseBurstMedicine(out IAction? act, bool clippingCheck = true)
+    public bool UseBurstMedicine(out IAction? act, bool clippingCheck = true)
     {
         act = null;
 

--- a/RotationSolver.Basic/Rotations/CustomRotation_OtherInfo.cs
+++ b/RotationSolver.Basic/Rotations/CustomRotation_OtherInfo.cs
@@ -508,7 +508,7 @@ public partial class CustomRotation
     /// How much time has passed since the last action was used.
     /// <br>WARNING: Do Not make this method the main of your rotation.</br>
     /// </summary>
-    protected static TimeSpan TimeSinceLastAction
+    public static TimeSpan TimeSinceLastAction
     {
         get
         {


### PR DESCRIPTION
- Completely redid VPR_Default, updated Viper base accordingly
- Moved SunSign check out of emergency ability
- Adjusted Wildfire usage when at lower levels.
- Changed access modifiers for `UseBurstMedicine` and `TimeSinceLastAction` to public in `CustomRotation` per request from Churin.