### PR TITLE
Update ability conditions in MCH_Rework.cs

### DIFF
--- a/BasicRotations/Ranged/MCH_Rework.cs
+++ b/BasicRotations/Ranged/MCH_Rework.cs
@@ -259,9 +259,12 @@ public sealed class MCH_Rework : MachinistRotation
         if (AirAnchorPvE.Cooldown.IsCoolingDown && DrillPvE.Cooldown.CurrentCharges < 2 && ChainSawPvE.Cooldown.IsCoolingDown
             && !HasExcavatorReady)
         {
-            if (FullMetalFieldPvE.CanUse(out act))
+            if (!WildfirePvE.Cooldown.IsCoolingDown || IsLastAbility(true, WildfirePvE))
             {
-                return true;
+                if (FullMetalFieldPvE.CanUse(out act))
+                {
+                    return true;
+                }
             }
         }
 


### PR DESCRIPTION
Modified the logic for using FullMetalFieldPvE to include checks for WildfirePvE's cooldown status and whether it was the last ability used, enhancing the rotation strategy.