### PR TITLE
SAM fixes, Variant Action fixes, various fixes to Autoduty menu

### DIFF
--- a/RebornRotations/Duty/VariantDefault.cs
+++ b/RebornRotations/Duty/VariantDefault.cs
@@ -8,7 +8,7 @@ internal class VariantDefault : VariantRotation
 {
     public override bool ProvokeAbility(IAction nextGCD, out IAction? act)
     {
-        if (VariantUltimatumPvE.CanUse(out act))
+        if (VariantUltimatumPvE.CanUse(out act, skipStatusProvideCheck: true))
         {
             return true;
         }
@@ -33,6 +33,21 @@ internal class VariantDefault : VariantRotation
 
     public override bool DefenseSingleAbility(IAction nextGCD, out IAction? act)
     {
+        if (VariantRampartPvE_33864.CanUse(out act, skipStatusProvideCheck: true))
+        {
+            return true;
+        }
+
+        if (VariantRampartPvE.CanUse(out act, skipStatusProvideCheck: true))
+        {
+            return true;
+        }
+
+        return base.DefenseSingleAbility(nextGCD, out act);
+    }
+
+    public override bool GeneralAbility(IAction nextGCD, out IAction? act)
+    {
         if (VariantRampartPvE_33864.CanUse(out act))
         {
             return true;
@@ -43,7 +58,12 @@ internal class VariantDefault : VariantRotation
             return true;
         }
 
-        return base.AttackAbility(nextGCD, out act);
+        if (VariantUltimatumPvE.CanUse(out act))
+        {
+            return true;
+        }
+
+        return base.GeneralAbility(nextGCD, out act);
     }
 
     public override bool HealSingleGCD(out IAction? act)
@@ -53,7 +73,7 @@ internal class VariantDefault : VariantRotation
             return true;
         }
 
-        if (VariantCurePvE.CanUse(out act))
+        if (VariantCurePvE.CanUse(out act, skipStatusProvideCheck: true))
         {
             return true;
         }

--- a/RebornRotations/Melee/SAM_Reborn.cs
+++ b/RebornRotations/Melee/SAM_Reborn.cs
@@ -186,7 +186,7 @@ public sealed class SAM_Reborn : SamuraiRotation
 
         if (!HiganbanaTargets || (HiganbanaTargets && NumberOfAllHostilesInRange < 2) && HasFugetsuAndFuka && !WillFugetsuEnd && !WillFukaEnd && !HasMeikyoShisui && !MidareSetsugekkaReady)
         {
-            if (HiganbanaPvE.CanUse(out act, skipStatusProvideCheck: true, skipComboCheck: true, skipTTKCheck: isTargetBoss) && HiganbanaPvE.Target.Target != null && (HiganbanaPvE.Target.Target?.WillStatusEnd(18, true, StatusID.Higanbana) ?? false))
+            if (HiganbanaPvE.CanUse(out act, skipComboCheck: true, skipTTKCheck: isTargetBoss))
             {
                 return true;
             }

--- a/RotationSolver.Basic/Rotations/Basic/SamuraiRotation.cs
+++ b/RotationSolver.Basic/Rotations/Basic/SamuraiRotation.cs
@@ -467,6 +467,7 @@ public partial class SamuraiRotation
         setting.CreateConfig = () => new ActionConfig()
         {
             TimeToKill = 48,
+            StatusGcdCount = 6,
         };
     }
 

--- a/RotationSolver/UI/RotationConfigWindow.cs
+++ b/RotationSolver/UI/RotationConfigWindow.cs
@@ -1250,19 +1250,20 @@ public partial class RotationConfigWindow : Window
         ImGui.Spacing();
 
         // Create a new list of AutoDutyPlugin objects
-        List<AutoDutyPlugin> pluginsToCheck = new()
-        {
+        List<AutoDutyPlugin> pluginsToCheck =
+        [
         new AutoDutyPlugin { Name = "AutoDuty", Url = "https://puni.sh/api/repository/herc" },
         new AutoDutyPlugin { Name = "vnavmesh", Url = "https://puni.sh/api/repository/veyn" },
         new AutoDutyPlugin { Name = "BossModReborn", Url = "https://raw.githubusercontent.com/FFXIV-CombatReborn/CombatRebornRepo/main/pluginmaster.json" },
         new AutoDutyPlugin { Name = "Boss Mod", Url = "https://puni.sh/api/repository/veyn" },
         new AutoDutyPlugin { Name = "Avarice", Url = "https://love.puni.sh/ment.json" },
-        new AutoDutyPlugin { Name = "Deliveroo", Url = "https://plugins.carvel.li/" },
+        new AutoDutyPlugin { Name = "Deliveroo", Url = "https://puni.sh/api/repository/vera" },
         new AutoDutyPlugin { Name = "AutoRetainer", Url = "https://love.puni.sh/ment.json" },
         new AutoDutyPlugin { Name = "SkipCutscene", Url = "https://raw.githubusercontent.com/KangasZ/DalamudPluginRepository/main/plugin_repository.json" },
         new AutoDutyPlugin { Name = "AntiAfkKick", Url = "https://raw.githubusercontent.com/NightmareXIV/MyDalamudPlugins/main/pluginmaster.json" },
+        new AutoDutyPlugin { Name = "Gearsetter", Url = "https://plugins.carvel.li/" },
         // Add more plugins as needed
-    };
+    ];
 
         // Check if "Boss Mod" and "BossMod Reborn" are enabled
         bool isBossModEnabled = pluginsToCheck.Any(plugin => plugin.Name == "Boss Mod" && plugin.IsEnabled);
@@ -1321,6 +1322,16 @@ public partial class RotationConfigWindow : Window
             {
                 color = ImGuiColors.DalamudYellow; // Display "Boss Mod" in yellow if both are installed
                 text = $"{plugin.Name} is {(isEnabled ? "installed and enabled" : "not enabled")}. Both Boss Mods cannot be installed and enabled at the same time. Please disable Boss Mod.";
+            }
+            else if (plugin.Name == "Boss Mod" && isBossModEnabled && !isBossModRebornEnabled)
+            {
+                color = isEnabled ? ImGuiColors.DalamudYellow : ImGuiColors.DalamudRed;
+                text = $"{plugin.Name} is {(isEnabled ? "installed and enabled" : "not enabled")}. Please use BossModReborn instead, BMR has specific intergration with RSR that improves RSRs ability to react to combat i.e. Gaze effects.";
+            }
+            else if (plugin.Name == "BossModReborn" && isBossModRebornEnabled && !isBossModEnabled)
+            {
+                color = isEnabled ? ImGuiColors.ParsedGreen : ImGuiColors.DalamudRed;
+                text = $"{plugin.Name} is {(isEnabled ? "installed and enabled" : "not enabled")}.";
             }
             else
             {


### PR DESCRIPTION
- Simplified `HiganbanaPvE` usage in `SAM_Reborn` by removing unnecessary parameters, now using user configurable refresh timer.
- Modified `ProvokeAbility`, `DefenseSingleAbility`, and `HealSingleGCD` in `VariantDefault` to include `skipStatusProvideCheck` for improved ability checks to fix issues with Variant Actions.
- Changed initialization of `AutoDutyPlugin` list in `RotationConfigWindow` and updated the "Deliveroo" plugin URL; added "Gearsetter".
- Introduced logic to manage interactions between "Boss Mod" and "BossMod Reborn", providing user feedback on plugin conflicts and recommendations.