### PR TITLE
Healer fixes and Autoduty menu updated

### DIFF
--- a/RebornRotations/Healer/SCH_Reborn.cs
+++ b/RebornRotations/Healer/SCH_Reborn.cs
@@ -288,6 +288,21 @@ public sealed class SCH_Reborn : ScholarRotation
     [RotationDesc(ActionID.AetherpactPvE, ActionID.ExcogitationPvE, ActionID.LustratePvE, ActionID.SacredSoilPvE, ActionID.WhisperingDawnPvE_16537, ActionID.FeyBlessingPvE)]
     protected override bool HealSingleAbility(IAction nextGCD, out IAction? act)
     {
+        bool haveLinkDRK = false;
+        foreach (IBattleChara p in PartyMembers)
+        {
+            if (p.HasStatus(true, StatusID.FeyUnion_1223) && p.HasStatus(false, StatusID.LivingDead))
+            {
+                haveLinkDRK = true;
+                break;
+            }
+        }
+        // remove link if the party member has link and also has Living Dead status
+        if (AetherpactPvE.CanUse(out act) && haveLinkDRK)
+        {
+            return true;
+        }
+
         // Check if any tank matches Excogitation target
         bool tankHasExcogTarget = false;
         IEnumerable<IBattleChara> tanks = PartyMembers.GetJobCategory(JobRole.Tank);

--- a/RebornRotations/Healer/SGE_Reborn.cs
+++ b/RebornRotations/Healer/SGE_Reborn.cs
@@ -230,7 +230,7 @@ public sealed class SGE_Reborn : SageRotation
     [RotationDesc(ActionID.KeracholePvE, ActionID.PhysisPvE, ActionID.HolosPvE, ActionID.IxocholePvE)]
     protected override bool HealAreaAbility(IAction nextGCD, out IAction? act)
     {
-        if ((!MergedStatus.HasFlag(AutoStatus.DefenseArea) || !MergedStatus.HasFlag(AutoStatus.DefenseSingle)) && PepsisPvE.CanUse(out act))
+        if (!MergedStatus.HasFlag(AutoStatus.DefenseArea) && !MergedStatus.HasFlag(AutoStatus.DefenseSingle) && PepsisPvE.CanUse(out act))
         {
             return true;
         }

--- a/RotationSolver/UI/RotationConfigWindow.cs
+++ b/RotationSolver/UI/RotationConfigWindow.cs
@@ -1342,7 +1342,6 @@ public partial class RotationConfigWindow : Window
         new AutoDutyPlugin { Name = "BossModReborn", Url = "https://raw.githubusercontent.com/FFXIV-CombatReborn/CombatRebornRepo/main/pluginmaster.json" },
         new AutoDutyPlugin { Name = "Boss Mod", Url = "https://puni.sh/api/repository/veyn" },
         new AutoDutyPlugin { Name = "Avarice", Url = "https://love.puni.sh/ment.json" },
-        new AutoDutyPlugin { Name = "Deliveroo", Url = "https://puni.sh/api/repository/vera" },
         new AutoDutyPlugin { Name = "AutoRetainer", Url = "https://love.puni.sh/ment.json" },
         new AutoDutyPlugin { Name = "SkipCutscene", Url = "https://raw.githubusercontent.com/KangasZ/DalamudPluginRepository/main/plugin_repository.json" },
         new AutoDutyPlugin { Name = "AntiAfkKick", Url = "https://raw.githubusercontent.com/NightmareXIV/MyDalamudPlugins/main/pluginmaster.json" },


### PR DESCRIPTION
- Removed Deliveroo from Autoduty menu
- On SCH added a bit to track if the Fairy Union member has Living Dead to remove the tether
- On SGE adjusted Pepsis logic in attempt to fix issue with stripping shield