### PR TITLE
RPR and SAM rotational logic fixes and new provoke option

### DIFF
--- a/RebornRotations/Melee/RPR_Reborn.cs
+++ b/RebornRotations/Melee/RPR_Reborn.cs
@@ -125,7 +125,7 @@ public sealed class RPR_Reborn : ReaperRotation
             }
         }
 
-        if (!HasBloodsownCircle && !HasPerfectioParata && !HasExecutioner && !HasImmortalSacrifice && ((GluttonyPvE.EnoughLevel && !GluttonyPvE.Cooldown.WillHaveOneChargeGCD(4)) || !GluttonyPvE.EnoughLevel || Soul == 100))
+        if (!HasBloodsownCircleSelf && !HasPerfectioParata && !HasExecutioner && !HasImmortalSacrifice && ((GluttonyPvE.EnoughLevel && !GluttonyPvE.Cooldown.WillHaveOneChargeGCD(4)) || !GluttonyPvE.EnoughLevel || Soul == 100))
         {
             if (GrimSwathePvE.CanUse(out act))
             {

--- a/RebornRotations/Melee/SAM_Reborn.cs
+++ b/RebornRotations/Melee/SAM_Reborn.cs
@@ -248,7 +248,7 @@ public sealed class SAM_Reborn : SamuraiRotation
             return true;
         }
 
-        if (TendoKaeshiGokenPvE.CanUse(out act))
+        if (TendoKaeshiGokenPvE.CanUse(out act, skipAoeCheck: true))
         {
             return true;
         }
@@ -258,7 +258,7 @@ public sealed class SAM_Reborn : SamuraiRotation
             return true;
         }
 
-        if (KaeshiGokenPvE.CanUse(out act, skipComboCheck: true))
+        if (KaeshiGokenPvE.CanUse(out act, skipComboCheck: true, skipAoeCheck: true))
         {
             return true;
         }

--- a/RebornRotations/PVPRotations/Melee/RPR_Default.PVP.cs
+++ b/RebornRotations/PVPRotations/Melee/RPR_Default.PVP.cs
@@ -103,9 +103,9 @@ public sealed class RPR_DefaultPvP : ReaperRotation
             return false;
         }
 
-        if (LemuresSlicePvP.CanUse(out action))
+        if (HasEnshroudedPvP)
         {
-            if (HasEnshroudedPvP)
+            if (LemuresSlicePvP.CanUse(out action))
             {
                 return true;
             }
@@ -116,9 +116,12 @@ public sealed class RPR_DefaultPvP : ReaperRotation
             return true;
         }
 
-        if (GrimSwathePvP.CanUse(out action) && !HasEnshroudedPvP)
+        if (!HasEnshroudedPvP)
         {
-            return true;
+            if (GrimSwathePvP.CanUse(out action))
+            {
+                return true;
+            }
         }
 
         return base.AttackAbility(nextGCD, out action);
@@ -134,11 +137,14 @@ public sealed class RPR_DefaultPvP : ReaperRotation
             return false;
         }
 
-        if (CommunioPvP.CanUse(out action))
+        if (HasEnshroudedPvP)
         {
-            if (Player.StatusStack(true, StatusID.Enshrouded_2863) == 1 || Player.WillStatusEndGCD(1, 0, true, StatusID.Enshrouded_2863))
+            if (CommunioPvP.CanUse(out action))
             {
-                return true;
+                if (Player.StatusStack(true, StatusID.Enshrouded_2863) == 1 || Player.WillStatusEndGCD(1, 0, true, StatusID.Enshrouded_2863))
+                {
+                    return true;
+                }
             }
         }
 
@@ -157,11 +163,14 @@ public sealed class RPR_DefaultPvP : ReaperRotation
             return true;
         }
 
-        if (PlentifulHarvestPvP.CanUse(out action))
+        if (HasImmortalSacrificePvP)
         {
-            if (Player.StatusStack(true, StatusID.ImmortalSacrifice_3204) > 3)
+            if (PlentifulHarvestPvP.CanUse(out action))
             {
-                return true;
+                if (Player.StatusStack(true, StatusID.ImmortalSacrifice_3204) > 3)
+                {
+                    return true;
+                }
             }
         }
 

--- a/RotationSolver.Basic/Actions/ActionBasicInfo.cs
+++ b/RotationSolver.Basic/Actions/ActionBasicInfo.cs
@@ -184,6 +184,11 @@ public readonly struct ActionBasicInfo
             return false;
         }
 
+        if (IsLimitBreak && !DataCenter.IsPvP)
+        {
+            return true;
+        }
+
         // 2. Basic requirements: not disabled, enough level, enough MP, spell unlocked
         if (IsActionDisabled() || !EnoughLevel || !HasEnoughMP() || !SpellUnlocked)
         {

--- a/RotationSolver.Basic/Actions/ActionTargetInfo.cs
+++ b/RotationSolver.Basic/Actions/ActionTargetInfo.cs
@@ -1503,13 +1503,11 @@ public struct ActionTargetInfo(IBaseAction action)
                 return null;
             }
 
-            foreach (var o in battleChara)
+            if (DataCenter.ProvokeTarget != null)
             {
-                if (o.GameObjectId == DataCenter.ProvokeTarget.GameObjectId)
-                {
-                    return DataCenter.ProvokeTarget;
-                }
+                return DataCenter.ProvokeTarget;
             }
+
             return null;
         }
 

--- a/RotationSolver.Basic/Configuration/Configs.cs
+++ b/RotationSolver.Basic/Configuration/Configs.cs
@@ -223,6 +223,10 @@ internal partial class Configs : IPluginConfiguration
         PvPFilter = JobFilterType.NoJob)]
     private static readonly bool _interruptibleMoreCheck = true;
 
+    [ConditionBool, UI("Provoke anything not on the no provoke list.",
+        Filter = AutoActionUsage, Section = 3)]
+    private static readonly bool _provokeAnything = false;
+
     [ConditionBool, UI("Stop casting if the target dies.", Filter = Extra)]
     private static readonly bool _useStopCasting = false;
 

--- a/RotationSolver.Basic/Helpers/ObjectHelper.cs
+++ b/RotationSolver.Basic/Helpers/ObjectHelper.cs
@@ -42,6 +42,11 @@ public static class ObjectHelper
             return false;
         }
 
+        if (Service.Config.ProvokeAnything)
+        {
+            return true;
+        }
+
         if (DataCenter.PlayerFateId != 0 && target.FateId() == DataCenter.PlayerFateId)
         {
             return false;
@@ -59,15 +64,18 @@ public static class ObjectHelper
             }
         }
 
-        // Target can move or too big and has a target
-        if ((target.GetObjectNPC()?.Unknown0 == 0 || target.HitboxRadius >= 5) // Unknown12 used to be the flag checked for the mobs ability to move, honestly just guessing on this one
-            && (target.TargetObject?.IsValid() ?? false))
+        if (!Service.Config.ProvokeAnything)
         {
-            // The target is not a tank role
-            if (Svc.Objects.SearchById(target.TargetObjectId) is IBattleChara targetObject && !targetObject.IsJobCategory(JobRole.Tank)
-                && (Vector3.Distance(target.Position, Player.Object?.Position ?? Vector3.Zero) > 5))
+            // Target can move or too big and has a target
+            if ((target.GetObjectNPC()?.Unknown0 == 0 || target.HitboxRadius >= 5) // Unknown12 used to be the flag checked for the mobs ability to move, honestly just guessing on this one
+                && (target.TargetObject?.IsValid() ?? false))
             {
-                return true;
+                // The target is not a tank role
+                if (Svc.Objects.SearchById(target.TargetObjectId) is IBattleChara targetObject && !targetObject.IsJobCategory(JobRole.Tank)
+                    && (Vector3.Distance(target.Position, Player.Object?.Position ?? Vector3.Zero) > 5))
+                {
+                    return true;
+                }
             }
         }
         return false;

--- a/RotationSolver.Basic/Rotations/Basic/ReaperRotation.cs
+++ b/RotationSolver.Basic/Rotations/Basic/ReaperRotation.cs
@@ -43,6 +43,11 @@ public partial class ReaperRotation
     /// <summary>
     /// 
     /// </summary>
+    public static bool HasEnshroudedPvP => Player.HasStatus(true, StatusID.Enshrouded_2863);
+
+    /// <summary>
+    /// 
+    /// </summary>
     public static bool HasSoulReaver => Player.HasStatus(true, StatusID.SoulReaver);
 
     /// <summary>
@@ -76,19 +81,29 @@ public partial class ReaperRotation
     public static bool HasExecutioner => Player.HasStatus(true, StatusID.Executioner);
 
     /// <summary>
-    /// 
+    /// Able to execute Enshroud
     /// </summary>
     public static bool HasIdealHost => Player.HasStatus(true, StatusID.IdealHost);
 
     /// <summary>
-    /// 
+    /// Able to execute Plentiful Harvest
     /// </summary>
     public static bool HasImmortalSacrifice => Player.HasStatus(true, StatusID.ImmortalSacrifice);
 
     /// <summary>
-    /// 
+    /// PvP version of Immortal Sacrifice
     /// </summary>
-    public static bool HasBloodsownCircle => Player.HasStatus(true, StatusID.BloodsownCircle_2972);
+    public static bool HasImmortalSacrificePvP => Player.HasStatus(true, StatusID.ImmortalSacrifice_3204);
+
+    /// <summary>
+    /// Grants Immortal Sacrifice to the reaper who applied this effect when duration expires
+    /// </summary>
+    public static bool HasBloodsownCircleOther => Player.HasStatus(true, StatusID.BloodsownCircle);
+
+    /// <summary>
+    /// Able to gain stacks of Immortal Sacrifice from party members under the effect of your Circle of Sacrifice
+    /// </summary>
+    public static bool HasBloodsownCircleSelf => Player.HasStatus(true, StatusID.BloodsownCircle_2972);
 
     /// <summary>
     /// 
@@ -104,11 +119,6 @@ public partial class ReaperRotation
     /// 
     /// </summary>
     public static bool HasPerfectioParata => Player.HasStatus(true, StatusID.PerfectioParata);
-
-    /// <summary>
-    /// 
-    /// </summary>
-    public static bool HasEnshroudedPvP => Player.HasStatus(true, StatusID.Enshrouded_2863);
     #endregion
 
     #region Actions Unassignable
@@ -356,8 +366,11 @@ public partial class ReaperRotation
 
     static partial void ModifyPlentifulHarvestPvE(ref ActionSetting setting)
     {
-        setting.StatusNeed = [StatusID.ImmortalSacrifice];
-        setting.ActionCheck = () => !Player.HasStatus(true, StatusID.BloodsownCircle_2972);
+        setting.ActionCheck = () => !HasBloodsownCircleSelf && HasImmortalSacrifice;
+        setting.CreateConfig = () => new ActionConfig()
+        {
+            AoeCount = 1,
+        };
     }
 
     static partial void ModifyCommunioPvE(ref ActionSetting setting)

--- a/RotationSolver.Basic/Rotations/Duties/DutyRotation.cs
+++ b/RotationSolver.Basic/Rotations/Duties/DutyRotation.cs
@@ -164,7 +164,7 @@ public partial class DutyRotation : IDisposable
     public static bool InCombat => DataCenter.InCombat;
 
     /// <summary>
-    /// Check if in combat.
+    /// 
     /// </summary>
     public static bool IsMoving => DataCenter.IsMoving;
 

--- a/RotationSolver/UI/CollapsingHeaderGroup.cs
+++ b/RotationSolver/UI/CollapsingHeaderGroup.cs
@@ -3,39 +3,25 @@ using ECommons.Logging;
 
 namespace RotationSolver.UI;
 
-internal class CollapsingHeaderGroup
+internal class CollapsingHeaderGroup(Dictionary<Func<string>, Action> headers)
 {
-    private readonly Dictionary<Func<string>, Action> _headers;
+    private readonly Dictionary<Func<string>, Action> _headers = headers ?? throw new ArgumentNullException(nameof(headers));
     private int _openedIndex = -1;
 
     public float HeaderSize { get; set; } = 24;
 
-    public CollapsingHeaderGroup(Dictionary<Func<string>, Action> headers)
-    {
-        _headers = headers ?? throw new ArgumentNullException(nameof(headers));
-    }
-
     public void AddCollapsingHeader(Func<string> name, Action action)
     {
-        if (name is null)
-        {
-            throw new ArgumentNullException(nameof(name));
-        }
+        ArgumentNullException.ThrowIfNull(name);
 
-        if (action is null)
-        {
-            throw new ArgumentNullException(nameof(action));
-        }
+        ArgumentNullException.ThrowIfNull(action);
 
         _headers[name] = action;
     }
 
     public void RemoveCollapsingHeader(Func<string> name)
     {
-        if (name is null)
-        {
-            throw new ArgumentNullException(nameof(name));
-        }
+        ArgumentNullException.ThrowIfNull(name);
 
         _ = _headers.Remove(name);
     }

--- a/RotationSolver/Updaters/StateUpdater.cs
+++ b/RotationSolver/Updaters/StateUpdater.cs
@@ -391,10 +391,15 @@ internal static class StateUpdater
 
     private static bool ShouldAddProvoke()
     {
-        return DataCenter.InCombat && DataCenter.Role == JobRole.Tank
-            && (Service.Config.AutoProvokeForTank
-                || CountAllianceTanks() < 2)
-            && DataCenter.ProvokeTarget != null;
+        bool isInCombatOrProvokeAnything = DataCenter.InCombat || Service.Config.ProvokeAnything;
+        bool isTankOrHasUltimatum = DataCenter.Role == JobRole.Tank || Player.Object.HasStatus(true, StatusID.VariantUltimatumSet);
+        bool shouldAutoProvoke = Service.Config.AutoProvokeForTank || CountAllianceTanks() < 2;
+        bool hasProvokeTarget = DataCenter.ProvokeTarget != null;
+
+        return isInCombatOrProvokeAnything
+            && isTankOrHasUltimatum
+            && shouldAutoProvoke
+            && hasProvokeTarget;
     }
 
     private static bool ShouldAddInterrupt()

--- a/RotationSolver/Updaters/TargetUpdater.cs
+++ b/RotationSolver/Updaters/TargetUpdater.cs
@@ -28,7 +28,7 @@ internal static partial class TargetUpdater
             DataCenter.AllHostileTargets = GetAllHostileTargets();
             DataCenter.DeathTarget = GetDeathTarget();
             DataCenter.DispelTarget = GetDispelTarget();
-            DataCenter.ProvokeTarget = DataCenter.Role == JobRole.Tank ? GetFirstHostileTarget(ObjectHelper.CanProvoke) : null; // Calculating this per frame rather than on-demand is actually a fair amount worse
+            DataCenter.ProvokeTarget = (DataCenter.Role == JobRole.Tank || Player.Object.HasStatus(true, StatusID.VariantUltimatumSet)) ? GetFirstHostileTarget(ObjectHelper.CanProvoke) : null; // Calculating this per frame rather than on-demand is actually a fair amount worse
             DataCenter.InterruptTarget = GetFirstHostileTarget(ObjectHelper.CanInterrupt); // Tanks, Melee, RDM, and various phantom and duty actions can interrupt so just deal with it
         }
         UpdateTimeToKill();


### PR DESCRIPTION
- Hotfixes to RPR rotation logic for Plentiful Harvest logic
- Fixes to SAM rotation to ensure follow up GCDs used even when transitioning from AOE to ST
- Added option for provoke logic to skip all checks and just provoke freely per user request