### PR TITLE
Update to DRG, NIN, VPR, and MCH. Added config for statusfull mobs.

### DIFF
--- a/BasicRotations/Melee/DRG_Default.cs
+++ b/BasicRotations/Melee/DRG_Default.cs
@@ -250,7 +250,7 @@ public sealed class DRG_Default : DragoonRotation
             return true;
         }
 
-        if (PiercingTalonPvE.CanUse(out act))
+        if (!IsLastAction(true, WingedGlidePvE) && PiercingTalonPvE.CanUse(out act))
         {
             return true;
         }

--- a/BasicRotations/Melee/VPR_Default.cs
+++ b/BasicRotations/Melee/VPR_Default.cs
@@ -496,6 +496,7 @@ public sealed class VPR_Default : ViperRotation
             }
         }
         //AOE Serpent Combo
+        // aoe 3
         switch ((HasGrimHunter, HasGrimSkin))
         {
             case (true, _):
@@ -513,66 +514,113 @@ public sealed class VPR_Default : ViperRotation
                     return true;
                 break;
         }
-
-        if (HuntersBitePvE.CanUse(out act, skipAoeCheck: true))
+        // aoe 2
+        switch (HunterOrSwiftEndsFirst)
         {
-            return true;
+            case "Hunter":
+                if (HuntersBitePvE.CanUse(out act))
+                    return true;
+                break;
+            case "Swift":
+                if (SwiftskinsBitePvE.CanUse(out act))
+                    return true;
+                break;
+            case "Equal":
+            case null:
+                if (HuntersBitePvE.CanUse(out act))
+                    return true;
+                if (SwiftskinsBitePvE.CanUse(out act))
+                    return true;
+                break;
         }
-
-        if (SwiftskinsBitePvE.CanUse(out act, skipAoeCheck: true))
+        // aoe 1
+        switch ((HasSteel, HasReavers))
         {
-            return true;
-        }
-
-        if (ReavingMawPvE.CanUse(out act))
-        {
-            return true;
-        }
-
-        if (SteelMawPvE.CanUse(out act))
-        {
-            return true;
+            case (true, _):
+                if (SteelMawPvE.CanUse(out act))
+                    return true;
+                break;
+            case (_, true):
+                if (ReavingMawPvE.CanUse(out act))
+                    return true;
+                break;
+            case (false, false):
+                if (ReavingMawPvE.CanUse(out act))
+                    return true;
+                if (SteelMawPvE.CanUse(out act))
+                    return true;
+                break;
         }
 
         //Single Target Serpent Combo
-        if (FlankstingStrikePvE.CanUse(out act))
+        // st 3
+        switch ((HasFlankstung, HasFlanksbane, HasHindstung, HasHindsbane))
         {
-            return true;
+            case (true, _, _, _):
+                if (HindsbaneFangPvE.CanUse(out act))
+                    return true;
+                break;
+            case (_, true, _, _):
+                if (HindstingStrikePvE.CanUse(out act))
+                    return true;
+                break;
+            case (_, _, true, _):
+                if (FlanksbaneFangPvE.CanUse(out act))
+                    return true;
+                break;
+            case (_, _, _, true):
+                if (FlankstingStrikePvE.CanUse(out act))
+                    return true;
+                break;
+            case (false, false, false, false):
+                if (HindsbaneFangPvE.CanUse(out act))
+                    return true;
+                if (HindstingStrikePvE.CanUse(out act))
+                    return true;
+                if (FlanksbaneFangPvE.CanUse(out act))
+                    return true;
+                if (FlankstingStrikePvE.CanUse(out act))
+                    return true;
+                break;
         }
 
-        if (FlanksbaneFangPvE.CanUse(out act))
+        // st 2
+        switch (HunterOrSwiftEndsFirst)
         {
-            return true;
+            case "Hunter":
+                if (HuntersStingPvE.CanUse(out act))
+                    return true;
+                break;
+            case "Swift":
+                if (SwiftskinsStingPvE.CanUse(out act))
+                    return true;
+                break;
+            case "Equal":
+            case null:
+                if (HuntersStingPvE.CanUse(out act))
+                    return true;
+                if (SwiftskinsStingPvE.CanUse(out act))
+                    return true;
+                break;
         }
 
-        if (HindstingStrikePvE.CanUse(out act))
+        // st 1
+        switch ((HasSteel, HasReavers))
         {
-            return true;
-        }
-
-        if (HindsbaneFangPvE.CanUse(out act))
-        {
-            return true;
-        }
-
-        if (HuntersStingPvE.CanUse(out act))
-        {
-            return true;
-        }
-
-        if (SwiftskinsStingPvE.CanUse(out act))
-        {
-            return true;
-        }
-
-        if (ReavingFangsPvE.CanUse(out act))
-        {
-            return true;
-        }
-
-        if (SteelFangsPvE.CanUse(out act))
-        {
-            return true;
+            case (true, _):
+                if (SteelFangsPvE.CanUse(out act))
+                    return true;
+                break;
+            case (_, true):
+                if (ReavingFangsPvE.CanUse(out act))
+                    return true;
+                break;
+            case (false, false):
+                if (ReavingFangsPvE.CanUse(out act))
+                    return true;
+                if (SteelFangsPvE.CanUse(out act))
+                    return true;
+                break;
         }
 
         //Ranged

--- a/BasicRotations/Ranged/MCH_Rework.cs
+++ b/BasicRotations/Ranged/MCH_Rework.cs
@@ -99,21 +99,21 @@ public sealed class MCH_Rework : MachinistRotation
         {
             if (!WildfirePvE.EnoughLevel)
             {
-                if (HyperchargePvE.CanUse(out act))
+                if (HyperchargePvE.CanUse(out act, skipTTKCheck: true))
                 {
                     return true;
                 }
             }
             if ((HasWildfire || (WildfirePvE.Cooldown.IsCoolingDown && Battery == 100)) && !FullMetalFieldPvE.EnoughLevel)
             {
-                if (HyperchargePvE.CanUse(out act))
+                if (HyperchargePvE.CanUse(out act, skipTTKCheck: true))
                 {
                     return true;
                 }
             }
             if (HasWildfire && FullMetalFieldPvE.EnoughLevel && IsLastAction(false, FullMetalFieldPvE))
             {
-                if (HyperchargePvE.CanUse(out act))
+                if (HyperchargePvE.CanUse(out act, skipTTKCheck: true))
                 {
                     return true;
                 }
@@ -352,7 +352,7 @@ public sealed class MCH_Rework : MachinistRotation
         }
         else
         {
-            return HyperchargePvE.CanUse(out act);
+            return HyperchargePvE.CanUse(out act, skipTTKCheck: true);
         }
     }
 
@@ -419,7 +419,7 @@ public sealed class MCH_Rework : MachinistRotation
         // Opener
         if (Battery == 60 && IsLastGCD(false, ExcavatorPvE) && CombatTime < 15)
         {
-            if (RookAutoturretPvE.CanUse(out act))
+            if (RookAutoturretPvE.CanUse(out act, skipTTKCheck: true))
             {
                 return true;
             }
@@ -428,7 +428,7 @@ public sealed class MCH_Rework : MachinistRotation
         // Only allow battery usage if the current transition matches the expected step
         if (foundStepPair)
         {
-            if (RookAutoturretPvE.CanUse(out act))
+            if (RookAutoturretPvE.CanUse(out act, skipTTKCheck: true))
             {
                 return true;
             }
@@ -438,7 +438,7 @@ public sealed class MCH_Rework : MachinistRotation
         if ((nextGCD.IsTheSameTo(false, CleanShotPvE, HeatedCleanShotPvE) && Battery > 90)
             || (nextGCD.IsTheSameTo(false, HotShotPvE, AirAnchorPvE, ChainSawPvE, ExcavatorPvE) && Battery > 80))
         {
-            if (RookAutoturretPvE.CanUse(out act))
+            if (RookAutoturretPvE.CanUse(out act, skipTTKCheck: true))
             {
                 return true;
             }

--- a/RotationSolver.Basic/Actions/ActionTargetInfo.cs
+++ b/RotationSolver.Basic/Actions/ActionTargetInfo.cs
@@ -251,6 +251,11 @@ public struct ActionTargetInfo(IBaseAction action)
             return false;
         }
 
+        if (Service.Config.Statuscap && battleChara != Player.Object && StatusHelper.IsStatusCapped(battleChara))
+        {
+            return false;
+        }
+
         if (!action.Config.ShouldCheckTargetStatus && !action.Config.ShouldCheckStatus)
         {
             return true;

--- a/RotationSolver.Basic/Configuration/Configs.cs
+++ b/RotationSolver.Basic/Configuration/Configs.cs
@@ -53,6 +53,10 @@ internal partial class Configs : IPluginConfiguration
     Filter = AutoActionUsage, Section = 3)]
     public AoEType AoEType { get; set; } = AoEType.Full;
 
+    [ConditionBool, UI("Ignore status application against mobs that are status capped.",
+    Filter = AutoActionUsage, Section = 3)]
+    private static readonly bool _statuscap = false;
+
     [ConditionBool, UI("Don't attack new mobs by AoE. (Dangerous)", Description = "Never use any AoE action when this may attack mobs that are not hostile targets.",
         Filter = AutoActionUsage, Section = 3)]
     private static readonly bool _noNewHostiles = false;

--- a/RotationSolver.Basic/Helpers/StatusHelper.cs
+++ b/RotationSolver.Basic/Helpers/StatusHelper.cs
@@ -436,6 +436,11 @@ public static class StatusHelper
     /// <param name="status"></param>
     public static void StatusOff(StatusID status)
     {
+        if (!DataCenter.IsActivated())
+        {
+            return;
+        }
+
         if (!Player.Object.HasStatus(false, status))
         {
             return;

--- a/RotationSolver.Basic/Rotations/Basic/ViperRotation.cs
+++ b/RotationSolver.Basic/Rotations/Basic/ViperRotation.cs
@@ -276,9 +276,29 @@ public partial class ViperRotation
     public static bool HasHind => Player.HasStatus(true, StatusID.HindsbaneVenom) || Player.HasStatus(true, StatusID.HindstungVenom);
 
     /// <summary>
+    /// Indicates if the player has upcoming Hind attack.
+    /// </summary>
+    public static bool HasHindsbane => Player.HasStatus(true, StatusID.HindsbaneVenom);
+
+    /// <summary>
+    /// Indicates if the player has upcoming Hind attack.
+    /// </summary>
+    public static bool HasHindstung => Player.HasStatus(true, StatusID.HindstungVenom);
+
+    /// <summary>
     /// Indicates if the player has upcoming Flanks attack.
     /// </summary>
     public static bool HasFlank => Player.HasStatus(true, StatusID.FlanksbaneVenom) || Player.HasStatus(true, StatusID.FlankstungVenom);
+
+    /// <summary>
+    /// Indicates if the player has upcoming Hind attack.
+    /// </summary>
+    public static bool HasFlanksbane => Player.HasStatus(true, StatusID.FlanksbaneVenom);
+
+    /// <summary>
+    /// Indicates if the player has upcoming Hind attack.
+    /// </summary>
+    public static bool HasFlankstung => Player.HasStatus(true, StatusID.FlankstungVenom);
 
     /// <summary>
     /// Indicates if the player has upcoming Bane attack.
@@ -360,12 +380,12 @@ public partial class ViperRotation
 
     static partial void ModifySteelFangsPvE(ref ActionSetting setting)
     {
-        setting.ActionCheck = () => NODREAD && HasSteel;
+        setting.ActionCheck = () => NODREAD;
     }
 
     static partial void ModifyHuntersStingPvE(ref ActionSetting setting)
     {
-        setting.ActionCheck = () => NODREAD && HasFlank;
+        setting.ActionCheck = () => NODREAD;
         setting.StatusProvide = [StatusID.HuntersInstinct];
         setting.CreateConfig = () => new ActionConfig()
         {
@@ -375,43 +395,43 @@ public partial class ViperRotation
 
     static partial void ModifyFlankstingStrikePvE(ref ActionSetting setting)
     {
-        setting.ActionCheck = () => NODREAD && HasFlank && HasSting;
+        setting.ActionCheck = () => NODREAD;
         setting.StatusProvide = [StatusID.HindstungVenom];
     }
 
     static partial void ModifyFlanksbaneFangPvE(ref ActionSetting setting)
     {
-        setting.ActionCheck = () => NODREAD && HasFlank && HasBane;
+        setting.ActionCheck = () => NODREAD;
         setting.StatusProvide = [StatusID.HindsbaneVenom];
     }
 
     static partial void ModifyReavingFangsPvE(ref ActionSetting setting)
     {
-        setting.ActionCheck = () => NODREAD && (HasReavers || NoHone);
+        setting.ActionCheck = () => NODREAD;
         setting.StatusProvide = [StatusID.HonedSteel];
     }
 
     static partial void ModifySwiftskinsStingPvE(ref ActionSetting setting)
     {
-        setting.ActionCheck = () => NODREAD && (HasNoVenom || HasHind);
+        setting.ActionCheck = () => NODREAD;
         setting.StatusProvide = [StatusID.Swiftscaled];
     }
 
     static partial void ModifyHindstingStrikePvE(ref ActionSetting setting)
     {
-        setting.ActionCheck = () => NODREAD && (HasNoVenom || (HasHind && HasSting));
+        setting.ActionCheck = () => NODREAD;
         setting.StatusProvide = [StatusID.FlanksbaneVenom];
     }
 
     static partial void ModifyHindsbaneFangPvE(ref ActionSetting setting)
     {
-        setting.ActionCheck = () => NODREAD && (HasNoVenom || (HasHind && HasBane));
+        setting.ActionCheck = () => NODREAD;
         setting.StatusProvide = [StatusID.FlankstungVenom];
     }
 
     static partial void ModifySteelMawPvE(ref ActionSetting setting)
     {
-        setting.ActionCheck = () => NODREAD && (HasSteel || NoHone);
+        setting.ActionCheck = () => NODREAD;
         setting.StatusProvide = [StatusID.HonedReavers];
         setting.CreateConfig = () => new ActionConfig()
         {
@@ -421,7 +441,7 @@ public partial class ViperRotation
 
     static partial void ModifyHuntersBitePvE(ref ActionSetting setting)
     {
-        setting.ActionCheck = () => NODREAD && !HasGrimSkin;
+        setting.ActionCheck = () => NODREAD;
         setting.StatusProvide = [StatusID.HuntersInstinct];
         setting.CreateConfig = () => new ActionConfig()
         {
@@ -431,7 +451,7 @@ public partial class ViperRotation
 
     static partial void ModifyJaggedMawPvE(ref ActionSetting setting)
     {
-        setting.ActionCheck = () => NODREAD && !HasGrimSkin;
+        setting.ActionCheck = () => NODREAD;
         setting.StatusProvide = [StatusID.GrimskinsVenom];
         setting.CreateConfig = () => new ActionConfig()
         {
@@ -443,7 +463,6 @@ public partial class ViperRotation
     {
         setting.ActionCheck = () => NODREAD;
         setting.StatusProvide = [StatusID.HonedSteel];
-        setting.StatusNeed = [StatusID.HonedReavers];
         setting.CreateConfig = () => new ActionConfig()
         {
             AoeCount = 3,
@@ -452,7 +471,7 @@ public partial class ViperRotation
 
     static partial void ModifySwiftskinsBitePvE(ref ActionSetting setting)
     {
-        setting.ActionCheck = () => NODREAD && !HasGrimHunter;
+        setting.ActionCheck = () => NODREAD;
         setting.StatusProvide = [StatusID.Swiftscaled];
         setting.CreateConfig = () => new ActionConfig()
         {
@@ -462,7 +481,7 @@ public partial class ViperRotation
 
     static partial void ModifyBloodiedMawPvE(ref ActionSetting setting)
     {
-        setting.ActionCheck = () => NODREAD && !HasGrimHunter;
+        setting.ActionCheck = () => NODREAD;
         setting.StatusProvide = [StatusID.GrimhuntersVenom];
         setting.CreateConfig = () => new ActionConfig()
         {


### PR DESCRIPTION
- Added config to prevent status application checks against mobs that have a full status list (often in CEs or hunt trains)
- Adjusted DRG to not use ranged GCD following the gap closer to try to mitigate action use when not necessary
- Adjusted Statusoff system to not run while RSR is not active, fixing issue with NIN Unhide option
- Added TTK skips for MCH Rework
- Complete rework to how VPR decides its 123 ST and 123 AOE action usage to be more efficient and prevent potential bricks in extremely rare cases.