### PR TITLE
Refactor dispel logic and enhance status handling

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+ko_fi: ltscombatreborn

--- a/RotationSolver.Basic/Actions/ActionTargetInfo.cs
+++ b/RotationSolver.Basic/Actions/ActionTargetInfo.cs
@@ -2132,37 +2132,7 @@ public struct ActionTargetInfo(IBaseAction action)
                 return null;
             }
 
-            // Manual Any() check for GameObjectId match
-            bool found = false;
-            foreach (var o in battleChara)
-            {
-                if (o.GameObjectId == DataCenter.DispelTarget.GameObjectId)
-                {
-                    found = true;
-                    break;
-                }
-            }
-            if (found)
-            {
-                return DataCenter.DispelTarget;
-            }
-
-            // Manual FirstOrDefault for a battle chara with a dispellable status
-            foreach (var o in battleChara)
-            {
-                if (o is IBattleChara b)
-                {
-                    foreach (var status in b.StatusList)
-                    {
-                        if (StatusHelper.CanDispel(status))
-                        {
-                            return b;
-                        }
-                    }
-                }
-            }
-
-            return null;
+            return DataCenter.DispelTarget;
         }
 
         IBattleChara? FindTankTarget()

--- a/RotationSolver.Basic/Configuration/Configs.cs
+++ b/RotationSolver.Basic/Configuration/Configs.cs
@@ -230,7 +230,7 @@ internal partial class Configs : IPluginConfiguration
     /// Enabling this setting will force the usage of Esuna on all target that are affected by a
     /// cleansable debuff.
     /// </markdown>
-    [ConditionBool, UI("Cleanse all dispellable debuffs (not just those in the status list).",
+    [ConditionBool, UI("Cleanse all dispellable debuffs regardless of healing.",
         Filter = AutoActionUsage, Section = 3,
         PvEFilter = JobFilterType.Dispel, PvPFilter = JobFilterType.NoJob)]
     private static readonly bool _dispelAll = false;

--- a/RotationSolver.Basic/Helpers/StatusHelper.cs
+++ b/RotationSolver.Basic/Helpers/StatusHelper.cs
@@ -446,7 +446,7 @@ public static class StatusHelper
         {
             return;
         }
-
+        
         try
         {
             Chat.SendMessage($"/statusoff {GetStatusName(status)}");
@@ -699,5 +699,45 @@ public static class StatusHelper
     public static bool CanDispel(this Status status)
     {
         return status != null && status.GameData.Value.CanDispel == true && status.RemainingTime > 1 + DataCenter.DefaultGCDRemain;
+    }
+
+    /// <summary>
+    /// 
+    /// </summary>
+    public static bool CanStatusOff(this Status status)
+    {
+        return status != null && status.GameData.Value.CanStatusOff == true && status.RemainingTime > 1 + DataCenter.DefaultGCDRemain;
+    }
+
+    /// <summary>
+    /// 
+    /// </summary>
+    public static bool LockActions(this Status status)
+    {
+        return status != null && status.GameData.Value.LockActions == true && status.RemainingTime > 1 + DataCenter.DefaultGCDRemain;
+    }
+
+    /// <summary>
+    /// 
+    /// </summary>
+    public static bool LockMovement(this Status status)
+    {
+        return status != null && status.GameData.Value.LockMovement == true && status.RemainingTime > 1 + DataCenter.DefaultGCDRemain;
+    }
+
+    /// <summary>
+    /// 
+    /// </summary>
+    public static bool LockControl(this Status status)
+    {
+        return status != null && status.GameData.Value.LockControl == true && status.RemainingTime > 1 + DataCenter.DefaultGCDRemain;
+    }
+
+    /// <summary>
+    /// Unknown3 is used to determine if the status indicates a tether.
+    /// </summary>
+    public static bool IsTether(this Status status)
+    {
+        return status != null && status.GameData.Value.Unknown3 == true && status.RemainingTime > 1 + DataCenter.DefaultGCDRemain;
     }
 }

--- a/RotationSolver/UI/RotationConfigWindow.cs
+++ b/RotationSolver/UI/RotationConfigWindow.cs
@@ -2738,8 +2738,7 @@ public partial class RotationConfigWindow : Window
         var list = new List<Status>();
         foreach (var s in sheet)
         {
-            if (!s.CanDispel && !s.LockMovement && !s.IsGaze && !s.IsFcBuff
-                && !string.IsNullOrEmpty(s.Name.ToString()) && s.Icon != 0)
+            if (!string.IsNullOrEmpty(s.Name.ToString()) && s.Icon != 0)
             {
                 list.Add(s);
             }
@@ -3568,6 +3567,7 @@ public partial class RotationConfigWindow : Window
     private static unsafe void DrawStatus()
     {
         ImGui.Text($"Merged Status: {DataCenter.MergedStatus}");
+        ImGui.Text($"PlayerHasLockActions: {ActionUpdater.PlayerHasLockActions()}");
         if ((IntPtr)FateManager.Instance() != IntPtr.Zero)
         {
             ImGui.Text($"Fate: {DataCenter.PlayerFateId}");

--- a/RotationSolver/Updaters/ActionUpdater.cs
+++ b/RotationSolver/Updaters/ActionUpdater.cs
@@ -221,6 +221,11 @@ internal static class ActionUpdater
             return false;
         }
 
+        if (PlayerHasLockActions())
+        {
+            return false;
+        }
+
         if (NextAction == null)
         {
             return false;
@@ -234,6 +239,26 @@ internal static class ActionUpdater
 
         // GCD
         return RSCommands.CanDoAnAction(ActionHelper.CanUseGCD);
+    }
+
+    internal static bool PlayerHasLockActions()
+    {
+        if (Player.Object == null)
+        {
+            return false;
+        }
+
+        if (Player.Object.StatusList == null)
+        {
+            return false;
+        }
+
+        foreach (var status in Player.Object.StatusList)
+        {
+            if (status != null && status.LockActions())
+                return true;
+        }
+        return false;
     }
 
     private unsafe static bool IsPlayerOccupied()

--- a/RotationSolver/Updaters/StateUpdater.cs
+++ b/RotationSolver/Updaters/StateUpdater.cs
@@ -192,18 +192,7 @@ internal static class StateUpdater
     {
         if (DataCenter.DispelTarget != null)
         {
-            foreach (Dalamud.Game.ClientState.Statuses.Status status in DataCenter.DispelTarget.StatusList)
-            {
-                if (StatusHelper.IsDangerous(status))
-                {
-                    return true;
-                }
-            }
-
-            if (!DataCenter.HasHostilesInRange || Service.Config.DispelAll || DataCenter.IsPvP)
-            {
-                return true;
-            }
+            return true;
         }
         return false;
     }

--- a/RotationSolver/Updaters/TargetUpdater.cs
+++ b/RotationSolver/Updaters/TargetUpdater.cs
@@ -291,6 +291,13 @@ internal static partial class TargetUpdater
             _dispelPartyTargets.Delay(weakenPeople);
             var delayedWeakenPeople = _dispelPartyTargets.ToList();
 
+            var CanDispelNonDangerous = !DataCenter.MergedStatus.HasFlag(AutoStatus.HealAreaAbility)
+                    && !DataCenter.MergedStatus.HasFlag(AutoStatus.HealAreaSpell)
+                    && !DataCenter.MergedStatus.HasFlag(AutoStatus.HealSingleAbility)
+                    && !DataCenter.MergedStatus.HasFlag(AutoStatus.HealSingleSpell)
+                    && !DataCenter.MergedStatus.HasFlag(AutoStatus.DefenseArea)
+                    && !DataCenter.MergedStatus.HasFlag(AutoStatus.DefenseSingle);
+
             foreach (IBattleChara person in delayedWeakenPeople)
             {
                 bool hasDangerous = false;
@@ -312,7 +319,15 @@ internal static partial class TargetUpdater
                 }
             }
 
-            return GetClosestTarget(dyingPeople) ?? GetClosestTarget(delayedWeakenPeople);
+            if (!CanDispelNonDangerous)
+            {
+                return GetClosestTarget(dyingPeople);
+            }
+
+            if (CanDispelNonDangerous || !DataCenter.HasHostilesInRange || Service.Config.DispelAll || DataCenter.IsPvP)
+            {
+                return GetClosestTarget(dyingPeople) ?? GetClosestTarget(delayedWeakenPeople);
+            }
         }
         return null;
     }


### PR DESCRIPTION
This commit simplifies the dispel target retrieval in `ActionTargetInfo.cs` and updates the cleansing debuffs setting in `Configs.cs`. 
New methods for status checks are added in `StatusHelper.cs`, including `CanStatusOff`, `LockActions`, and `LockMovement`. 
The status filtering logic in `RotationConfigWindow.cs` is streamlined, and a new method `PlayerHasLockActions` is introduced in `ActionUpdater.cs`. 
Additionally, the logic for adding dispel actions in `StateUpdater.cs` is simplified, and `TargetUpdater.cs` now differentiates between dangerous and non-dangerous statuses for target selection.