### PR TITLE
Improvements to healing and raise logic for Healers and OffRaise/OffHealers

### DIFF
--- a/RebornRotations/Healer/WHM_Default.cs
+++ b/RebornRotations/Healer/WHM_Default.cs
@@ -113,7 +113,7 @@ public sealed class WHM_Default : WhiteMageRotation
     protected override bool EmergencyAbility(IAction nextGCD, out IAction? act)
     {
         bool useLastThinAirCharge = ThinAirLastChargeUsage == ThinAirUsageStrategy.UseAllCharges || (ThinAirLastChargeUsage == ThinAirUsageStrategy.ReserveLastChargeForRaise && nextGCD == RaisePvE);
-        if (((nextGCD is IBaseAction action && action.Info.MPNeed >= ThinAirNeed) || (MergedStatus.HasFlag(AutoStatus.Raise) && Player.CurrentMp > 2400 && IsLastAction() == IsLastGCD())) &&
+        if (((nextGCD is IBaseAction action && action.Info.MPNeed >= ThinAirNeed) || (MergedStatus.HasFlag(AutoStatus.Raise) && IsLastAction() == IsLastGCD())) &&
             ThinAirPvE.CanUse(out act, usedUp: useLastThinAirCharge))
         {
             return true;

--- a/RebornRotations/Magical/RDM_Reborn.cs
+++ b/RebornRotations/Magical/RDM_Reborn.cs
@@ -1,11 +1,14 @@
 ﻿namespace RebornRotations.Magical;
 
 [Rotation("Reborn", CombatType.PvE, GameVersion = "7.25")]
-[SourceCode(Path = "main/BasicRotations/Magical/RDM_Reborn.cs")]
+[SourceCode(Path = "main/RebornRotations/Magical/RDM_Reborn.cs")]
 [Api(5)]
 public sealed class RDM_Reborn : RedMageRotation
 {
     #region Config Options
+    [RotationConfig(CombatType.PvE, Name = "Use GCDs to heal. (Ignored if there are no healers alive in party)")]
+    public bool GCDHeal { get; set; } = false;
+
     [RotationConfig(CombatType.PvE, Name = "Use Vercure for Dualcast when out of combat.")]
     public bool UseVercure { get; set; } = false;
 
@@ -460,4 +463,20 @@ public sealed class RDM_Reborn : RedMageRotation
         return base.GeneralGCD(out act);
     }
     #endregion
+
+    public override bool CanHealSingleSpell
+    {
+        get
+        {
+            int aliveHealerCount = 0;
+            IEnumerable<IBattleChara> healers = PartyMembers.GetJobCategory(JobRole.Healer);
+            foreach (IBattleChara h in healers)
+            {
+                if (!h.IsDead)
+                    aliveHealerCount++;
+            }
+
+            return base.CanHealSingleSpell && (GCDHeal || aliveHealerCount == 0);
+        }
+    }
 }

--- a/RebornRotations/Magical/SMN_Reborn.cs
+++ b/RebornRotations/Magical/SMN_Reborn.cs
@@ -8,7 +8,6 @@ namespace RebornRotations.Magical;
 [Api(5)]
 public sealed class SMN_Reborn : SummonerRotation
 {
-
     #region Config Options
 
     public enum SummonOrderType : byte
@@ -21,6 +20,9 @@ public sealed class SMN_Reborn : SummonerRotation
 
         [Description("Ruby-Emerald-Topaz")] RubyEmeraldTopaz,
     }
+
+    [RotationConfig(CombatType.PvE, Name = "Use GCDs to heal. (Ignored if there are no healers alive in party)")]
+    public bool GCDHeal { get; set; } = false;
 
     [RotationConfig(CombatType.PvE, Name = "Use Crimson Cyclone at any range, regardless of saftey use with caution (Enabling this ignores the below distance setting).")]
     public bool AddCrimsonCyclone { get; set; } = true;
@@ -492,6 +494,20 @@ public sealed class SMN_Reborn : SummonerRotation
     #endregion
 
     #region Extra Methods
+    public override bool CanHealSingleSpell
+    {
+        get
+        {
+            int aliveHealerCount = 0;
+            IEnumerable<IBattleChara> healers = PartyMembers.GetJobCategory(JobRole.Healer);
+            foreach (IBattleChara h in healers)
+            {
+                if (!h.IsDead)
+                    aliveHealerCount++;
+            }
 
+            return base.CanHealSingleSpell && (GCDHeal || aliveHealerCount == 0);
+        }
+    }
     #endregion
 }

--- a/RebornRotations/Tank/PLD_Reborn.cs
+++ b/RebornRotations/Tank/PLD_Reborn.cs
@@ -2,13 +2,16 @@
 
 namespace RebornRotations.Tank;
 
-[Rotation("Default", CombatType.PvE, GameVersion = "7.25")]
-[SourceCode(Path = "main/BasicRotations/Tank/PLD_Default.cs")]
+[Rotation("Reborn", CombatType.PvE, GameVersion = "7.25")]
+[SourceCode(Path = "main/RebornRotations/Tank/PLD_Reborn.cs")]
 [Api(5)]
 
-public sealed class PLD_Default : PaladinRotation
+public sealed class PLD_Reborn : PaladinRotation
 {
     #region Config Options
+
+    [RotationConfig(CombatType.PvE, Name = "Use GCDs to heal. (Ignored if there are no healers alive in party)")]
+    public bool GCDHeal { get; set; } = false;
 
     [RotationConfig(CombatType.PvE, Name = "Only use Fight or Flight while in melee range of an enemy")]
     public bool MeleeFoF { get; set; } = true;
@@ -496,6 +499,22 @@ public sealed class PLD_Default : PaladinRotation
         }
 
         return false;
+    }
+
+    public override bool CanHealSingleSpell
+    {
+        get
+        {
+            int aliveHealerCount = 0;
+            IEnumerable<IBattleChara> healers = PartyMembers.GetJobCategory(JobRole.Healer);
+            foreach (IBattleChara h in healers)
+            {
+                if (!h.IsDead)
+                    aliveHealerCount++;
+            }
+
+            return base.CanHealSingleSpell && (GCDHeal || aliveHealerCount == 0);
+        }
     }
     #endregion
 }

--- a/RotationSolver.Basic/Configuration/Configs.cs
+++ b/RotationSolver.Basic/Configuration/Configs.cs
@@ -570,11 +570,11 @@ internal partial class Configs : IPluginConfiguration
     [Range(0, 10, ConfigUnitType.Seconds, 0.002f)]
     public Vector2 EsunaDelay { get; set; } = new(0f, 0f);
 
-    [Range(0, 10000, ConfigUnitType.None, 200)]
+    [Range(0, 10000, ConfigUnitType.None, 100)]
     [UI("Never raise player if MP is less than this",
         Filter = HealingActionCondition, Section = 2,
-        PvEFilter = JobFilterType.Raise)]
-    public int LessMPNoRaise { get; set; }
+        PvEFilter = JobFilterType.Raise, PvPFilter = JobFilterType.NoJob)]
+    public int LessMPNoRaise { get; set; } = 2400;
 
     /// <markdown file="Extra" name="HP standard deviation for using AoE heal">
     /// Controls how much party members' HP must differ before using AoE healing instead

--- a/RotationSolver.Basic/Rotations/Basic/AstrologianRotation.cs
+++ b/RotationSolver.Basic/Rotations/Basic/AstrologianRotation.cs
@@ -107,6 +107,7 @@ public partial class AstrologianRotation
         ImGui.Text($"DrawnCard: {string.Join(", ", DrawnCard)}");
         ImGui.Text($"DrawnCrownCard: {DrawnCrownCard}");
         ImGui.Text($"ActiveDraw: {ActiveDraw}");
+        ImGui.Text($"RaiseMPMinimum: {RaiseMPMinimum}");
     }
     #endregion
 
@@ -158,6 +159,7 @@ public partial class AstrologianRotation
     static partial void ModifyAscendPvE(ref ActionSetting setting)
     {
         setting.IsFriendly = true;
+        setting.ActionCheck = () => Player.CurrentMp >= RaiseMPMinimum;
     }
 
     static partial void ModifyEssentialDignityPvE(ref ActionSetting setting)

--- a/RotationSolver.Basic/Rotations/Basic/PaladinRotation.cs
+++ b/RotationSolver.Basic/Rotations/Basic/PaladinRotation.cs
@@ -8,11 +8,6 @@ public partial class PaladinRotation
     /// <summary>
     /// 
     /// </summary>
-    public override bool CanHealSingleSpell => DataCenter.PartyMembers.Count == 1 && base.CanHealSingleSpell;
-
-    /// <summary>
-    /// 
-    /// </summary>
     public override bool CanHealAreaAbility => false;
 
     /// <inheritdoc/>

--- a/RotationSolver.Basic/Rotations/Basic/RedMageRotation.cs
+++ b/RotationSolver.Basic/Rotations/Basic/RedMageRotation.cs
@@ -7,9 +7,6 @@ public partial class RedMageRotation
 
     private protected sealed override IBaseAction Raise => VerraisePvE;
 
-    /// <inheritdoc/>
-    public override bool CanHealSingleSpell => DataCenter.PartyMembers.Count == 1 && base.CanHealSingleSpell;
-
     #region Job Gauge
     /// <summary>
     /// 
@@ -353,6 +350,7 @@ public partial class RedMageRotation
     static partial void ModifyVerraisePvE(ref ActionSetting setting)
     {
         setting.StatusNeed = [StatusID.Dualcast];
+        setting.ActionCheck = () => Player.CurrentMp >= RaiseMPMinimum;
     }
 
     static partial void ModifyVerflarePvE(ref ActionSetting setting)

--- a/RotationSolver.Basic/Rotations/Basic/SageRotation.cs
+++ b/RotationSolver.Basic/Rotations/Basic/SageRotation.cs
@@ -105,6 +105,7 @@ public partial class SageRotation
     static partial void ModifyEgeiroPvE(ref ActionSetting setting)
     {
         setting.IsFriendly = true;
+        setting.ActionCheck = () => Player.CurrentMp >= RaiseMPMinimum;
     }
 
     static partial void ModifyPhysisPvE(ref ActionSetting setting)

--- a/RotationSolver.Basic/Rotations/Basic/ScholarRotation.cs
+++ b/RotationSolver.Basic/Rotations/Basic/ScholarRotation.cs
@@ -118,6 +118,7 @@ public partial class ScholarRotation
     static partial void ModifyResurrectionPvE(ref ActionSetting setting)
     {
         setting.IsFriendly = true;
+        setting.ActionCheck = () => Player.CurrentMp >= RaiseMPMinimum;
     }
 
     static partial void ModifyWhisperingDawnPvE_16537(ref ActionSetting setting)

--- a/RotationSolver.Basic/Rotations/Basic/SummonerRotation.cs
+++ b/RotationSolver.Basic/Rotations/Basic/SummonerRotation.cs
@@ -8,9 +8,6 @@ public partial class SummonerRotation
     /// <inheritdoc/>
     public override MedicineType MedicineType => MedicineType.Intelligence;
 
-    /// <inheritdoc/>
-    public override bool CanHealSingleSpell => DataCenter.PartyMembers.Count == 1 && base.CanHealSingleSpell;
-
     private protected sealed override IBaseAction Raise => ResurrectionPvE;
 
     #region JobGauge
@@ -354,7 +351,7 @@ public partial class SummonerRotation
 
     static partial void ModifyResurrectionPvE(ref ActionSetting setting)
     {
-
+        setting.ActionCheck = () => Player.CurrentMp >= RaiseMPMinimum;
     }
 
     static partial void ModifySummonTopazPvE(ref ActionSetting setting)

--- a/RotationSolver.Basic/Rotations/Basic/WhiteMageRotation.cs
+++ b/RotationSolver.Basic/Rotations/Basic/WhiteMageRotation.cs
@@ -120,7 +120,8 @@ public partial class WhiteMageRotation
 
     static partial void ModifyRaisePvE(ref ActionSetting setting)
     {
-
+        setting.ActionCheck = () => Player.CurrentMp >= RaiseMPMinimum || HasThinAir;
+        setting.MPOverride = () => HasThinAir ? 0 : (uint)2400;
     }
 
     static partial void ModifyStoneIiPvE(ref ActionSetting setting)

--- a/RotationSolver.Basic/Rotations/CustomRotation_Ability.cs
+++ b/RotationSolver.Basic/Rotations/CustomRotation_Ability.cs
@@ -549,7 +549,7 @@ public partial class CustomRotation
             }
         }
 
-        if (Service.Config.RaisePlayerBySwift && DataCenter.CanRaise() && IActionHelper.IsLastActionGCD() && nextGCD.IsTheSameTo(true, ActionID.RaisePvE, ActionID.EgeiroPvE, ActionID.ResurrectionPvE, ActionID.AscendPvE, ActionID.VerraisePvE))
+        if (Service.Config.RaisePlayerBySwift && DataCenter.CanRaise() && IActionHelper.IsLastActionGCD() && nextGCD.IsTheSameTo(true, ActionID.RaisePvE, ActionID.EgeiroPvE, ActionID.ResurrectionPvE, ActionID.AscendPvE))
         {
             if (SwiftcastPvE.CanUse(out act))
             {

--- a/RotationSolver.Basic/Rotations/CustomRotation_GCD.cs
+++ b/RotationSolver.Basic/Rotations/CustomRotation_GCD.cs
@@ -416,7 +416,6 @@ public partial class CustomRotation
                 return false;
             }
         }
-
         if (RaiseGCD(out act))
         {
             return true;
@@ -444,7 +443,7 @@ public partial class CustomRotation
 
         bool RaiseAction(out IAction act, bool ignoreCastingCheck)
         {
-            if (Player.CurrentMp > Service.Config.LessMPNoRaise && (Raise?.CanUse(out act, skipCastingCheck: ignoreCastingCheck) ?? false))
+            if (Raise?.CanUse(out act, skipCastingCheck: ignoreCastingCheck) ?? false)
             {
                 return true;
             }

--- a/RotationSolver.Basic/Rotations/CustomRotation_OtherInfo.cs
+++ b/RotationSolver.Basic/Rotations/CustomRotation_OtherInfo.cs
@@ -365,6 +365,11 @@ public partial class CustomRotation
     public virtual bool CanHealSingleSpell => true;
 
     /// <summary>
+    /// 
+    /// </summary>
+    public static int RaiseMPMinimum => Service.Config.LessMPNoRaise;
+
+    /// <summary>
     /// Is RSR enabled.
     /// </summary>
     [Description("The state of auto. True for on.")]


### PR DESCRIPTION
- Enhanced Thin Air logic in `WHM_Default`.
- Adjusted `LessMPNoRaise` default value in `Configs`.
- Added `RaiseMPMinimum` checks in various rotation classes.
- Removed `CanHealSingleSpell` restrictions in `PaladinRotation` and `RedMageRotation`.
- Ensured all relevant classes now incorporate the new healing logic.