### PR TITLE
Refactored the Player Input Intercept system

### DIFF
--- a/RotationSolver.Basic/Configuration/Configs.cs
+++ b/RotationSolver.Basic/Configuration/Configs.cs
@@ -47,17 +47,25 @@ internal partial class Configs : IPluginConfiguration
     Filter = AutoActionUsage, Section = 5)]
     private static readonly bool _interceptAction2 = false;
 
-    [ConditionBool, UI("Intercept Spells. (Experimental)",
+    [ConditionBool, UI("Allow intercepting Spells. (Experimental)",
     Filter = AutoActionUsage, Section = 5)]
     private static readonly bool _interceptSpell2 = false;
 
-    [ConditionBool, UI("Intercept Weaponskills. (Experimental)",
+    [ConditionBool, UI("Allow intercepting Weaponskills. (Experimental)",
     Filter = AutoActionUsage, Section = 5)]
     private static readonly bool _interceptWeaponskill2 = false;
 
-    [ConditionBool, UI("Intercept Abilities. (Experimental)",
+    [ConditionBool, UI("Allow intercepting Abilities. (Experimental)",
     Filter = AutoActionUsage, Section = 5)]
     private static readonly bool _interceptAbility2 = false;
+
+    [ConditionBool, UI("Allow intercepting actions in macros. (Experimental)",
+    Filter = AutoActionUsage, Section = 5)]
+    private static readonly bool _interceptMacro = false;
+
+    [ConditionBool, UI("Allow intercepting actions that are currently on cooldown. (Experimental)",
+    Filter = AutoActionUsage, Section = 5)]
+    private static readonly bool _interceptCooldown = false;
 
     [UI("Intercepted action execution window",
     Filter = AutoActionUsage, Section = 5)]

--- a/RotationSolver/Updaters/ActionQueueManager.cs
+++ b/RotationSolver/Updaters/ActionQueueManager.cs
@@ -3,7 +3,6 @@ using ECommons.DalamudServices;
 using ECommons.GameHelpers;
 using ECommons.Logging;
 using FFXIVClientStructs.FFXIV.Client.Game;
-using RotationSolver.Commands;
 
 namespace RotationSolver.Updaters
 {
@@ -28,7 +27,7 @@ namespace RotationSolver.Updaters
         }
 
         private static unsafe void InitializeActionHooks()
-        {            
+        {
             try
             {
                 var useActionAddress = ActionManager.Addresses.UseAction.Value;
@@ -67,11 +66,51 @@ namespace RotationSolver.Updaters
             {
                 try
                 {
-                    // Cast actionType to ActionType enum before passing to ShouldInterceptAction
-                    if (ShouldInterceptAction((ActionType)actionType, actionID))
+                    if (actionType == 1 && (useType != 2 || Service.Config.InterceptMacro)) // ActionType.Action == 1
                     {
-                        HandleInterceptedAction(actionID);
-                        return false; // Block the original action
+                        if (ShouldInterceptAction(actionType, actionID))
+                        {
+                            // More efficient action lookup - avoid creating new collections
+                            var rotationActions = RotationUpdater.CurrentRotationActions ?? [];
+                            var dutyActions = DataCenter.CurrentDutyRotation?.AllActions ?? [];
+
+                            // Find matching action by ID without creating intermediate collections
+                            IAction? matchingAction = null;
+                            uint adjustedActionId = Service.GetAdjustedActionId(actionID);
+
+                            PluginLog.Debug($"[ActionQueueManager] Detected player input: (ID: {actionID})");
+
+                            // Search rotation actions first
+                            foreach (var action in rotationActions)
+                            {                                
+                                if (action.ID == adjustedActionId)
+                                {
+                                    matchingAction = action;
+                                    break;
+                                }
+                            }
+
+                            // If not found, search duty actions
+                            if (matchingAction == null)
+                            {
+                                foreach (var action in dutyActions)
+                                {
+                                    if (action.ID == adjustedActionId)
+                                    {
+                                        matchingAction = action;
+                                        break;
+                                    }
+                                }
+                            }
+
+                            PluginLog.Debug($"[ActionQueueManager] Matching action decided: (ID: {matchingAction})");
+
+                            if (matchingAction != null && matchingAction.IsEnabled && matchingAction.EnoughLevel && (!matchingAction.Cooldown.IsCoolingDown || Service.Config.InterceptCooldown))
+                            {
+                                HandleInterceptedAction(matchingAction, actionID);
+                                return false; // Block the original action
+                            }
+                        }
                     }
                 }
                 catch (Exception ex)
@@ -80,19 +119,18 @@ namespace RotationSolver.Updaters
                 }
             }
 
+            // Call original function if available, otherwise return true (allow action)
             if (_useActionHook?.Original != null)
             {
                 return _useActionHook.Original(actionManager, actionType, actionID, targetObjectID, param, useType, pvp, isGroundTarget);
             }
-            return false;
+
+            // Return true to allow the action to proceed if hook is unavailable
+            return true;
         }
 
-        private static bool ShouldInterceptAction(ActionType actionType, uint actionId)
+        private static bool ShouldInterceptAction(uint actionType, uint actionId)
         {
-            // Only intercept player actions, not system actions
-            if (actionType != ActionType.Action)
-                return false;
-
             if (ActionUpdater.NextAction != null && actionId == ActionUpdater.NextAction.AdjustedID)
                 return false;
 
@@ -101,27 +139,30 @@ namespace RotationSolver.Updaters
             var action = actionSheet?.GetRow(actionId);
             var type = action?.ActionCategory.Value.RowId;
 
-            if (type == (uint)ActionCate.None)
+            // Handle null case
+            if (type == null) return false;
+
+            if (type == 0) // ActionCate.None
             {
                 return false;
             }
 
-            if (type == (uint)ActionCate.Autoattack)
+            if (type == 1) // ActionCate.Autoattack
             {
                 return false;
             }
 
-            if (!Service.Config.InterceptSpell2 && type == (uint)ActionCate.Spell)
+            if (!Service.Config.InterceptSpell2 && type == 2) // ActionCate.Spell
             {
                 return false;
             }
 
-            if (!Service.Config.InterceptWeaponskill2 && type == (uint)ActionCate.Weaponskill)
+            if (!Service.Config.InterceptWeaponskill2 && type == 3) // ActionCate.Weaponskill
             {
                 return false;
             }
 
-            if (!Service.Config.InterceptAbility2 && type == (uint)ActionCate.Ability)
+            if (!Service.Config.InterceptAbility2 && type == 4) // ActionCate.Ability
             {
                 return false;
             }
@@ -129,50 +170,19 @@ namespace RotationSolver.Updaters
             return true;
         }
 
-        private static void HandleInterceptedAction(uint actionId)
+        private static void HandleInterceptedAction(IAction matchingAction, uint actionID)
         {
             try
             {
-                // Find the action in current rotation
-                var rotationActions = RotationUpdater.CurrentRotationActions ?? [];
-                var dutyActions = DataCenter.CurrentDutyRotation?.AllActions ?? [];
+                // Use DataCenter.AddCommandAction directly instead of going through RSCommands.DoActionCommand
+                // This avoids the string parsing overhead and potential format issues
+                DataCenter.AddCommandAction(matchingAction, Service.Config.InterceptActionTime);
 
-                // Combine actions from both sources
-                var allActions = new List<IAction>();
-                allActions.AddRange(rotationActions);
-                allActions.AddRange(dutyActions);
-
-                // Find matching action by ID
-                IAction? matchingAction = null;
-                foreach (var action in allActions)
-                {                  
-                    if (action.ID == Service.GetAdjustedActionId(actionId))
-                    {
-                        matchingAction = action;
-                        break;
-                    }
-                }
-
-                if (matchingAction != null)
-                {
-                    // Use the RSCommand system to queue the action - this is the correct approach
-                    // The action will be queued using DataCenter.AddCommandAction and executed via RSCommands.DoAction()
-                    string actionName = matchingAction.Name;
-                    string commandString = $"{actionName}-{Service.Config.InterceptActionTime}";
-
-                    // Use the DoActionCommand which properly integrates with the RSCommand system
-                    RSCommands.DoActionCommand(commandString);
-
-                    PluginLog.Debug($"[ActionQueueManager] Intercepted and queued action via RSCommand: {matchingAction.Name} (ID: {actionId})");
-                }
-                else
-                {
-                    PluginLog.Warning($"[ActionQueueManager] Could not find matching action for intercepted ID: {actionId}");
-                }
+                PluginLog.Debug($"[ActionQueueManager] Intercepted and queued action: {matchingAction.Name} (ID: {actionID})");
             }
             catch (Exception ex)
             {
-                PluginLog.Error($"[ActionQueueManager] Error handling intercepted action {actionId}: {ex}");
+                PluginLog.Error($"[ActionQueueManager] Error handling intercepted action {actionID}: {ex}");
             }
         }
     }


### PR DESCRIPTION
- Updated to allow more granular control over what actions cant be intercepted
- Now requires the action be enabled in RSR Action tab to be intercepted
- Now requires player be high enough level for action to be intercepted
- Added toggle for intercepting actions called through macros
- Added toggle for intercepting actions that are in cooldown or not, to allow pre-queuing of actions that are about to come off of cooldown if user wants
- Refactored how AQM manages translating those actions between player input and RSR DoAction queue