### PR TITLE
BRD fixes, GNB fixes, action category fixes, fixes for low level combat

### DIFF
--- a/RebornRotations/Ranged/BRD_Default.cs
+++ b/RebornRotations/Ranged/BRD_Default.cs
@@ -409,32 +409,64 @@ public sealed class BRD_Default : BardRotation
             return true;
         }
 
-        if (StormbitePvE.CanUse(out act, skipTTKCheck: true))
+        if (StormbitePvE.EnoughLevel)
         {
-            if ((DOTBoss && StormbitePvE.Target.Target.IsBossFromIcon()) || !DOTBoss)
+            if (StormbitePvE.CanUse(out act))
             {
-                if (IronJawsPvE.EnoughLevel && StormbitePvE.Target.Target.HasStatus(true, StatusID.Windbite, StatusID.Stormbite) == false)
+                if ((DOTBoss && StormbitePvE.Target.Target.IsBossFromIcon()) || !DOTBoss)
                 {
-                    return true;
+                    if (StormbitePvE.Target.Target.HasStatus(true, StatusID.Stormbite) == false)
+                    {
+                        return true;
+                    }
                 }
-                if (!IronJawsPvE.EnoughLevel)
+            }
+        }
+        if (CausticBitePvE.EnoughLevel)
+        {
+            if (CausticBitePvE.CanUse(out act))
+            {
+                if ((DOTBoss && CausticBitePvE.Target.Target.IsBossFromIcon()) || !DOTBoss)
                 {
-                    return true;
+                    if (CausticBitePvE.Target.Target.HasStatus(true, StatusID.VenomousBite) == false)
+                    {
+                        return true;
+                    }
                 }
             }
         }
 
-        if (CausticBitePvE.CanUse(out act, skipTTKCheck: true))
+        if (!StormbitePvE.EnoughLevel)
         {
-            if ((DOTBoss && CausticBitePvE.Target.Target.IsBossFromIcon()) || !DOTBoss)
+            if (WindbitePvE.CanUse(out act))
             {
-                if (IronJawsPvE.EnoughLevel && CausticBitePvE.Target.Target.HasStatus(true, StatusID.VenomousBite, StatusID.CausticBite) == false)
+                if ((DOTBoss && WindbitePvE.Target.Target.IsBossFromIcon()) || !DOTBoss)
                 {
-                    return true;
+                    if (IronJawsPvE.EnoughLevel && WindbitePvE.Target.Target.HasStatus(true, StatusID.Windbite) == false)
+                    {
+                        return true;
+                    }
+                    if (!IronJawsPvE.EnoughLevel)
+                    {
+                        return true;
+                    }
                 }
-                if (!IronJawsPvE.EnoughLevel)
+            }
+        }
+        if (!CausticBitePvE.EnoughLevel)
+        {
+            if (VenomousBitePvE.CanUse(out act))
+            {
+                if ((DOTBoss && VenomousBitePvE.Target.Target.IsBossFromIcon()) || !DOTBoss)
                 {
-                    return true;
+                    if (IronJawsPvE.EnoughLevel && VenomousBitePvE.Target.Target.HasStatus(true, StatusID.CausticBite) == false)
+                    {
+                        return true;
+                    }
+                    if (!IronJawsPvE.EnoughLevel)
+                    {
+                        return true;
+                    }
                 }
             }
         }

--- a/RebornRotations/Tank/GNB_Default.cs
+++ b/RebornRotations/Tank/GNB_Default.cs
@@ -156,9 +156,12 @@ public sealed class GNB_Default : GunbreakerRotation
     [RotationDesc(ActionID.AuroraPvE)]
     protected override bool HealSingleAbility(IAction nextGCD, out IAction? act)
     {
-        if (AuroraPvE.CanUse(out act, usedUp: true))
+        if (!IsLastAbility(ActionID.AuroraPvE) && AuroraPvE.CanUse(out act, usedUp: Player.GetHealthRatio() < 0.9))
         {
-            return true;
+            if (AuroraPvE.Target.Target.HasStatus(true, StatusID.Aurora) == false)
+            {
+                return true;
+            }
         }
 
         return base.HealSingleAbility(nextGCD, out act);

--- a/RotationSolver.Basic/DataCenter.cs
+++ b/RotationSolver.Basic/DataCenter.cs
@@ -6,6 +6,7 @@ using ECommons.Logging;
 using FFXIVClientStructs.FFXIV.Client.Game;
 using FFXIVClientStructs.FFXIV.Client.Game.Character;
 using FFXIVClientStructs.FFXIV.Client.Game.Fate;
+using FFXIVClientStructs.FFXIV.Client.Game.UI;
 using Lumina.Excel.Sheets;
 using RotationSolver.Basic.Configuration;
 using RotationSolver.Basic.Configuration.Conditions;
@@ -345,7 +346,7 @@ internal static class DataCenter
 
     #region Territory Info Tracking
 
-    public static TerritoryInfo? Territory { get; set; }
+    public static Data.TerritoryInfo? Territory { get; set; }
     public static ushort TerritoryID => Svc.ClientState.TerritoryType;
 
     public static bool IsPvP => Territory?.IsPvP ?? false;
@@ -512,6 +513,28 @@ internal static class DataCenter
 
             return radius;
         }
+    }
+
+    /// <summary>
+    /// This quest is needed to do the quests that give Job Stones.
+    /// </summary>
+    public static unsafe bool SylphManagementFinished()
+    {
+        if (UIState.Instance()->IsUnlockLinkUnlockedOrQuestCompleted(66049))
+            return true;
+
+        return false;
+    }
+
+    /// <summary>
+    /// Returns true if the current class is a base class (pre-jobstone), otherwise false.
+    /// </summary>
+    public static bool BaseClass()
+    {
+        // FFXIV base classes: 1-7, 26, 29 (GLA, PGL, MRD, LNC, ARC, CNJ, THM, ACN, ROG)
+        if (Svc.ClientState.LocalPlayer == null) return false;
+        var rowId = Svc.ClientState.LocalPlayer.ClassJob.RowId;
+        return (rowId >= 1 && rowId <= 7) || rowId == 26 || rowId == 29;
     }
     #endregion
 

--- a/RotationSolver.Basic/Rotations/Basic/BardRotation.cs
+++ b/RotationSolver.Basic/Rotations/Basic/BardRotation.cs
@@ -137,7 +137,7 @@ public partial class BardRotation
 
     static partial void ModifyVenomousBitePvE(ref ActionSetting setting)
     {
-        setting.TargetStatusProvide = [StatusID.VenomousBite, StatusID.CausticBite];
+        setting.TargetStatusProvide = [StatusID.VenomousBite];
         setting.CreateConfig = () => new ActionConfig()
         {
             TimeToKill = 0,
@@ -175,7 +175,7 @@ public partial class BardRotation
 
     static partial void ModifyWindbitePvE(ref ActionSetting setting)
     {
-        setting.TargetStatusProvide = [StatusID.Windbite, StatusID.Stormbite];
+        setting.TargetStatusProvide = [StatusID.Windbite];
         setting.UnlockedByQuestID = 65612;
         setting.CreateConfig = () => new ActionConfig()
         {
@@ -289,7 +289,7 @@ public partial class BardRotation
 
     static partial void ModifyCausticBitePvE(ref ActionSetting setting)
     {
-        setting.TargetStatusProvide = [StatusID.VenomousBite, StatusID.CausticBite];
+        setting.TargetStatusProvide = [StatusID.CausticBite];
         setting.StatusProvide = [StatusID.HawksEye_3861];
         setting.CreateConfig = () => new ActionConfig()
         {
@@ -299,7 +299,7 @@ public partial class BardRotation
 
     static partial void ModifyStormbitePvE(ref ActionSetting setting)
     {
-        setting.TargetStatusProvide = [StatusID.Windbite, StatusID.Stormbite];
+        setting.TargetStatusProvide = [StatusID.Stormbite];
         setting.StatusProvide = [StatusID.HawksEye_3861];
         setting.CreateConfig = () => new ActionConfig()
         {

--- a/RotationSolver.Basic/Rotations/Basic/BlueMageRotation.cs
+++ b/RotationSolver.Basic/Rotations/Basic/BlueMageRotation.cs
@@ -180,12 +180,12 @@ public partial class BlueMageRotation
             List<uint> idList = new List<uint>(ActiveActions.Length);
             foreach (var a in ActiveActions)
             {
-                if (a.Info.SpellUnlocked)
+                if (a.Info.IsQuestUnlocked())
                 {
                     idList.Add(a.Action.RowId);
                 }
             }
-            uint[] idArray = idList.ToArray();
+            uint[] idArray = [.. idList];
 
             if (idArray.Equals(GetBlueMageActions()))
             {

--- a/RotationSolver.Basic/Rotations/Basic/MonkRotation.cs
+++ b/RotationSolver.Basic/Rotations/Basic/MonkRotation.cs
@@ -38,14 +38,29 @@ public partial class MonkRotation
     public static int OpoOpoFury => JobGauge.OpoOpoFury;
 
     /// <summary>
+    /// 
+    /// </summary>
+    public static bool OpoOpoUnlocked => Player.Level >= 50;
+
+    /// <summary>
     /// Gets the amount of available Raptor Fury stacks.
     /// </summary>
     public static int RaptorFury => JobGauge.RaptorFury;
 
     /// <summary>
+    /// 
+    /// </summary>
+    public static bool RaptorUnlocked => Player.Level >= 18;
+
+    /// <summary>
     /// Gets the amount of available Coeurl Fury stacks.
     /// </summary>
     public static int CoeurlFury => JobGauge.CoeurlFury;
+
+    /// <summary>
+    /// 
+    /// </summary>
+    public static bool CoeurlUnlocked => Player.Level >= 30;
 
     /// <summary>
     /// Determines whether all elements in the <see cref="BeastChakras"/> array are the same.
@@ -240,14 +255,14 @@ public partial class MonkRotation
 
     static partial void ModifyTrueStrikePvE(ref ActionSetting setting)
     {
-        setting.ActionCheck = () => (InRaptorForm || HasFormlessFist || HasPerfectBalance) && RaptorFury > 0;
+        setting.ActionCheck = () => (InRaptorForm || HasFormlessFist || HasPerfectBalance) && (RaptorFury > 0 || !RaptorUnlocked);
         setting.StatusProvide = [StatusID.CoeurlForm];
         setting.MPOverride = () => 0;
     }
 
     static partial void ModifySnapPunchPvE(ref ActionSetting setting)
     {
-        setting.ActionCheck = () => (InCoeurlForm || HasFormlessFist || HasPerfectBalance) && CoeurlFury > 0;
+        setting.ActionCheck = () => (InCoeurlForm || HasFormlessFist || HasPerfectBalance) && (CoeurlFury > 0 || !CoeurlUnlocked);
         setting.StatusProvide = [StatusID.OpoopoForm];
     }
 
@@ -287,7 +302,7 @@ public partial class MonkRotation
 
     static partial void ModifyRockbreakerPvE(ref ActionSetting setting)
     {
-        setting.ActionCheck = () => InCoeurlForm || HasFormlessFist || HasPerfectBalance;
+        setting.ActionCheck = () => (InCoeurlForm || HasFormlessFist || HasPerfectBalance);
         setting.StatusProvide = [StatusID.OpoopoForm];
         setting.UnlockedByQuestID = 66597;
         setting.CreateConfig = () => new ActionConfig()
@@ -518,19 +533,19 @@ public partial class MonkRotation
     static partial void ModifyLeapingOpoPvE(ref ActionSetting setting)
     {
         setting.StatusProvide = [StatusID.RaptorForm];
-        setting.ActionCheck = () => (InOpoopoForm || HasFormlessFist || HasPerfectBalance) && OpoOpoFury > 0;
+        setting.ActionCheck = () => (InOpoopoForm || HasFormlessFist || HasPerfectBalance) && (OpoOpoFury > 0 || !OpoOpoUnlocked);
     }
 
     static partial void ModifyRisingRaptorPvE(ref ActionSetting setting)
     {
         setting.StatusProvide = [StatusID.CoeurlForm];
-        setting.ActionCheck = () => (InRaptorForm || HasFormlessFist || HasPerfectBalance) && RaptorFury > 0;
+        setting.ActionCheck = () => (InRaptorForm || HasFormlessFist || HasPerfectBalance) && (RaptorFury > 0 || !RaptorUnlocked);
     }
 
     static partial void ModifyPouncingCoeurlPvE(ref ActionSetting setting)
     {
         setting.StatusProvide = [StatusID.OpoopoForm];
-        setting.ActionCheck = () => (InCoeurlForm || HasFormlessFist || HasPerfectBalance) && CoeurlFury > 0;
+        setting.ActionCheck = () => (InCoeurlForm || HasFormlessFist || HasPerfectBalance) && (CoeurlFury > 0 || !CoeurlUnlocked);
     }
 
     static partial void ModifyElixirBurstPvE(ref ActionSetting setting)

--- a/RotationSolver.Basic/Rotations/CustomRotation_OtherInfo.cs
+++ b/RotationSolver.Basic/Rotations/CustomRotation_OtherInfo.cs
@@ -2,6 +2,7 @@
 using Dalamud.Game.ClientState.Objects.SubKinds;
 using Dalamud.Plugin.Services;
 using ECommons.DalamudServices;
+using ECommons.ExcelServices;
 using FFXIVClientStructs.FFXIV.Client.Game.UI;
 
 namespace RotationSolver.Basic.Rotations;
@@ -65,6 +66,11 @@ public partial class CustomRotation
     /// </summary>
     [Description("Player's MP")]
     public static uint CurrentMp => DataCenter.CurrentMp;
+
+    /// <summary>
+    /// IsPGL.
+    /// </summary>
+    public static bool IsJobstoneless => DataCenter.BaseClass();
 
     /// <summary>
     /// Determines if the current combat time is within an even minute.

--- a/RotationSolver/UI/RotationConfigWindow.cs
+++ b/RotationSolver/UI/RotationConfigWindow.cs
@@ -2223,10 +2223,12 @@ public partial class RotationConfigWindow : Window
                         ImGui.TextColored(ImGuiColors.DalamudRed, "Target is not a valid BattleChara.");
                         return;
                     }
-
+                    ImGui.Text($"Can Use: {action.CanUse(out _)} ");
+                    ImGui.Spacing();
                     ImGui.Text("ID: " + action.Info.ID);
                     ImGui.Text("AdjustedID: " + Service.GetAdjustedActionId(action.Info.ID));
-                    ImGui.Text($"Can Use: {action.CanUse(out _)} ");
+                    ImGui.Text($"IsQuestUnlocked: {action.Info.IsQuestUnlocked()} ({action.Action.UnlockLink.RowId})");
+                    ImGui.Text("EnoughLevel: " + action.EnoughLevel);
                     ImGui.Text("AoeCount: " + action.Config.AoeCount);
                     ImGui.Text("ShouldCheckStatus: " + action.Config.ShouldCheckStatus);
                     ImGui.Text("ShouldCheckTargetStatus: " + action.Config.ShouldCheckTargetStatus);
@@ -2242,6 +2244,7 @@ public partial class RotationConfigWindow : Window
                     }
                     ImGui.Text("Cast Time: " + action.Info.CastTime);
                     ImGui.Text("MP: " + action.Info.MPNeed);
+                    ImGui.Text("HasEnoughMP: " + action.Info.HasEnoughMP());
                     ImGui.Text("AttackType: " + action.Info.AttackType);
                     ImGui.Text("Level: " + action.Info.Level);
                     ImGui.Text("Range: " + action.Info.Range);
@@ -2256,7 +2259,6 @@ public partial class RotationConfigWindow : Window
 
                     ImGui.Text("IgnoreCastCheck:" + action.CanUse(out _, skipCastingCheck: true));
                     ImGui.Text("Target Name: " + action.Target.Target?.Name ?? string.Empty);
-                    ImGui.Text($"SpellUnlocked: {action.Info.SpellUnlocked} ({action.Action.UnlockLink.RowId})");
                 }
                 catch (Exception ex)
                 {


### PR DESCRIPTION
- Updated logic in `BRD_Default` and `GNB_Default` for ability usage, including status checks and health conditions.
- Enhanced `ActionBasicInfo` with new properties for quest unlocks.
- Modified `DataCenter` to include new methods for job stone quests and base class checks.
- Simplified target status checks in `BardRotation` methods.
- Switched to `IsQuestUnlocked` in `BlueMageRotation` for action filtering.
- Added level-based checks for abilities in `MonkRotation`.
- Introduced jobstoneless check in `CustomRotation`.
- Improved UI in `RotationConfigWindow` to display action usability details.