### PR TITLE
Update MNK and BRD rotations, enable status cap logic

### DIFF
--- a/BasicRotations/Ranged/BRD_Default.cs
+++ b/BasicRotations/Ranged/BRD_Default.cs
@@ -273,21 +273,16 @@ public sealed class BRD_Default : BardRotation
             }
         }
 
-        if (SidewinderPvE.CanUse(out act))
+        if (SidewinderPvE.EnoughLevel)
         {
-            if (HasBattleVoice && ((HasRadiantFinale && RagingStrikesPvE.Cooldown.IsCoolingDown) || !RadiantFinalePvE.EnoughLevel))
+            if ((BattleVoicePvE.Cooldown.IsCoolingDown && !BattleVoicePvE.Cooldown.WillHaveOneCharge(10))
+            && (!RadiantFinalePvE.EnoughLevel || (RadiantFinalePvE.EnoughLevel && RadiantFinalePvE.Cooldown.IsCoolingDown && !RadiantFinalePvE.Cooldown.WillHaveOneCharge(10)))
+            && RagingStrikesPvE.Cooldown.IsCoolingDown)
             {
-                return true;
-            }
-
-            if (!BattleVoicePvE.Cooldown.WillHaveOneCharge(10) && !RadiantFinalePvE.Cooldown.WillHaveOneCharge(10) && RagingStrikesPvE.Cooldown.IsCoolingDown)
-            {
-                return true;
-            }
-
-            if (RagingStrikesPvE.Cooldown.IsCoolingDown && HasRagingStrikes)
-            {
-                return true;
+                if (SidewinderPvE.CanUse(out act))
+                {
+                    return true;
+                }
             }
         }
 

--- a/RotationSolver.Basic/Actions/ActionTargetInfo.cs
+++ b/RotationSolver.Basic/Actions/ActionTargetInfo.cs
@@ -266,7 +266,7 @@ public struct ActionTargetInfo(IBaseAction action)
 
         if (action.Setting.TargetStatusProvide != null && !skipStatusProvideCheck)
         {
-            if (!battleChara.WillStatusEndGCD(action.Config.StatusGcdCount, 0, action.Setting.StatusFromSelf, action.Setting.TargetStatusProvide) || (Service.Config.Statuscap && StatusHelper.IsStatusCapped(battleChara)))
+            if (!battleChara.WillStatusEndGCD(action.Config.StatusGcdCount, 0, action.Setting.StatusFromSelf, action.Setting.TargetStatusProvide) || (Service.Config.Statuscap2 && StatusHelper.IsStatusCapped(battleChara)))
             {
                 return false;
             }

--- a/RotationSolver.Basic/Configuration/Configs.cs
+++ b/RotationSolver.Basic/Configuration/Configs.cs
@@ -55,7 +55,7 @@ internal partial class Configs : IPluginConfiguration
 
     [ConditionBool, UI("Ignore status application against mobs that are status capped.",
     Filter = AutoActionUsage, Section = 3)]
-    private static readonly bool _statuscap = false;
+    private static readonly bool _statuscap2 = true;
 
     [ConditionBool, UI("Don't attack new mobs by AoE. (Dangerous)", Description = "Never use any AoE action when this may attack mobs that are not hostile targets.",
         Filter = AutoActionUsage, Section = 3)]

--- a/RotationSolver.Basic/Rotations/Basic/MonkRotation.cs
+++ b/RotationSolver.Basic/Rotations/Basic/MonkRotation.cs
@@ -240,13 +240,14 @@ public partial class MonkRotation
 
     static partial void ModifyTrueStrikePvE(ref ActionSetting setting)
     {
-        setting.ActionCheck = () => InRaptorForm || HasFormlessFist || HasPerfectBalance;
+        setting.ActionCheck = () => (InRaptorForm || HasFormlessFist || HasPerfectBalance) && RaptorFury > 0;
         setting.StatusProvide = [StatusID.CoeurlForm];
+        setting.MPOverride = () => 0;
     }
 
     static partial void ModifySnapPunchPvE(ref ActionSetting setting)
     {
-        setting.ActionCheck = () => InCoeurlForm || HasFormlessFist || HasPerfectBalance;
+        setting.ActionCheck = () => (InCoeurlForm || HasFormlessFist || HasPerfectBalance) && CoeurlFury > 0;
         setting.StatusProvide = [StatusID.OpoopoForm];
     }
 
@@ -264,8 +265,9 @@ public partial class MonkRotation
 
     static partial void ModifyTwinSnakesPvE(ref ActionSetting setting)
     {
-        setting.ActionCheck = () => InRaptorForm || HasFormlessFist || HasPerfectBalance;
+        setting.ActionCheck = () => (InRaptorForm || HasFormlessFist || HasPerfectBalance) && RaptorFury == 0;
         setting.StatusProvide = [StatusID.CoeurlForm];
+        setting.MPOverride = () => 0;
     }
 
     static partial void ModifyArmOfTheDestroyerPvE(ref ActionSetting setting)
@@ -279,7 +281,7 @@ public partial class MonkRotation
 
     static partial void ModifyDemolishPvE(ref ActionSetting setting)
     {
-        setting.ActionCheck = () => InCoeurlForm || HasFormlessFist || HasPerfectBalance;
+        setting.ActionCheck = () => (InCoeurlForm || HasFormlessFist || HasPerfectBalance) && CoeurlFury == 0;
         setting.StatusProvide = [StatusID.OpoopoForm];
     }
 
@@ -341,6 +343,7 @@ public partial class MonkRotation
     static partial void ModifyDragonKickPvE(ref ActionSetting setting)
     {
         setting.StatusProvide = [StatusID.RaptorForm];
+        setting.ActionCheck = () => OpoOpoFury == 0;
     }
 
     static partial void ModifyPerfectBalancePvE(ref ActionSetting setting)
@@ -515,18 +518,19 @@ public partial class MonkRotation
     static partial void ModifyLeapingOpoPvE(ref ActionSetting setting)
     {
         setting.StatusProvide = [StatusID.RaptorForm];
+        setting.ActionCheck = () => (InOpoopoForm || HasFormlessFist || HasPerfectBalance) && OpoOpoFury > 0;
     }
 
     static partial void ModifyRisingRaptorPvE(ref ActionSetting setting)
     {
         setting.StatusProvide = [StatusID.CoeurlForm];
-        setting.ActionCheck = () => InRaptorForm || HasFormlessFist || HasPerfectBalance;
+        setting.ActionCheck = () => (InRaptorForm || HasFormlessFist || HasPerfectBalance) && RaptorFury > 0;
     }
 
     static partial void ModifyPouncingCoeurlPvE(ref ActionSetting setting)
     {
         setting.StatusProvide = [StatusID.OpoopoForm];
-        setting.ActionCheck = () => InCoeurlForm || HasFormlessFist || HasPerfectBalance;
+        setting.ActionCheck = () => (InCoeurlForm || HasFormlessFist || HasPerfectBalance) && CoeurlFury > 0;
     }
 
     static partial void ModifyElixirBurstPvE(ref ActionSetting setting)


### PR DESCRIPTION
Fix for MNK rotation logic on skipping form logic and using Meditation 
Fix for BRD rotation logic for odd minute sidewider use, including logic for lower levels 
Renamed statuscap toggle and set default to true, setting out of experimental phase 
Update for ecommons