### PR TITLE
Small hotfix for MCH Rework, other misc fixes

### DIFF
--- a/BasicRotations/Ranged/MCH_Rework.cs
+++ b/BasicRotations/Ranged/MCH_Rework.cs
@@ -92,19 +92,28 @@ public sealed class MCH_Rework : MachinistRotation
             }
         }
 
-        if (HyperchargePvE.CanUse(out act))
+        if (HyperchargePvE.EnoughLevel)
         {
             if (!WildfirePvE.EnoughLevel)
             {
-                return true;
+                if (HyperchargePvE.CanUse(out act))
+                {
+                    return true;
+                }
             }
-            if (HasWildfire && !FullMetalFieldPvE.EnoughLevel)
+            if ((HasWildfire || (WildfirePvE.Cooldown.IsCoolingDown && Battery == 100)) && !FullMetalFieldPvE.EnoughLevel)
             {
-                return true;
+                if (HyperchargePvE.CanUse(out act))
+                {
+                    return true;
+                }
             }
             if (HasWildfire && FullMetalFieldPvE.EnoughLevel && IsLastAction(false, FullMetalFieldPvE))
             {
-                return true;
+                if (HyperchargePvE.CanUse(out act))
+                {
+                    return true;
+                }
             }
         }
 
@@ -144,7 +153,7 @@ public sealed class MCH_Rework : MachinistRotation
         }
         if (!FullMetalFieldPvE.EnoughLevel)
         {
-            if (WildfirePvE.Cooldown.WillHaveOneChargeGCD(1) && (IsLastAbility(false, HyperchargePvE) || Heat >= 50 || HasHypercharged) && ToolChargeSoon(out _) && !LowLevelHyperCheck)
+            if ((Heat >= 50 || HasHypercharged) && ToolChargeSoon(out _) && !LowLevelHyperCheck)
             {
                 if (WeaponRemain < GCDTime(1) / 2 && WildfirePvE.CanUse(out act))
                 {
@@ -232,13 +241,18 @@ public sealed class MCH_Rework : MachinistRotation
         if (!SpreadShotPvE.CanUse(out _))
         {
             // use AirAnchor if possible
-            if (AirAnchorPvE.CanUse(out act))
+            if (HotShotMasteryTrait.EnoughLevel && AirAnchorPvE.CanUse(out act))
             {
                 return true;
             }
 
             // for opener: only use the first charge of Drill after AirAnchor when there are two
             if (DrillPvE.CanUse(out act, usedUp: false))
+            {
+                return true;
+            }
+
+            if (!HotShotMasteryTrait.EnoughLevel && HotShotPvE.CanUse(out act))
             {
                 return true;
             }

--- a/RotationSolver.Basic/Configuration/Configs.cs
+++ b/RotationSolver.Basic/Configuration/Configs.cs
@@ -712,7 +712,7 @@ internal partial class Configs : IPluginConfiguration
     [JobConfig, Range(0.05f, 0.25f, ConfigUnitType.Percent)]
     [UI("Action Ahead (Percent of your GCD time remaining on a GCD cycle before RSR will try to queue the next GCD)", Filter = BasicTimer,
     Description = "This setting controls how many oGCDs RSR will try to fit in a single GCD window\nLower numbers mean more oGCDs, but potentially more GCD clipping")]
-    private readonly float _action5head = 0.20f;
+    private readonly float _action6head = 0.25f;
 
     [JobConfig, UI("The HP for using Guard.",
         Filter = PvPSpecificControls)]

--- a/RotationSolver.Basic/DataCenter.cs
+++ b/RotationSolver.Basic/DataCenter.cs
@@ -328,7 +328,7 @@ internal static class DataCenter
     /// <summary>
     /// Calculates the action ahead time based on the default GCD total and minimum animation lock.
     /// </summary>
-    public static float CalculatedActionAhead => DefaultGCDTotal * Service.Config.Action5Head;
+    public static float CalculatedActionAhead => DefaultGCDTotal * Service.Config.Action6Head;
 
     /// <summary>
     /// Calculates the total GCD time for a given number of GCDs and an optional offset.

--- a/RotationSolver.Basic/Helpers/ObjectHelper.cs
+++ b/RotationSolver.Basic/Helpers/ObjectHelper.cs
@@ -2,6 +2,7 @@
 using Dalamud.Game.ClientState.Objects.Enums;
 using Dalamud.Game.ClientState.Objects.SubKinds;
 using ECommons;
+using ECommons.Automation.UIInput;
 using ECommons.DalamudServices;
 using ECommons.ExcelServices;
 using ECommons.GameFunctions;
@@ -166,23 +167,45 @@ public static class ObjectHelper
             }
         }
 
-        if (Service.Config.BozjaCEmobtargeting
-            && DataCenter.IsInBozjanFieldOp
-            && !DataCenter.IsInDelubrumNormal
-            && !DataCenter.IsInDelubrumSavage)
+        if (DataCenter.IsInBozjanFieldOp)
         {
             bool isInCE = DataCenter.IsInBozjanFieldOpCE;
 
-            // Prevent targeting mobs in Bozja CE if you are not in CE
-            if (battleChara.IsBozjanCEFateMob() && !isInCE)
+            if (isInCE)
             {
-                return false;
+                if (!battleChara.IsBozjanCEMob())
+                {
+                    return false;
+                }
             }
 
-            // Prevent targeting mobs out of Bozja CE if you are in CE
-            if (!battleChara.IsBozjanCEFateMob() && isInCE)
+            if (!isInCE)
             {
-                return false;
+                if (battleChara.IsBozjanCEMob())
+                {
+                    return false;
+                }
+            }
+        }
+
+        if (DataCenter.IsInOccultCrescentOp)
+        {
+            bool isInCE = Player.Object.GetEventType() == EventHandlerContent.PublicContentDirector;
+
+            if (isInCE)
+            {
+                if (!battleChara.IsOccultCEMob())
+                {
+                    return false;
+                }
+            }
+
+            if (!isInCE)
+            {
+                if (battleChara.IsOccultCEMob())
+                {
+                    return false;
+                }
             }
         }
 
@@ -225,14 +248,14 @@ public static class ObjectHelper
             };
     }
 
-    internal static bool IsBozjanCEFateMob(this IBattleChara battleChara)
+    internal static bool IsBozjanCEMob(this IBattleChara battleChara)
     {
         if (battleChara == null)
         {
             return false;
         }
 
-        if (battleChara.IsEnemy() == false)
+        if (!battleChara.IsEnemy())
         {
             return false;
         }
@@ -246,7 +269,6 @@ public static class ObjectHelper
         return battleChara.GetEventType() == EventHandlerContent.PublicContentDirector;
     }
 
-    // This exists because OC CEs can often have a large amount of players in them, and if you are not on AllTargetsCanAttack the mobs target may despawn due to object limit
     internal static bool IsOccultCEMob(this IBattleChara battleChara)
     {
         if (battleChara == null)
@@ -254,7 +276,7 @@ public static class ObjectHelper
             return false;
         }
 
-        if (battleChara.IsEnemy() == false)
+        if (!battleChara.IsEnemy())
         {
             return false;
         }

--- a/RotationSolver.Basic/Rotations/Basic/ViperRotation.cs
+++ b/RotationSolver.Basic/Rotations/Basic/ViperRotation.cs
@@ -4,6 +4,17 @@ public partial class ViperRotation
 {
     /// <inheritdoc/>
     public override MedicineType MedicineType => MedicineType.Dexterity;
+
+    /// <inheritdoc/>
+    public override bool IsBursting()
+    {
+        if (HasHunterAndSwift)
+        {
+            return true;
+        }
+        return false;
+    }
+
     #region JobGauge
     /// <summary>
     /// Gets how many uses of uncoiled fury the player has.

--- a/RotationSolver/UI/RotationConfigWindow.cs
+++ b/RotationSolver/UI/RotationConfigWindow.cs
@@ -3814,7 +3814,7 @@ public partial class RotationConfigWindow : Window
             ImGui.Spacing();
             ImGui.Text($"FateID: {battleChara.FateId().ToString() ?? string.Empty}");
             ImGui.Text($"EventType: {battleChara.GetEventType().ToString() ?? string.Empty}");
-            ImGui.Text($"IsBozjanCEFateMob: {battleChara.IsBozjanCEFateMob()}");
+            ImGui.Text($"IsBozjanCEFateMob: {battleChara.IsBozjanCEMob()}");
             ImGui.Spacing();
             ImGui.Text($"IsOccultCEMob: {battleChara.IsOccultCEMob()}");
             ImGui.Text($"IsOccultFateMob: {battleChara.IsOccultFateMob()}");


### PR DESCRIPTION
- Improved logic for ability checks in `MCH_Rework.cs` for `HyperchargePvE` and `WildfirePvE`.
- Updated action ahead configuration to default to 25%, preventing gcd clipping triple weaving.
- Simplified mob targeting logic in `ObjectHelper.cs` for Bozjan and Occult Crescent operations.
- Renamed `IsBozjanCEFateMob` to `IsBozjanCEMob` in `ObjectHelper.cs` for clarity.
- Added `IsBursting` method in `ViperRotation.cs` to check bursting state.