### PR TITLE
Fix targeting logic for Void Ark alliance raid Irminsul and Sawtooth bosses

### DIFF
--- a/RotationSolver.Basic/Actions/ActionTargetInfo.cs
+++ b/RotationSolver.Basic/Actions/ActionTargetInfo.cs
@@ -288,6 +288,10 @@ public struct ActionTargetInfo(IBaseAction action)
         {
             return false;
         }
+        if (battleChara.StatusList == null)
+        {
+            return false;
+        }
 
         try
         {
@@ -307,7 +311,7 @@ public struct ActionTargetInfo(IBaseAction action)
             }
             if (Range >= 20) // Range
             {
-                if (battleChara.HasStatus(false, StatusID.RangedResistance, StatusID.EnergyField))
+                if (battleChara.HasStatus(false, StatusID.EnergyField))
                 {
                     return false;
                 }

--- a/RotationSolver.Basic/Helpers/ObjectHelper.cs
+++ b/RotationSolver.Basic/Helpers/ObjectHelper.cs
@@ -1007,6 +1007,44 @@ public static class ObjectHelper
     /// </summary>
     /// <param name="battleChara">the object.</param>
     /// <returns></returns>
+    public static bool IsIrminsulSawtoothImmune(this IBattleChara battleChara)
+    {
+        if (DataCenter.TerritoryID == 120)
+        {
+            var RangedPhysicalRole = Player.Job.IsPhysicalRangedDps();
+            var RangedMagicalRole = Player.Job.IsMagicalRangedDps();
+            var HealerRole = Player.Job.IsHealer();
+
+            var RangedResistance = battleChara.HasStatus(false, StatusID.RangedResistance);
+            var MagicResistance = battleChara.HasStatus(false, StatusID.MagicResistance);
+
+            if (RangedResistance && RangedPhysicalRole)
+            {
+                if (Service.Config.InDebug)
+                {
+                    PluginLog.Information("IsIrminsulSawtoothImmune: Sawtooth Immune status found");
+                }
+                return true;
+            }
+
+            if (MagicResistance && (RangedMagicalRole || HealerRole))
+            {
+                if (Service.Config.InDebug)
+                {
+                    PluginLog.Information("IsIrminsulSawtoothImmune: Irminsul Immune status found");
+                }
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// 
+    /// </summary>
+    /// <param name="battleChara">the object.</param>
+    /// <returns></returns>
     public static bool IsSuperiorFlightUnitImmune(this IBattleChara battleChara)
     {
         if (DataCenter.TerritoryID == 736)

--- a/RotationSolver.Basic/Rotations/Basic/MachinistRotation.cs
+++ b/RotationSolver.Basic/Rotations/Basic/MachinistRotation.cs
@@ -281,7 +281,7 @@ public partial class MachinistRotation
     static partial void ModifyTacticianPvE(ref ActionSetting setting)
     {
         setting.UnlockedByQuestID = 67244;
-        setting.StatusProvide = StatusHelper.PhysicalRangedResistance;
+        setting.StatusProvide = StatusHelper.RangePhysicalDefense;
         setting.CreateConfig = () => new ActionConfig()
         {
             AoeCount = 1,
@@ -290,7 +290,6 @@ public partial class MachinistRotation
 
     static partial void ModifyDrillPvE(ref ActionSetting setting)
     {
-        setting.StatusProvide = StatusHelper.PhysicalRangedResistance;
         setting.UnlockedByQuestID = 67246;
         setting.CreateConfig = () => new ActionConfig()
         {


### PR DESCRIPTION
- Introduced `IsIrminsulSawtoothImmune` method in `ObjectHelper` for immunity checks with debug logging.
- Fixed status provided by MCH AOE mit