### PR TITLE
Update for VPR, DRG, and BLM. Added options for VPR adn DRG, hotfix for triplecast on BLM.

### DIFF
--- a/RebornRotations/Magical/BLM_Default.cs
+++ b/RebornRotations/Magical/BLM_Default.cs
@@ -154,7 +154,7 @@ public class BLM_Default : BlackMageRotation
     [RotationDesc(ActionID.TransposePvE, ActionID.LeyLinesPvE, ActionID.RetracePvE)]
     protected override bool GeneralAbility(IAction nextGCD, out IAction? act)
     {
-        if (IsMoving && HasHostilesInRange && TriplecastPvE.CanUse(out act, usedUp: true))
+        if (IsMoving && HasHostilesInRange && InCombat && TriplecastPvE.CanUse(out act, usedUp: true))
         {
             return true;
         }

--- a/RebornRotations/Magical/BLM_zAlpha.cs
+++ b/RebornRotations/Magical/BLM_zAlpha.cs
@@ -116,7 +116,7 @@ public class BLM_zAlpha : BlackMageRotation
     [RotationDesc(ActionID.TransposePvE, ActionID.LeyLinesPvE, ActionID.RetracePvE)]
     protected override bool GeneralAbility(IAction nextGCD, out IAction? act)
     {
-        if (IsMoving && HasHostilesInRange && TriplecastPvE.CanUse(out act, usedUp: true))
+        if (IsMoving && HasHostilesInRange && InCombat && TriplecastPvE.CanUse(out act, usedUp: true))
         {
             return true;
         }

--- a/RebornRotations/Melee/DRG_Reborn.cs
+++ b/RebornRotations/Melee/DRG_Reborn.cs
@@ -1,14 +1,22 @@
 namespace RebornRotations.Melee;
 
-[Rotation("Default", CombatType.PvE, GameVersion = "7.25")]
-[SourceCode(Path = "main/BasicRotations/Melee/DRG_Default.cs")]
+[Rotation("Reborn", CombatType.PvE, GameVersion = "7.25")]
+[SourceCode(Path = "main/RebornRotations/Melee/DRG_Reborn.cs")]
 [Api(5)]
 
-public sealed class DRG_Default : DragoonRotation
+public sealed class DRG_Reborn : DragoonRotation
 {
     #region Config Options
     [RotationConfig(CombatType.PvE, Name = "Use Doom Spike for damage uptime if out of melee range even if it breaks combo")]
     public bool DoomSpikeWhenever { get; set; } = true;
+
+    [Range(1, 20, ConfigUnitType.Yalms)]
+    [RotationConfig(CombatType.PvE, Name = "Max distance you need to be from the target for Stardiver useage")]
+    public float StardiverDistance { get; set; } = 20;
+
+    [Range(1, 20, ConfigUnitType.Yalms)]
+    [RotationConfig(CombatType.PvE, Name = "Max distance you need to be from the target for Dragonfire Dive useage")]
+    public float DragonfireDiveDistance { get; set; } = 20;
     #endregion
 
     private static bool InBurstStatus => Player.HasStatus(true, StatusID.BattleLitany);
@@ -71,7 +79,10 @@ public sealed class DRG_Default : DragoonRotation
         {
             if (StardiverPvE.CanUse(out act))
             {
-                return true;
+                if (StardiverPvE.Target.Target.DistanceToPlayer() <= StardiverDistance)
+                {
+                    return true;
+                }
             }
         }
 
@@ -155,7 +166,10 @@ public sealed class DRG_Default : DragoonRotation
         {
             if (DragonfireDivePvE.CanUse(out act))
             {
-                return true;
+                if (DragonfireDivePvE.Target.Target.DistanceToPlayer() <= DragonfireDiveDistance)
+                {
+                    return true;
+                }
             }
         }
 

--- a/RebornRotations/Melee/VPR_Reborn.cs
+++ b/RebornRotations/Melee/VPR_Reborn.cs
@@ -1,9 +1,9 @@
 ﻿namespace RebornRotations.Melee;
 
-[Rotation("Default", CombatType.PvE, GameVersion = "7.25")]
-[SourceCode(Path = "main/BasicRotations/Melee/VPR_Default.cs")]
+[Rotation("Reborn", CombatType.PvE, GameVersion = "7.25")]
+[SourceCode(Path = "main/RebornRotations/Melee/VPR_Reborn.cs")]
 [Api(5)]
-public sealed class VPR_Default : ViperRotation
+public sealed class VPR_Reborn : ViperRotation
 {
     #region Config Options
 
@@ -40,6 +40,9 @@ public sealed class VPR_Default : ViperRotation
 
     [RotationConfig(CombatType.PvE, Name = "Attempt to prevent regular combo from dropping (Experimental)")]
     public bool PreserveCombo { get; set; } = false;
+
+    [RotationConfig(CombatType.PvE, Name = "Only allow switching to AOE rotation if your last combo action increased gauge (Experimental)")]
+    public bool STtoAOEBetaLogic { get; set; } = false;
     #endregion
 
     #region Additional oGCD Logic
@@ -463,23 +466,25 @@ public sealed class VPR_Default : ViperRotation
             if (HuntersBitePvE.CanUse(out act, skipStatusProvideCheck: true, skipComboCheck: true))
                 return true;
         }
-        // aoe 1
-        switch ((HasSteel, HasReavers))
+        if (!STtoAOEBetaLogic || (STtoAOEBetaLogic && (IsLastComboAction() || IsLastComboAction(ActionID.FlankstingStrikePvE, ActionID.FlanksbaneFangPvE, ActionID.HindsbaneFangPvE, ActionID.HindstingStrikePvE, ActionID.JaggedMawPvE, ActionID.BloodiedMawPvE))))
         {
-            case (true, _):
-                if (SteelMawPvE.CanUse(out act))
-                    return true;
-                break;
-            case (_, true):
-                if (ReavingMawPvE.CanUse(out act))
-                    return true;
-                break;
-            case (false, false):
-                if (ReavingMawPvE.CanUse(out act))
-                    return true;
-                if (SteelMawPvE.CanUse(out act))
-                    return true;
-                break;
+            switch ((HasSteel, HasReavers))
+            {
+                case (true, _):
+                    if (SteelMawPvE.CanUse(out act))
+                        return true;
+                    break;
+                case (_, true):
+                    if (ReavingMawPvE.CanUse(out act))
+                        return true;
+                    break;
+                case (false, false):
+                    if (ReavingMawPvE.CanUse(out act))
+                        return true;
+                    if (SteelMawPvE.CanUse(out act))
+                        return true;
+                    break;
+            }
         }
 
         ////Single Target Dread Combo


### PR DESCRIPTION
- Added option to VPR to ensure last ST combo generates gauge before switching to AOE combo
- Added configs for Stardiver and Dragonfire Dive distance requirements
- Added InCombat check to Triplecast on BLM Default and Alpha