### PR TITLE
Fixes for rare BRD crash and changed DRG Life Surge prioritization, and more

### DIFF
--- a/RebornRotations/Melee/DRG_Default.cs
+++ b/RebornRotations/Melee/DRG_Default.cs
@@ -137,7 +137,7 @@ public sealed class DRG_Default : DragoonRotation
                 || (!DisembowelPvE.EnoughLevel && nextGCD.IsTheSameTo(true, VorpalThrustPvE))
                 || (!FullThrustPvE.EnoughLevel && nextGCD.IsTheSameTo(true, VorpalThrustPvE, DisembowelPvE))
                 || (!LanceChargePvE.EnoughLevel && nextGCD.IsTheSameTo(true, DisembowelPvE, FullThrustPvE))
-                || (!BattleLitanyPvE.EnoughLevel && nextGCD.IsTheSameTo(true, ChaosThrustPvE, FullThrustPvE)))
+                || (!BattleLitanyPvE.EnoughLevel && nextGCD.IsTheSameTo(true, FullThrustPvE)))
             {
                 if (LifeSurgePvE.CanUse(out act, usedUp: true))
                 {

--- a/RebornRotations/Ranged/BRD_Default.cs
+++ b/RebornRotations/Ranged/BRD_Default.cs
@@ -15,6 +15,9 @@ public sealed class BRD_Default : BardRotation
     [RotationConfig(CombatType.PvE, Name = "Attempt to assign Raging Strikes, Battle Voice, and Radiant Finale to specific ogcd slots (Experimental)")]
     public bool OGCDTimers { get; set; } = false;
 
+    [RotationConfig(CombatType.PvE, Name = "Only use DOTs on targets with Boss Icon")]
+    public bool DOTBoss { get; set; } = false;
+
     [Range(1, 45, ConfigUnitType.Seconds, 1)]
     [RotationConfig(CombatType.PvE, Name = "Wanderer's Minuet Uptime")]
     public float WANDTime { get; set; } = 43;
@@ -379,7 +382,7 @@ public sealed class BRD_Default : BardRotation
                 return true;
             }
 
-            if (CurrentTarget?.WillStatusEndGCD(1, 0.5f, true, StatusID.Windbite, StatusID.Stormbite, StatusID.VenomousBite, StatusID.CausticBite) ?? false)
+            if (BlastArrowPvE.Target.Target?.WillStatusEndGCD(1, 0.5f, true, StatusID.Windbite, StatusID.Stormbite, StatusID.VenomousBite, StatusID.CausticBite) ?? false)
             {
                 return false;
             }
@@ -406,23 +409,35 @@ public sealed class BRD_Default : BardRotation
             return true;
         }
 
-        if (IronJawsPvE.EnoughLevel && CurrentTarget?.HasStatus(true, StatusID.Windbite, StatusID.Stormbite) == true && CurrentTarget?.HasStatus(true, StatusID.VenomousBite, StatusID.CausticBite) == true)
+        if (StormbitePvE.CanUse(out act, skipTTKCheck: true))
         {
-            // Do not use WindbitePvE or VenomousBitePvE if both statuses are present and IronJawsPvE has enough level
-        }
-        else
-        {
-            if (WindbitePvE.CanUse(out act, skipTTKCheck: true))
+            if ((DOTBoss && StormbitePvE.Target.Target.IsBossFromIcon()) || !DOTBoss)
             {
-                return true;
-            }
-
-            if (VenomousBitePvE.CanUse(out act, skipTTKCheck: true))
-            {
-                return true;
+                if (IronJawsPvE.EnoughLevel && StormbitePvE.Target.Target.HasStatus(true, StatusID.Windbite, StatusID.Stormbite) == false)
+                {
+                    return true;
+                }
+                if (!IronJawsPvE.EnoughLevel)
+                {
+                    return true;
+                }
             }
         }
 
+        if (CausticBitePvE.CanUse(out act, skipTTKCheck: true))
+        {
+            if ((DOTBoss && CausticBitePvE.Target.Target.IsBossFromIcon()) || !DOTBoss)
+            {
+                if (IronJawsPvE.EnoughLevel && CausticBitePvE.Target.Target.HasStatus(true, StatusID.VenomousBite, StatusID.CausticBite) == false)
+                {
+                    return true;
+                }
+                if (!IronJawsPvE.EnoughLevel)
+                {
+                    return true;
+                }
+            }
+        }
 
         if (RefulgentArrowPvE.CanUse(out act, skipComboCheck: true))
         {

--- a/RotationSolver.Basic/Actions/ActionTargetInfo.cs
+++ b/RotationSolver.Basic/Actions/ActionTargetInfo.cs
@@ -1754,7 +1754,7 @@ public struct ActionTargetInfo(IBaseAction action)
             }
 
             // Filter out characters marked with stop markers
-            if (Service.Config.FilterStopMark)
+            if (Service.Config.FilterStopMark && !DataCenter.IsPvP)
             {
                 IEnumerable<IBattleChara> filteredCharacters = MarkingHelper.FilterStopCharacters(battleChara);
                 // Manual Any() check

--- a/RotationSolver.Basic/Helpers/ObjectHelper.cs
+++ b/RotationSolver.Basic/Helpers/ObjectHelper.cs
@@ -1,6 +1,7 @@
 ﻿using Dalamud.Game.ClientState.Conditions;
 using Dalamud.Game.ClientState.Objects.Enums;
 using Dalamud.Game.ClientState.Objects.SubKinds;
+using Dalamud.Game.ClientState.Objects.Types;
 using ECommons;
 using ECommons.DalamudServices;
 using ECommons.ExcelServices;
@@ -9,6 +10,7 @@ using ECommons.GameHelpers;
 using ECommons.Logging;
 using ExCSS;
 using FFXIVClientStructs.FFXIV.Client.Game;
+using FFXIVClientStructs.FFXIV.Client.Game.Character;
 using FFXIVClientStructs.FFXIV.Client.Game.Event;
 using FFXIVClientStructs.FFXIV.Common.Component.BGCollision;
 using Lumina.Excel.Sheets;
@@ -377,8 +379,47 @@ public static class ObjectHelper
 
     internal static unsafe bool IsEnemy(this IGameObject obj)
     {
-        return obj != null
-        && ActionManager.CanUseActionOnTarget((uint)ActionID.BlizzardPvE, obj.Struct());
+        if (obj == null)
+        {
+            return false;
+        }
+
+        if (!obj.IsTargetable)
+        {
+            return false;
+        }
+
+        if (ActionManager.CanUseActionOnTarget((uint)ActionID.BlizzardPvE, obj.Struct()))
+        {
+            return true;
+        }
+
+        return false;
+    }
+
+    internal static unsafe bool IsFriendly(this IGameObject obj)
+    {
+        if (obj == null)
+        {
+            return false;
+        }
+
+        if (!obj.IsTargetable)
+        {
+            return false;
+        }
+
+        if (ActionManager.CanUseActionOnTarget((uint)ActionID.CurePvE, obj.Struct()))
+        {
+            return true;
+        }
+
+        if (ActionManager.CanUseActionOnTarget((uint)ActionID.RaisePvE, obj.Struct()))
+        {
+            return true;
+        }
+
+        return false;
     }
 
     internal static unsafe bool IsAllianceMember(this ICharacter obj)


### PR DESCRIPTION
- Reorganized Stormbite and Caustic Bite logic to ensure there is always a valid target before checking statuslist
- Removed Chaos Thrust from Life Surge logic
- Sorted DataCenter
- Disabled StopMarker logic in PvP