### PR TITLE
Refactor NIN_Default and improved raise target filtering

### DIFF
--- a/BasicRotations/Melee/NIN_Default.cs
+++ b/BasicRotations/Melee/NIN_Default.cs
@@ -28,6 +28,7 @@ public sealed class NIN_Default : NinjaRotation
     private IBaseAction? _lastNinActionAim = null;
     // Holds the next ninjutsu action to perform.
     private IBaseAction? _ninActionAim = null;
+    private readonly ActionID NinjutsuPvEid = AdjustId(ActionID.NinjutsuPvE);
 
     private bool KeepKassatsuinBurst => !Player.WillStatusEndGCD(2, 0, true, StatusID.Kassatsu) && HasKassatsu && !InTrickAttack && !IsExecutingMudra;
 
@@ -35,6 +36,7 @@ public sealed class NIN_Default : NinjaRotation
     {
         ImGui.Text($"Last Ninjutsu Action Cleared From Queue: {_lastNinActionAim}");
         ImGui.Text($"Current Ninjutsu Action: {_ninActionAim}");
+        ImGui.Text($"Ninjutsu ID: {AdjustId(NinjutsuPvEid)}");
         base.DisplayStatus();
     }
     #endregion
@@ -111,7 +113,7 @@ public sealed class NIN_Default : NinjaRotation
             ClearNinjutsu();
         }
 
-        if ((InCombat || (CombatMudra && HasHostilesInMaxRange)) && ChoiceNinjutsu(out act))
+        if ((InCombat || (CombatMudra && HasHostilesInMaxRange && TenPvE.Cooldown.CurrentCharges == TenPvE.Cooldown.MaxCharges)) && ChoiceNinjutsu(out act))
         {
             return true;
         }
@@ -341,10 +343,7 @@ public sealed class NIN_Default : NinjaRotation
                 return false;
             }
         }
-        else if (TenPvE.Cooldown.HasOneCharge && 
-            ((ShadowWalkerNeeded && (!IsShadowWalking || IsLastAction(false, SuitonPvE))) 
-            || InTrickAttack 
-            || TenPvE.Cooldown.WillHaveXChargesGCD(2, 2, 0)))
+        else if ((TenPvE.Cooldown.CurrentCharges == TenPvE.Cooldown.MaxCharges) || TenPvE.Cooldown.HasOneCharge && (ShadowWalkerNeeded || InTrickAttack || TenPvE.Cooldown.WillHaveXChargesGCD(2, 2, 0)))
         {
             // Chooses buffs or AoE actions based on combat conditions and cooldowns.
             // For instance, setting Huton for speed buff or choosing AoE Ninjutsu like Katon or Doton based on enemy positioning.
@@ -493,35 +492,33 @@ public sealed class NIN_Default : NinjaRotation
 
         if (_ninActionAim == HyoshoRanryuPvE)
         {
-            ActionID id = AdjustId(ActionID.NinjutsuPvE);
-
             //Failed
-            if ((uint)id == RabbitMediumPvE.ID)
+            if ((uint)AdjustId(NinjutsuPvEid) == RabbitMediumPvE.ID)
             {
                 ClearNinjutsu();
                 act = null;
                 return false;
             }
             //Action Execution
-            else if ((uint)id == HyoshoRanryuPvE.ID)
+            else if ((uint)AdjustId(NinjutsuPvEid) == HyoshoRanryuPvE.ID)
             {
                 if (HyoshoRanryuPvE.CanUse(out act, skipAoeCheck: true))
                 {
                     return true;
                 }
             }
-            //First
-            else if (id == ActionID.NinjutsuPvE)
+            //Second
+            else if ((uint)AdjustId(NinjutsuPvEid) == FumaShurikenPvE.ID)
             {
-                if (ChiPvE_18806.CanUse(out act, usedUp: true))
+                if (JinPvE_18807.CanUse(out act, usedUp: true))
                 {
                     return true;
                 }
             }
-            //Second
-            else if ((uint)id == FumaShurikenPvE.ID)
+            //First
+            else if ((uint)AdjustId(NinjutsuPvEid) == NinjutsuPvE.ID)
             {
-                if (JinPvE_18807.CanUse(out act, usedUp: true))
+                if (ChiPvE_18806.CanUse(out act, usedUp: true))
                 {
                     return true;
                 }
@@ -541,35 +538,33 @@ public sealed class NIN_Default : NinjaRotation
 
         if (_ninActionAim == GokaMekkyakuPvE)
         {
-            ActionID id = AdjustId(ActionID.NinjutsuPvE);
-
             //Failed
-            if ((uint)id == RabbitMediumPvE.ID)
+            if ((uint)AdjustId(NinjutsuPvEid) == RabbitMediumPvE.ID)
             {
                 ClearNinjutsu();
                 act = null;
                 return false;
             }
             //Action Execution
-            else if ((uint)id == GokaMekkyakuPvE.ID)
+            else if ((uint)AdjustId(NinjutsuPvEid) == GokaMekkyakuPvE.ID)
             {
                 if (GokaMekkyakuPvE.CanUse(out act, skipAoeCheck: true))
                 {
                     return true;
                 }
             }
-            //First
-            else if (id == ActionID.NinjutsuPvE)
+            //Second
+            else if ((uint)AdjustId(NinjutsuPvEid) == FumaShurikenPvE.ID)
             {
-                if (ChiPvE_18806.CanUse(out act, usedUp: true))
+                if (TenPvE_18805.CanUse(out act, usedUp: true))
                 {
                     return true;
                 }
             }
-            //Second
-            else if ((uint)id == FumaShurikenPvE.ID)
+            //First
+            else if ((uint)AdjustId(NinjutsuPvEid) == NinjutsuPvE.ID)
             {
-                if (TenPvE_18805.CanUse(out act, usedUp: true))
+                if (ChiPvE_18806.CanUse(out act, usedUp: true))
                 {
                     return true;
                 }
@@ -589,43 +584,41 @@ public sealed class NIN_Default : NinjaRotation
 
         if (_ninActionAim == SuitonPvE)
         {
-            ActionID id = AdjustId(ActionID.NinjutsuPvE);
-
             //Failed
-            if ((uint)id == RabbitMediumPvE.ID)
+            if ((uint)AdjustId(NinjutsuPvEid) == RabbitMediumPvE.ID)
             {
                 ClearNinjutsu();
                 act = null;
                 return false;
             }
             //Action Execution
-            else if ((uint)id == SuitonPvE.ID)
+            else if ((uint)AdjustId(NinjutsuPvEid) == SuitonPvE.ID)
             {
                 if (SuitonPvE.CanUse(out act))
                 {
                     return true;
                 }
             }
-            //First
-            else if (id == ActionID.NinjutsuPvE)
+            //Third
+            else if ((uint)AdjustId(NinjutsuPvEid) == RaitonPvE.ID)
             {
-                if (TenPvE.CanUse(out act, usedUp: true))
+                if (JinPvE_18807.CanUse(out act, usedUp: true))
                 {
                     return true;
                 }
             }
             //Second
-            else if ((uint)id == FumaShurikenPvE.ID)
+            else if ((uint)AdjustId(NinjutsuPvEid) == FumaShurikenPvE.ID)
             {
                 if (ChiPvE_18806.CanUse(out act, usedUp: true))
                 {
                     return true;
                 }
             }
-            //Third
-            else if ((uint)id == KatonPvE.ID || (uint)id == RaitonPvE.ID || (uint)id == HyotonPvE.ID)
+            //First
+            else if ((uint)AdjustId(NinjutsuPvEid) == NinjutsuPvE.ID)
             {
-                if (JinPvE_18807.CanUse(out act, usedUp: true))
+                if (TenPvE.CanUse(out act, usedUp: true))
                 {
                     return true;
                 }
@@ -645,43 +638,41 @@ public sealed class NIN_Default : NinjaRotation
 
         if (_ninActionAim == DotonPvE)
         {
-            ActionID id = AdjustId(ActionID.NinjutsuPvE);
-
             //Failed
-            if ((uint)id == RabbitMediumPvE.ID)
+            if ((uint)AdjustId(NinjutsuPvEid) == RabbitMediumPvE.ID)
             {
                 ClearNinjutsu();
                 act = null;
                 return false;
             }
             //Action Execution
-            else if ((uint)id == DotonPvE.ID)
+            else if ((uint)AdjustId(NinjutsuPvEid) == DotonPvE.ID)
             {
                 if (DotonPvE.CanUse(out act, skipAoeCheck: true))
                 {
                     return true;
                 }
             }
-            //First
-            else if (id == ActionID.NinjutsuPvE)
+            //Third
+            else if ((uint)AdjustId(NinjutsuPvEid) == HyotonPvE.ID)
             {
-                if (TenPvE.CanUse(out act, usedUp: true))
+                if (ChiPvE_18806.CanUse(out act, usedUp: true))
                 {
                     return true;
                 }
             }
             //Second
-            else if ((uint)id == FumaShurikenPvE.ID)
+            else if ((uint)AdjustId(NinjutsuPvEid) == FumaShurikenPvE.ID)
             {
                 if (JinPvE_18807.CanUse(out act, usedUp: true))
                 {
                     return true;
                 }
             }
-            //Third
-            else if ((uint)id == KatonPvE.ID || (uint)id == RaitonPvE.ID || (uint)id == HyotonPvE.ID)
+            //First
+            else if ((uint)AdjustId(NinjutsuPvEid) == NinjutsuPvE.ID)
             {
-                if (ChiPvE_18806.CanUse(out act, usedUp: true))
+                if (TenPvE.CanUse(out act, usedUp: true))
                 {
                     return true;
                 }
@@ -701,43 +692,41 @@ public sealed class NIN_Default : NinjaRotation
 
         if (_ninActionAim == HutonPvE)
         {
-            ActionID id = AdjustId(ActionID.NinjutsuPvE);
-
             //Failed
-            if ((uint)id == RabbitMediumPvE.ID)
+            if ((uint)AdjustId(NinjutsuPvEid) == RabbitMediumPvE.ID)
             {
                 ClearNinjutsu();
                 act = null;
                 return false;
             }
             //Action Execution
-            else if ((uint)id == HutonPvE.ID)
+            else if ((uint)AdjustId(NinjutsuPvEid) == HutonPvE.ID)
             {
                 if (HutonPvE.CanUse(out act, skipAoeCheck: true))
                 {
                     return true;
                 }
             }
-            //First
-            else if (id == ActionID.NinjutsuPvE)
+            //Third
+            else if ((uint)AdjustId(NinjutsuPvEid) == HyotonPvE.ID)
             {
-                if (ChiPvE.CanUse(out act, usedUp: true))
+                if (TenPvE_18805.CanUse(out act, usedUp: true))
                 {
                     return true;
                 }
             }
             //Second
-            else if ((uint)id == FumaShurikenPvE.ID)
+            else if ((uint)AdjustId(NinjutsuPvEid) == FumaShurikenPvE.ID)
             {
                 if (JinPvE_18807.CanUse(out act, usedUp: true))
                 {
                     return true;
                 }
             }
-            //Third
-            else if ((uint)id == KatonPvE.ID || (uint)id == RaitonPvE.ID || (uint)id == HyotonPvE.ID)
+            //First
+            else if ((uint)AdjustId(NinjutsuPvEid) == NinjutsuPvE.ID)
             {
-                if (TenPvE_18805.CanUse(out act, usedUp: true))
+                if (ChiPvE.CanUse(out act, usedUp: true))
                 {
                     return true;
                 }
@@ -757,35 +746,33 @@ public sealed class NIN_Default : NinjaRotation
 
         if (_ninActionAim == HyotonPvE)
         {
-            ActionID id = AdjustId(ActionID.NinjutsuPvE);
-
             //Failed
-            if ((uint)id == RabbitMediumPvE.ID)
+            if ((uint)AdjustId(NinjutsuPvEid) == RabbitMediumPvE.ID)
             {
                 ClearNinjutsu();
                 act = null;
                 return false;
             }
             //Action Execution
-            else if ((uint)id == HyotonPvE.ID)
+            else if ((uint)AdjustId(NinjutsuPvEid) == HyotonPvE.ID)
             {
                 if (HyotonPvE.CanUse(out act))
                 {
                     return true;
                 }
             }
-            //First
-            else if (id == ActionID.NinjutsuPvE)
+            //Second
+            else if ((uint)AdjustId(NinjutsuPvEid) == FumaShurikenPvE.ID)
             {
-                if (ChiPvE.CanUse(out act, usedUp: true))
+                if (JinPvE_18807.CanUse(out act, usedUp: true))
                 {
                     return true;
                 }
             }
-            //Second
-            else if ((uint)id == FumaShurikenPvE.ID)
+            //First
+            else if ((uint)AdjustId(NinjutsuPvEid) == NinjutsuPvE.ID)
             {
-                if (JinPvE_18807.CanUse(out act, usedUp: true))
+                if (ChiPvE.CanUse(out act, usedUp: true))
                 {
                     return true;
                 }
@@ -805,35 +792,33 @@ public sealed class NIN_Default : NinjaRotation
 
         if (_ninActionAim == RaitonPvE)
         {
-            ActionID id = AdjustId(ActionID.NinjutsuPvE);
-
             //Failed
-            if ((uint)id == RabbitMediumPvE.ID)
+            if ((uint)AdjustId(NinjutsuPvEid) == RabbitMediumPvE.ID)
             {
                 ClearNinjutsu();
                 act = null;
                 return false;
             }
             //Action Execution
-            else if ((uint)id == RaitonPvE.ID)
+            else if ((uint)AdjustId(NinjutsuPvEid) == RaitonPvE.ID)
             {
                 if (RaitonPvE.CanUse(out act))
                 {
                     return true;
                 }
             }
-            //First
-            else if (id == ActionID.NinjutsuPvE)
+            //Second
+            else if ((uint)AdjustId(NinjutsuPvEid) == FumaShurikenPvE.ID)
             {
-                if (TenPvE.CanUse(out act, usedUp: true))
+                if (ChiPvE_18806.CanUse(out act, usedUp: true))
                 {
                     return true;
                 }
             }
-            //Second
-            else if ((uint)id == FumaShurikenPvE.ID)
+            //First
+            else if ((uint)AdjustId(NinjutsuPvEid) == NinjutsuPvE.ID)
             {
-                if (ChiPvE_18806.CanUse(out act, usedUp: true))
+                if (TenPvE.CanUse(out act, usedUp: true))
                 {
                     return true;
                 }
@@ -853,35 +838,33 @@ public sealed class NIN_Default : NinjaRotation
 
         if (_ninActionAim == KatonPvE)
         {
-            ActionID id = AdjustId(ActionID.NinjutsuPvE);
-
             //Failed
-            if ((uint)id == RabbitMediumPvE.ID)
+            if ((uint)AdjustId(NinjutsuPvEid) == RabbitMediumPvE.ID)
             {
                 ClearNinjutsu();
                 act = null;
                 return false;
             }
             //Action Execution
-            else if ((uint)id == KatonPvE.ID)
+            else if ((uint)AdjustId(NinjutsuPvEid) == KatonPvE.ID)
             {
                 if (KatonPvE.CanUse(out act, skipAoeCheck: true))
                 {
                     return true;
                 }
             }
-            //First
-            else if (id == ActionID.NinjutsuPvE)
+            //Second
+            else if ((uint)AdjustId(NinjutsuPvEid) == FumaShurikenPvE.ID)
             {
-                if (ChiPvE.CanUse(out act, usedUp: true))
+                if (TenPvE_18805.CanUse(out act, usedUp: true))
                 {
                     return true;
                 }
             }
-            //Second
-            else if ((uint)id == FumaShurikenPvE.ID)
+            //First
+            else if ((uint)AdjustId(NinjutsuPvEid) == NinjutsuPvE.ID)
             {
-                if (TenPvE_18805.CanUse(out act, usedUp: true))
+                if (ChiPvE.CanUse(out act, usedUp: true))
                 {
                     return true;
                 }
@@ -901,17 +884,15 @@ public sealed class NIN_Default : NinjaRotation
 
         if (_ninActionAim == FumaShurikenPvE)
         {
-            ActionID id = AdjustId(ActionID.NinjutsuPvE);
-
             //Failed
-            if ((uint)id == RabbitMediumPvE.ID)
+            if ((uint)AdjustId(NinjutsuPvEid) == RabbitMediumPvE.ID)
             {
                 ClearNinjutsu();
                 act = null;
                 return false;
             }
             //Action Execution
-            else if ((uint)id == FumaShurikenPvE.ID)
+            else if ((uint)AdjustId(NinjutsuPvEid) == FumaShurikenPvE.ID)
             {
                 if (FumaShurikenPvE.CanUse(out act))
                 {
@@ -919,7 +900,7 @@ public sealed class NIN_Default : NinjaRotation
                 }
             }
             //First
-            else if (id == ActionID.NinjutsuPvE)
+            else if ((uint)AdjustId(NinjutsuPvEid) == NinjutsuPvE.ID)
             {
                 if (TenPvE.CanUse(out act, usedUp: true))
                 {

--- a/RotationSolver.Basic/Helpers/ObjectHelper.cs
+++ b/RotationSolver.Basic/Helpers/ObjectHelper.cs
@@ -353,7 +353,7 @@ public static class ObjectHelper
     internal static unsafe bool IsAllianceMember(this ICharacter obj)
     {
         return obj.GameObjectId is not 0
-            && !DataCenter.IsPvP && DataCenter.IsInAllianceRaid && obj is IPlayerCharacter
+            && !DataCenter.IsPvP && (DataCenter.IsInAllianceRaid || DataCenter.IsInBozjanFieldOpCE || DataCenter.IsInOccultCrescentOp) && obj is IPlayerCharacter
             && (ActionManager.CanUseActionOnTarget((uint)ActionID.RaisePvE, (FFXIVClientStructs.FFXIV.Client.Game.Object.GameObject*)obj.Struct())
             || ActionManager.CanUseActionOnTarget((uint)ActionID.CurePvE, (FFXIVClientStructs.FFXIV.Client.Game.Object.GameObject*)obj.Struct()));
     }

--- a/RotationSolver.Basic/Helpers/StatusHelper.cs
+++ b/RotationSolver.Basic/Helpers/StatusHelper.cs
@@ -175,15 +175,6 @@ public static class StatusHelper
     ];
 
     /// <summary>
-    /// Statuses that indicate that a player cannot be raised.
-    /// </summary>
-    public static StatusID[] CanNotRaise { get; } =
-    [
-        StatusID.ResurrectionRestricted,
-        StatusID.ResurrectionDenied
-    ];
-
-    /// <summary>
     /// Statuses that can be dispelled by Occult Dispel.
     /// </summary>
     public static StatusID[] PhantomDispellable { get; } =

--- a/RotationSolver.Basic/Helpers/TargetFilter.cs
+++ b/RotationSolver.Basic/Helpers/TargetFilter.cs
@@ -20,9 +20,15 @@ public static class TargetFilter
 
         foreach (IBattleChara item in charas)
         {
-            if (item == null || !item.IsDead || item.CurrentHp != 0 || !item.IsTargetable)
+            if (item == null || !item.IsDead || item.CurrentHp != 0 || !item.IsTargetable || item.IsTargetMoving() || item.IsEnemy())
+                continue;
+            if (!item.IsParty() && !item.IsAllianceMember())
+                continue;
+            if (!item.CanSee())
                 continue;
             if (item.HasStatus(false, StatusID.Raise))
+                continue;
+            if (item.HasStatus(false, StatusID.ResurrectionDenied))
                 continue;
             if (!Service.Config.RaiseBrinkOfDeath && item.HasStatus(false, StatusID.BrinkOfDeath))
                 continue;

--- a/RotationSolver/Updaters/StateUpdater.cs
+++ b/RotationSolver/Updaters/StateUpdater.cs
@@ -226,8 +226,7 @@ internal static class StateUpdater
 
             if (ConfigurationHelper.ActionPositional.TryGetValue((ActionID)id, out EnemyPositional positional)
                 && positional != target?.FindEnemyPositional()
-                && target?.HasPositional() == true
-                && !target.HasStatus(false, StatusID.DirectionalDisregard))
+                && target?.HasPositional() == true)
             {
                 return true;
             }

--- a/RotationSolver/Updaters/TargetUpdater.cs
+++ b/RotationSolver/Updaters/TargetUpdater.cs
@@ -164,10 +164,7 @@ internal static partial class TargetUpdater
                 {
                     foreach (var target in DataCenter.PartyMembers.GetDeath())
                     {
-                        if (!target.IsTargetMoving())
-                        {
-                            deathParty.Add(target);
-                        }
+                        deathParty.Add(target);
                     }
                 }
 
@@ -179,7 +176,7 @@ internal static partial class TargetUpdater
                     {
                         foreach (var member in DataCenter.AllianceMembers)
                         {
-                            if (!member.IsTargetMoving())
+                            if (!deathParty.Contains(member))
                             {
                                 if (raisetype == RaiseType.PartyAndAllianceHealers && member.IsJobCategory(JobRole.Healer))
                                     validRaiseTargets.Add(member);
@@ -193,7 +190,7 @@ internal static partial class TargetUpdater
                 {
                     foreach (var target in DataCenter.AllTargets.GetDeath())
                     {
-                        if (!target.IsEnemy() && !target.IsTargetMoving() && !deathParty.Contains(target))
+                        if (!deathParty.Contains(target))
                         {
                             validRaiseTargets.Add(target);
                         }


### PR DESCRIPTION
- Added `NinjutsuPvEid` field in `NIN_Default.cs` for clarity.
- Updated conditional checks to use `NinjutsuPvEid` for better readability.
- Enhanced alliance member checks in `ObjectHelper.cs` for additional operations.
- Removed `CanNotRaise` property in `StatusHelper.cs` to streamline resurrection handling.
- Refined target selection criteria in `TargetFilter.cs` to account for moving targets and enemies.
- Simplified conditions in `StateUpdater.cs` by removing unnecessary checks.
- Improved raise target identification logic in `TargetUpdater.cs` for efficiency.