### PR TITLE
Fixes for Duty Rotaiton load/unload issues, fixes for Variant Dungeon actions

### DIFF
--- a/RebornRotations/Duty/VariantDefault.cs
+++ b/RebornRotations/Duty/VariantDefault.cs
@@ -6,6 +6,42 @@ namespace RebornRotations.Duty;
 
 internal class VariantDefault : VariantRotation
 {
+    public override void DisplayStatus()
+    {
+        if (InVariantDungeon)
+        {
+            ImGui.Text($"VariantUltimatumPvE Status: {Player.HasStatus(true, StatusID.VariantUltimatumSet)}");
+            ImGui.Spacing();
+            ImGui.Text($"VariantSpiritDartPvE_33863  Status: {Player.HasStatus(true, StatusID.VariantSpiritDartSet)}");
+            ImGui.Text($"VariantSpiritDartPvE_33863 Slotted: {VariantSpiritDartPvE_33863.Info.IsOnSlot}");
+            ImGui.Spacing();
+            ImGui.Text($"VariantSpiritDartPvE  Status: {Player.HasStatus(true, StatusID.VariantSpiritDartSet)}");
+            ImGui.Text($"VariantSpiritDartPvE Slotted: {VariantSpiritDartPvE.Info.IsOnSlot}");
+            ImGui.Spacing();
+            ImGui.Text($"VariantRampartPvE_33864 Status: {Player.HasStatus(true, StatusID.VariantRampartSet)}");
+            ImGui.Spacing();
+            ImGui.Text($"VariantRampartPvE Status: {Player.HasStatus(true, StatusID.VariantRampartSet)}");
+            ImGui.Spacing();
+            ImGui.Text($"VariantCurePvE_33862  Status: {Player.HasStatus(true, StatusID.VariantCureSet)}");
+            ImGui.Text($"VariantCurePvE_33862 Slotted: {VariantCurePvE_33862.Info.IsOnSlot}");
+            ImGui.Spacing();
+            ImGui.Text($"VariantCurePvE  Status: {Player.HasStatus(true, StatusID.VariantCureSet)}");
+            ImGui.Text($"VariantCurePvE Slotted: {VariantCurePvE.Info.IsOnSlot}");
+            ImGui.Spacing();
+            ImGui.Text($"VariantRaisePvE Status: {Player.HasStatus(true, StatusID.VariantRampartSet)}");
+            ImGui.Spacing();
+            ImGui.Text($"VariantRaiseIiPvE Status: {Player.HasStatus(true, StatusID.VariantRaiseSet)}");
+            ImGui.Spacing();
+            ImGui.Text($"VariantRampartPvE Status: {Player.HasStatus(true, StatusID.VariantRaiseSet)}");
+            ImGui.Spacing();
+            ImGui.Spacing();
+            ImGui.Text($"Sildihn Subterrane: {SildihnSubterrane}");
+            ImGui.Text($"Mount Rokkon: {MountRokkon}");
+            ImGui.Text($"Aloalo Island: {AloaloIsland}");
+            ImGui.Spacing();
+        }
+    }
+
     public override bool ProvokeAbility(IAction nextGCD, out IAction? act)
     {
         if (VariantUltimatumPvE.CanUse(out act, skipStatusProvideCheck: true))
@@ -18,14 +54,20 @@ internal class VariantDefault : VariantRotation
 
     public override bool AttackAbility(IAction nextGCD, out IAction? act)
     {
-        if (VariantSpiritDartPvE_33863.CanUse(out act, skipAoeCheck: true))
+        if (VariantSpiritDartPvE_33863.Info.IsOnSlot)
         {
-            return true;
+            if (VariantSpiritDartPvE_33863.CanUse(out act, skipAoeCheck: true))
+            {
+                return true;
+            }
         }
 
-        if (VariantSpiritDartPvE.CanUse(out act, skipAoeCheck: true))
+        if (VariantSpiritDartPvE.Info.IsOnSlot)
         {
-            return true;
+            if (VariantSpiritDartPvE.CanUse(out act, skipAoeCheck: true))
+            {
+                return true;
+            }
         }
 
         return base.AttackAbility(nextGCD, out act);
@@ -33,14 +75,20 @@ internal class VariantDefault : VariantRotation
 
     public override bool DefenseSingleAbility(IAction nextGCD, out IAction? act)
     {
-        if (VariantRampartPvE_33864.CanUse(out act, skipStatusProvideCheck: true))
+        if (VariantRampartPvE_33864.Info.IsOnSlot)
         {
-            return true;
+            if (VariantRampartPvE_33864.CanUse(out act, skipStatusProvideCheck: true))
+            {
+                return true;
+            }
         }
 
-        if (VariantRampartPvE.CanUse(out act, skipStatusProvideCheck: true))
+        if (VariantRampartPvE.Info.IsOnSlot)
         {
-            return true;
+            if (VariantRampartPvE.CanUse(out act, skipStatusProvideCheck: true))
+            {
+                return true;
+            }
         }
 
         return base.DefenseSingleAbility(nextGCD, out act);
@@ -48,14 +96,20 @@ internal class VariantDefault : VariantRotation
 
     public override bool GeneralAbility(IAction nextGCD, out IAction? act)
     {
-        if (VariantRampartPvE_33864.CanUse(out act))
+        if (VariantRampartPvE_33864.Info.IsOnSlot)
         {
-            return true;
+            if (VariantRampartPvE_33864.CanUse(out act))
+            {
+                return true;
+            }
         }
 
-        if (VariantRampartPvE.CanUse(out act))
+        if (VariantRampartPvE.Info.IsOnSlot)
         {
-            return true;
+            if (VariantRampartPvE.CanUse(out act))
+            {
+                return true;
+            }
         }
 
         if (VariantUltimatumPvE.CanUse(out act))
@@ -68,14 +122,20 @@ internal class VariantDefault : VariantRotation
 
     public override bool HealSingleGCD(out IAction? act)
     {
-        if (VariantCurePvE_33862.CanUse(out act, skipStatusProvideCheck: true))
+        if (VariantCurePvE_33862.Info.IsOnSlot)
         {
-            return true;
+            if (VariantCurePvE_33862.CanUse(out act, skipStatusProvideCheck: true))
+            {
+                return true;
+            }
         }
 
-        if (VariantCurePvE.CanUse(out act, skipStatusProvideCheck: true))
+        if (VariantCurePvE.Info.IsOnSlot)
         {
-            return true;
+            if (VariantCurePvE.CanUse(out act, skipStatusProvideCheck: true))
+            {
+                return true;
+            }
         }
 
         return base.HealSingleGCD(out act);

--- a/RotationSolver.Basic/DataCenter.cs
+++ b/RotationSolver.Basic/DataCenter.cs
@@ -210,6 +210,28 @@ internal static class DataCenter
         && Player.Object.HasStatus(false, StatusID.DutiesAsAssigned_4228);
     #endregion
 
+    #region Variant Dungeon
+    /// <summary>
+    /// 
+    /// </summary>
+    public static bool SildihnSubterrane => IsInTerritory(1069);
+
+    /// <summary>
+    /// 
+    /// </summary>
+    public static bool MountRokkon => IsInTerritory(1137);
+
+    /// <summary>
+    /// 
+    /// </summary>
+    public static bool AloaloIsland => IsInTerritory(1176);
+
+    /// <summary>
+    /// 
+    /// </summary>
+    public static bool InVariantDungeon => AloaloIsland || MountRokkon || SildihnSubterrane;
+    #endregion
+
     public static AutoStatus MergedStatus => AutoStatus | CommandStatus;
 
     public static AutoStatus AutoStatus { get; set; } = AutoStatus.None;

--- a/RotationSolver.Basic/Rotations/Duties/DutyRotation.cs
+++ b/RotationSolver.Basic/Rotations/Duties/DutyRotation.cs
@@ -169,6 +169,26 @@ public partial class DutyRotation : IDisposable
     public static bool IsMoving => DataCenter.IsMoving;
 
     /// <summary>
+    /// 
+    /// </summary>
+    public static bool SildihnSubterrane => DataCenter.SildihnSubterrane;
+
+    /// <summary>
+    /// 
+    /// </summary>
+    public static bool MountRokkon => DataCenter.MountRokkon;
+
+    /// <summary>
+    /// 
+    /// </summary>
+    public static bool AloaloIsland => DataCenter.AloaloIsland;
+
+    /// <summary>
+    /// 
+    /// </summary>
+    public static bool InVariantDungeon => DataCenter.InVariantDungeon;
+
+    /// <summary>
     /// This is the player.
     /// </summary>
     protected static IPlayerCharacter Player => ECommons.GameHelpers.Player.Object;

--- a/RotationSolver/UI/RotationConfigWindow.cs
+++ b/RotationSolver/UI/RotationConfigWindow.cs
@@ -355,11 +355,18 @@ public partial class RotationConfigWindow : Window
                 }
                 else if (item == RotationConfigWindowTab.Duty && Player.Object != null)
                 {
-                    if (!DataCenter.IsInDuty)
+                    if (!DataCenter.IsInDuty || DataCenter.CurrentDutyRotation == null)
                     {
                         continue;
                     }
-                    displayName = $"Duty - {DutyRotation.ActivePhantomJob}"; // Use the active phantom job name for Duty tab
+
+                    displayName = true switch
+                    {
+                        var _ when DataCenter.IsInOccultCrescentOp => $"Duty - {DutyRotation.ActivePhantomJob}",
+                        var _ when DataCenter.InVariantDungeon => "Duty - Variant",
+                        var _ when DataCenter.IsInBozja => "Duty - Bozja",
+                        _ => "Duty",
+                    };
                 }
 
                 // Reverse the order of these to do the non-interop check first
@@ -3697,6 +3704,11 @@ public partial class RotationConfigWindow : Window
         ImGui.Text($"ThiefLevel: {DutyRotation.ThiefLevel}");
         ImGui.Text($"SamuraiLevel: {DutyRotation.SamuraiLevel}");
         ImGui.Text($"GeomancerLevel: {DutyRotation.GeomancerLevel}");
+        ImGui.Spacing();
+        ImGui.Text($"InVariantDungeon: {DataCenter.InVariantDungeon}");
+        ImGui.Text($"AloaloIsland: {DataCenter.AloaloIsland}");
+        ImGui.Text($"MountRokkon: {DataCenter.MountRokkon}");
+        ImGui.Text($"SildihnSubterrane: {DataCenter.SildihnSubterrane}");
         ImGui.Spacing();
     }
 

--- a/RotationSolver/Updaters/RotationUpdater.cs
+++ b/RotationSolver/Updaters/RotationUpdater.cs
@@ -446,7 +446,6 @@ internal static class RotationUpdater
         return false;
     }
 
-
     private static void PrintLoadedAssemblies(IEnumerable<string>? assemblies)
     {
         if (assemblies == null)
@@ -665,6 +664,13 @@ internal static class RotationUpdater
     {
         if (!DutyRotations.TryGetValue(Svc.ClientState.TerritoryType, out Type[]? rotations))
         {
+            // Unload the current duty rotation if leaving a duty
+            if (DataCenter.CurrentDutyRotation != null)
+            {
+                DataCenter.CurrentDutyRotation.Dispose();
+                DataCenter.CurrentDutyRotation = null;
+                _curDutyRotationName = string.Empty;
+            }
             return;
         }
 


### PR DESCRIPTION
- Added various status tracking for Variant Rotation
- Added Variant Duty tracking logic to DataCenter and Debug menu
- Fixed Duty Rotaiton not unloading properly so when you exit one duty with a Duty Rotation and go into another one it would not load the new one and therefore not use any Duty Actions
- Fixed UI display for Duty Rotation info