### PR TITLE
Add DtrCycle option for target type cycling

### DIFF
--- a/RotationSolver.Basic/Configuration/Configs.cs
+++ b/RotationSolver.Basic/Configuration/Configs.cs
@@ -829,6 +829,10 @@ internal partial class Configs : IPluginConfiguration
         Filter = TargetConfig)]
     private static readonly bool _bigHP = false;
 
+    [ConditionBool, UI("Change clicking the DTR bar behaviour to cycle through each Target Type selected.",
+        Filter = TargetConfig)]
+    private static readonly bool _dtrCycle = false;
+
     #endregion
 
     #region Integer

--- a/RotationSolver/Updaters/MiscUpdater.cs
+++ b/RotationSolver/Updaters/MiscUpdater.cs
@@ -52,12 +52,64 @@ internal static class MiscUpdater
                     new IconPayload(icon),
                     new TextPayload(showStr)
                 );
-                _dtrEntry.OnClick = _ => RSCommands.IncrementState();
+                if (Service.Config.DtrCycle)
+                {
+                    _dtrEntry.OnClick = _ => CycleStateWithAllTargetTypes();
+                }
+                else
+                {
+                    _dtrEntry.OnClick = _ => RSCommands.IncrementState();
+                }
             }
         }
         else if (_dtrEntry != null && _dtrEntry.Shown)
         {
             _dtrEntry.Shown = false;
+        }
+    }
+
+    private static void CycleStateWithAllTargetTypes()
+    {
+        // If currently Off, start with the first TargetType
+        if (!DataCenter.State)
+        {
+            if (Service.Config.TargetingTypes.Count > 0)
+            {
+                Service.Config.TargetingIndex = 0;
+                RSCommands.DoStateCommandType(StateCommandType.Auto, 0);
+            }
+            else
+            {
+                // No targeting types configured, go to Manual
+                RSCommands.DoStateCommandType(StateCommandType.Manual);
+            }
+            return;
+        }
+
+        // If currently in Auto mode, cycle through all TargetTypes
+        if (DataCenter.State && !DataCenter.IsManual)
+        {
+            int nextIndex = Service.Config.TargetingIndex + 1;
+
+            // If we've gone through all TargetTypes, switch to Manual
+            if (nextIndex >= Service.Config.TargetingTypes.Count)
+            {
+                RSCommands.DoStateCommandType(StateCommandType.Manual);
+            }
+            else
+            {
+                // Move to next TargetType
+                Service.Config.TargetingIndex = nextIndex;
+                RSCommands.DoStateCommandType(StateCommandType.Auto, nextIndex);
+            }
+            return;
+        }
+
+        // If currently in Manual mode, turn off
+        if (DataCenter.State && DataCenter.IsManual)
+        {
+            RSCommands.DoStateCommandType(StateCommandType.Off);
+            return;
         }
     }
 


### PR DESCRIPTION
Introduced a new `dtrCycle` configuration in the `Configs` class to allow users to cycle through selected target types via the DTR bar. Updated the `_dtrEntry` click handler in `MiscUpdater` to utilize this new option, calling `CycleStateWithAllTargetTypes` when enabled. This method manages the cycling logic in Auto mode and handles transitions to Manual mode as needed.