### PR TITLE
NIN ninjustsu rework and RPR Rework hotfix

### DIFF
--- a/BasicRotations/Melee/RPR_Default.cs
+++ b/BasicRotations/Melee/RPR_Default.cs
@@ -35,6 +35,46 @@ public sealed class RPR_Default : ReaperRotation
     #endregion
 
     #region oGCD Logic
+    [RotationDesc(ActionID.HellsIngressPvE)]
+    protected override bool MoveForwardAbility(IAction nextGCD, out IAction? act)
+    {
+        if (HellsIngressPvE.CanUse(out act))
+        {
+            return true;
+        }
+        return base.MoveForwardAbility(nextGCD, out act);
+    }
+
+    [RotationDesc(ActionID.HellsEgressPvE)]
+    protected override bool MoveBackAbility(IAction nextGCD, out IAction? act)
+    {
+        if (HellsEgressPvE.CanUse(out act))
+        {
+            return true;
+        }
+        return base.MoveBackAbility(nextGCD, out act);
+    }
+
+    [RotationDesc(ActionID.FeintPvE)]
+    protected override bool DefenseAreaAbility(IAction nextGCD, out IAction? act)
+    {
+        if (!HasSoulReaver && !HasEnshrouded && !HasExecutioner && FeintPvE.CanUse(out act))
+        {
+            return true;
+        }
+        return base.DefenseAreaAbility(nextGCD, out act);
+    }
+
+    [RotationDesc(ActionID.ArcaneCrestPvE)]
+    protected override bool DefenseSingleAbility(IAction nextGCD, out IAction? act)
+    {
+        if (!HasSoulReaver && !HasEnshrouded && !HasExecutioner && ArcaneCrestPvE.CanUse(out act))
+        {
+            return true;
+        }
+        return base.DefenseSingleAbility(nextGCD, out act);
+    }
+
     protected override bool AttackAbility(IAction nextGCD, out IAction? act)
     {
         bool IsTargetBoss = CurrentTarget?.IsBossFromTTK() ?? false;

--- a/BasicRotations/Melee/RPR_Reborn.cs
+++ b/BasicRotations/Melee/RPR_Reborn.cs
@@ -156,11 +156,17 @@ public sealed class RPR_Reborn : ReaperRotation
 
                 switch ((HasEnhancedGallows, HasEnhancedGibbet))
                 {
-                    case (true, _):
+                    case (true, true):
+                        if (ExecutionersGallowsPvE.CanUse(out act, skipComboCheck: true) && ExecutionersGallowsPvE.Target.Target != null && CanHitPositional(EnemyPositional.Rear, ExecutionersGallowsPvE.Target.Target))
+                            return true;
+                        if (ExecutionersGibbetPvE.CanUse(out act, skipComboCheck: true) && ExecutionersGibbetPvE.Target.Target != null && CanHitPositional(EnemyPositional.Flank, ExecutionersGibbetPvE.Target.Target))
+                            return true;
+                        break;
+                    case (true, false):
                         if (ExecutionersGallowsPvE.CanUse(out act, skipComboCheck: true))
                             return true;
                         break;
-                    case (_, true):
+                    case (false, true):
                         if (ExecutionersGibbetPvE.CanUse(out act, skipComboCheck: true))
                             return true;
                         break;
@@ -305,12 +311,18 @@ public sealed class RPR_Reborn : ReaperRotation
 
             switch ((HasEnhancedGallows, HasEnhancedGibbet))
             {
+                case (true, true):
+                    if (GallowsPvE.CanUse(out act, skipComboCheck: true) && GallowsPvE.Target.Target != null && CanHitPositional(EnemyPositional.Rear, GallowsPvE.Target.Target))
+                        return true;
+                    if (GibbetPvE.CanUse(out act, skipComboCheck: true) && GibbetPvE.Target.Target != null && CanHitPositional(EnemyPositional.Flank, GibbetPvE.Target.Target))
+                        return true;
+                    break;
                 case (true, _):
-                    if (GallowsPvE.CanUse(out act))
+                    if (GallowsPvE.CanUse(out act, skipComboCheck: true))
                         return true;
                     break;
                 case (_, true):
-                    if (GibbetPvE.CanUse(out act))
+                    if (GibbetPvE.CanUse(out act, skipComboCheck: true))
                         return true;
                     break;
                 case (false, false):

--- a/RotationSolver.Basic/Rotations/Basic/NinjaRotation.cs
+++ b/RotationSolver.Basic/Rotations/Basic/NinjaRotation.cs
@@ -457,8 +457,8 @@ public partial class NinjaRotation
         HutonPvE.Setting.Ninjutsu = [ChiPvE, JinPvE_18807, TenPvE_18805];
         DotonPvE.Setting.Ninjutsu = [TenPvE, JinPvE_18807, ChiPvE_18806];
         SuitonPvE.Setting.Ninjutsu = [TenPvE, ChiPvE_18806, JinPvE_18807];
-        GokaMekkyakuPvE.Setting.Ninjutsu = [ChiPvE, TenPvE_18805];
-        HyoshoRanryuPvE.Setting.Ninjutsu = [ChiPvE, JinPvE_18807];
+        GokaMekkyakuPvE.Setting.Ninjutsu = [ChiPvE_18806, TenPvE_18805];
+        HyoshoRanryuPvE.Setting.Ninjutsu = [ChiPvE_18806, JinPvE_18807];
     }
 
     static partial void ModifyFumaShurikenPvE(ref ActionSetting setting)
@@ -506,6 +506,7 @@ public partial class NinjaRotation
         setting.ActionCheck = () => DotonPvEReady;
         setting.StatusProvide = [StatusID.Doton];
         setting.UnlockedByQuestID = 68488;
+        setting.TargetType = TargetType.Self;
         setting.CreateConfig = () => new ActionConfig()
         {
             AoeCount = 3,
@@ -524,7 +525,7 @@ public partial class NinjaRotation
         setting.ActionCheck = () => HasKassatsu;
         setting.CreateConfig = () => new ActionConfig()
         {
-            AoeCount = 3,
+            AoeCount = 1,
         };
     }
 


### PR DESCRIPTION
- Added `KeepKassatsuinBurst` property to `NIN_Default` for better Kassatsu management.
- Updated action logic to include shadow walking checks and refined cooldown conditions for Ninjutsu actions.
- Streamlined Ninjutsu action handling for improved state checks.
- Updated `RPR_Default` with readded movement and defense ability methods.
- Improved switch-case logic in `RPR_Reborn` for enhanced ability conditions.
- Updated Ninjutsu settings in `NinjaRotation.cs` for better action dependencies.
- Added target type to `ModifyDotonPvE` and adjusted AOE count in `ModifyGokaMekkyakuPvE`.