### PR TITLE
Added new properties to the Rotation Config Attribute

### DIFF
--- a/RotationSolver.Basic/Attributes/RotationConfigAttribute.cs
+++ b/RotationSolver.Basic/Attributes/RotationConfigAttribute.cs
@@ -3,7 +3,7 @@
 namespace RotationSolver.Basic.Attributes;
 
 /// <summary>
-/// 
+///
 /// </summary>
 /// <param name="type"></param>
 [AttributeUsage(AttributeTargets.Property)]
@@ -20,7 +20,19 @@ public class RotationConfigAttribute(CombatType type) : Attribute
     public string Name { get; set; } = string.Empty;
 
     /// <summary>
+    /// Gets or sets the parent of this config item.
+    /// </summary>
+    public string Parent { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the value that the parent property must have for this config item to be enabled/visible.
+    /// </summary>
+    public object? ParentValue { get; set; }
+
+    /// <summary>
     /// Phantom Job for this config.
     /// </summary>
     public PhantomJob PhantomJob { get; set; } = PhantomJob.None;
+
+
 }

--- a/RotationSolver.Basic/Configuration/RotationConfig/IRotationConfig.cs
+++ b/RotationSolver.Basic/Configuration/RotationConfig/IRotationConfig.cs
@@ -26,6 +26,11 @@ public interface IRotationConfig
     CombatType Type { get; }
 
     /// <summary>
+    /// Gets the parent of this configuration for hierarchical display.
+    /// </summary>
+    string Parent { get; }
+
+    /// <summary>
     /// Gets or sets the current value of this configuration.
     /// </summary>
     string Value { get; set; }

--- a/RotationSolver.Basic/Configuration/RotationConfig/RotationConfigBase.cs
+++ b/RotationSolver.Basic/Configuration/RotationConfig/RotationConfigBase.cs
@@ -39,6 +39,16 @@ internal abstract class RotationConfigBase : IRotationConfig
     public PhantomJob PhantomJob { get; }
 
     /// <summary>
+    /// Gets the parent of this configuration.
+    /// </summary>
+    public string Parent { get; }
+
+    /// <summary>
+    /// Gets the parent value of this configuration.
+    /// </summary>
+    public object? ParentValue { get; private set; }
+
+    /// <summary>
     /// Gets or sets the value of the configuration.
     /// </summary>
     public string Value
@@ -68,16 +78,33 @@ internal abstract class RotationConfigBase : IRotationConfig
 
         Name = property.Name;
         DefaultValue = property.GetValue(rotation)?.ToString() ?? string.Empty;
-        RotationConfigAttribute? attr = property.GetCustomAttribute<RotationConfigAttribute>();
+        var attr = property.GetCustomAttribute<RotationConfigAttribute>();
         if (attr != null)
         {
             DisplayName = attr.Name;
             Type = attr.Type;
+            Parent = attr.Parent;
+
+            // Use ParentValue from the attribute if specified
+            if (attr.ParentValue != null)
+            {
+                ParentValue = attr.ParentValue;
+            }
+            // Otherwise, get the actual value from the parent property
+            else if (!string.IsNullOrEmpty(Parent))
+            {
+                PropertyInfo? parentProperty = rotation.GetType().GetProperty(Parent);
+                if (parentProperty != null)
+                {
+                    ParentValue = parentProperty.GetValue(rotation);
+                }
+            }
         }
         else
         {
             DisplayName = Name;
             Type = CombatType.None;
+            Parent = string.Empty;
         }
 
         // Set up initial value
@@ -105,12 +132,28 @@ internal abstract class RotationConfigBase : IRotationConfig
             DisplayName = attr.Name;
             Type = attr.Type;
             PhantomJob = attr.PhantomJob;
+            Parent = attr.Parent;
 
+            // Use ParentValue from the attribute if specified
+            if (attr.ParentValue != null)
+            {
+                ParentValue = attr.ParentValue;
+            }
+            // Otherwise, get the actual value from the parent property
+            else if (!string.IsNullOrEmpty(Parent))
+            {
+                PropertyInfo? parentProperty = rotation.GetType().GetProperty(Parent);
+                if (parentProperty != null)
+                {
+                    ParentValue = parentProperty.GetValue(rotation);
+                }
+            }
         }
         else
         {
             DisplayName = Name;
             Type = CombatType.None;
+            Parent = string.Empty;
         }
 
         // Set up initial value

--- a/RotationSolver/ExtraRotations/Ranged/ChurinDNC.cs
+++ b/RotationSolver/ExtraRotations/Ranged/ChurinDNC.cs
@@ -116,7 +116,7 @@ public sealed class ChurinDNC : DancerRotation
 
     #endregion
 
-    #region Other Properties
+    #region Enums
     private enum PotionTimings
     {
         [Description("None")] None,
@@ -159,28 +159,32 @@ public sealed class ChurinDNC : DancerRotation
     [RotationConfig(CombatType.PvE, Name = "Use Custom Potion Timing")]
     private static bool CustomPotionTiming { get; set; } = false;
 
-    [RotationConfig(CombatType.PvE, Name = "Custom Potions - Enable First Potion")]
-    private bool CustomEnableFirstPotion { get; set; } = true;
+    [RotationConfig(CombatType.PvE, Name = "Custom Potions - Enable First Potion", Parent = nameof(CustomPotionTiming))]
+    private static bool CustomEnableFirstPotion { get; set; }
 
     [Range(0, 20, ConfigUnitType.None, 1)]
-    [RotationConfig(CombatType.PvE, Name = "Custom Potions - First Potion(time in minutes)")]
-    private int CustomFirstPotionTime { get; set; } = 0;
+    [RotationConfig(CombatType.PvE, Name = "Custom Potions - First Potion(time in minutes)", Parent = nameof(CustomEnableFirstPotion))]
+    private static int CustomFirstPotionTime { get; set; } = 0;
 
-    [RotationConfig(CombatType.PvE, Name = "Custom Potions - Enable Second Potion")]
-    private bool CustomEnableSecondPotion { get; set; } = true;
-
-    [Range(0, 20, ConfigUnitType.None, 1)]
-    [RotationConfig(CombatType.PvE, Name = "Custom Potions - Second Potion(time in minutes)")]
-    private int CustomSecondPotionTime { get; set; } = 0;
-
-    [RotationConfig(CombatType.PvE, Name = "Custom Potions - Enable Third Potion")]
-    private bool CustomEnableThirdPotion { get; set; } = true;
+    [RotationConfig(CombatType.PvE, Name = "Custom Potions - Enable Second Potion", Parent = nameof(CustomPotionTiming))]
+    private static bool CustomEnableSecondPotion { get; set; }
 
     [Range(0, 20, ConfigUnitType.None, 1)]
-    [RotationConfig(CombatType.PvE, Name = "Custom Potions - Third Potion(time in minutes)")]
-    private int CustomThirdPotionTime { get; set; } = 0;
-    [Range(0,1, ConfigUnitType.Seconds, 0)]
+    [RotationConfig(CombatType.PvE, Name = "Custom Potions - Second Potion(time in minutes)", Parent = nameof(CustomEnableSecondPotion))]
+    private static int CustomSecondPotionTime { get; set; } = 0;
 
+    [RotationConfig(CombatType.PvE, Name = "Custom Potions - Enable Third Potion", Parent = nameof(CustomPotionTiming))]
+    private static bool CustomEnableThirdPotion { get; set; }
+
+    [Range(0, 20, ConfigUnitType.None, 1)]
+    [RotationConfig(CombatType.PvE, Name = "Custom Potions - Third Potion(time in minutes)", Parent = nameof(CustomEnableThirdPotion))]
+    private static int CustomThirdPotionTime { get; set; } = 0;
+
+    [Range(0,16, ConfigUnitType.Seconds, 0)]
+    [RotationConfig(CombatType.PvE, Name = "How many seconds before combat starts to use Standard Step?")]
+    private float OpenerStandardStepTime { get; set; } = 15.5f;
+
+    [Range(0, 1, ConfigUnitType.Seconds, 0)]
     [RotationConfig(CombatType.PvE, Name = "How many seconds before combat starts to use Standard Finish?")]
     private float OpenerFinishTime { get; set; } = 0.5f;
 
@@ -197,9 +201,9 @@ public sealed class ChurinDNC : DancerRotation
     {
         InitializePotions();
         UpdatePotions();
-        if (remainTime > 15) return base.CountDownAction(remainTime);
+        if (remainTime > OpenerStandardStepTime) return base.CountDownAction(remainTime);
         if (TryUseClosedPosition(out var act) ||
-            remainTime <= 15 &&StandardStepPvE.CanUse(out act) ||
+            remainTime <= OpenerStandardStepTime && StandardStepPvE.CanUse(out act) ||
             ExecuteStepGCD(out act) ||
             TryUsePotion(out act)
             || remainTime <= OpenerFinishTime && DoubleStandardFinishPvE.CanUse(out act)) return act;

--- a/RotationSolver/ExtraRotations/Tank/ChurinDRK.cs
+++ b/RotationSolver/ExtraRotations/Tank/ChurinDRK.cs
@@ -46,34 +46,49 @@ public sealed class ChurinDRK : DarkKnightRotation
         [Description("Opener and Six Minutes")] ZeroSix,
         [Description("Two Minutes and Eight Minutes")] TwoEight,
         [Description("Opener, Five Minutes and Ten Minutes")] ZeroFiveTen,
-        [Description("Custom - set values below")] Custom
     }
     private readonly List<(int Time, bool Enabled, bool Used)> _potions = [];
 
     private void InitializePotions()
     {
         _potions.Clear();
-        switch (PotionTiming)
+        switch (PotionTiming, CustomPotionTiming)
         {
-            case PotionTimings.ZeroSix:
+            case (PotionTimings.None, false):
+                break;
+            case (PotionTimings.ZeroSix, false):
                 _potions.Add((0, true, false));
                 _potions.Add((6, true, false));
                 break;
-            case PotionTimings.TwoEight:
+            case (PotionTimings.TwoEight, false):
                 _potions.Add((2, true, false));
                 _potions.Add((8, true, false));
                 break;
-            case PotionTimings.ZeroFiveTen:
+            case (PotionTimings.ZeroFiveTen, false):
                 _potions.Add((0, true, false));
                 _potions.Add((5, true, false));
                 _potions.Add((10, true, false));
                 break;
-            case PotionTimings.Custom:
-                if (CustomEnableFirstPotion) _potions.Add((CustomFirstPotionTime, true, false));
-                if (CustomEnableSecondPotion) _potions.Add((CustomSecondPotionTime, true, false));
-                if (CustomEnableThirdPotion) _potions.Add((CustomThirdPotionTime, true, false));
-                break;
         }
+
+        if (CustomPotionTiming)
+        {
+            if (CustomEnableFirstPotion)
+            {
+                _potions.Add((CustomFirstPotionTime, true, false));
+            }
+
+            if (CustomEnableSecondPotion)
+            {
+                _potions.Add((CustomSecondPotionTime, true, false));
+            }
+
+            if (CustomEnableThirdPotion)
+            {
+                _potions.Add((CustomThirdPotionTime, true, false));
+            }
+        }
+
     }
 
 
@@ -99,25 +114,32 @@ public sealed class ChurinDRK : DarkKnightRotation
     [RotationConfig(CombatType.PvE, Name = "Potion Presets")]
     private PotionTimings PotionTiming { get; set; } = PotionTimings.None;
 
-    [RotationConfig(CombatType.PvE, Name = "Enable First Potion for Custom Potion Timings?")]
-    private bool CustomEnableFirstPotion { get; set; } = true;
+    [Range(0, 20, ConfigUnitType.Seconds, 0.5f)]
+    [RotationConfig(CombatType.PvE, Name = "Use Opener Potion at minus time in seconds")]
+    private float OpenerPotionTime { get; set; } = 1f;
+
+    [RotationConfig(CombatType.PvE, Name = "Use Custom Potion Timing")]
+    private bool CustomPotionTiming { get; set; } = false;
+
+    [RotationConfig(CombatType.PvE, Name = "Custom Potions - Enable First Potion", Parent = nameof(CustomPotionTiming))]
+    private bool CustomEnableFirstPotion { get; set; }
 
     [Range(0, 20, ConfigUnitType.None, 1)]
-    [RotationConfig(CombatType.PvE, Name = "First Potion Usage for custom timings - enter time in minutes")]
+    [RotationConfig(CombatType.PvE, Name = "Custom Potions - First Potion(time in minutes)", Parent = nameof(CustomEnableFirstPotion))]
     private int CustomFirstPotionTime { get; set; } = 0;
 
-    [RotationConfig(CombatType.PvE, Name = "Enable Second Potion for Custom Potion Timings?")]
-    private bool CustomEnableSecondPotion { get; set; } = true;
+    [RotationConfig(CombatType.PvE, Name = "Custom Potions - Enable Second Potion", Parent = nameof(CustomPotionTiming))]
+    private bool CustomEnableSecondPotion { get; set; }
 
     [Range(0, 20, ConfigUnitType.None, 1)]
-    [RotationConfig(CombatType.PvE, Name = "Second Potion Usage for custom timings - enter time in minutes")]
+    [RotationConfig(CombatType.PvE, Name = "Custom Potions - Second Potion(time in minutes)", Parent = nameof(CustomEnableSecondPotion))]
     private int CustomSecondPotionTime { get; set; } = 0;
 
-    [RotationConfig(CombatType.PvE, Name = "Enable Third Potion for Custom Potion Timings?")]
-    private bool CustomEnableThirdPotion { get; set; } = true;
+    [RotationConfig(CombatType.PvE, Name = "Custom Potions - Enable Third Potion", Parent = nameof(CustomPotionTiming))]
+    private bool CustomEnableThirdPotion { get; set; }
 
     [Range(0, 20, ConfigUnitType.None, 1)]
-    [RotationConfig(CombatType.PvE, Name = "Third Potion Usage for custom timings - enter time in minutes")]
+    [RotationConfig(CombatType.PvE, Name = "Custom Potions - Third Potion(time in minutes)", Parent = nameof(CustomEnableThirdPotion))]
     private int CustomThirdPotionTime { get; set; } = 0;
 
     #endregion


### PR DESCRIPTION
This pull request introduces hierarchical configuration support and improves potion timing customization for rotation configurations. The main changes add parent-child relationships to configuration attributes, allowing certain config options to be conditionally displayed or enabled based on other config values. Additionally, potion timing logic for Bard and Dancer rotations is refactored for greater flexibility and usability, including support for early opener potions and more intuitive custom potion timing controls.

**Hierarchical Configuration Enhancements:**

* Added `Parent` and `ParentValue` properties to `RotationConfigAttribute`, `IRotationConfig`, and `RotationConfigBase`, enabling configuration options to be conditionally shown or enabled based on the value of another config property. The logic in `RotationConfigBase` constructors was updated to set these values appropriately. [[1]](diffhunk://#diff-d851d60e0fc6a14bfa9880811c6e149e53d48a53fd6955d38c2c3995aab6adadR22-R37) [[2]](diffhunk://#diff-30257d45ed9f0254059620a03f562268ef6641d1ec5196708f1c492acc529a29R28-R32) [[3]](diffhunk://#diff-6d2f781e55f3719389dbf8e5b5b4eee45ef0e36fbaa5cbea0f03c93cb9422034R41-R50) [[4]](diffhunk://#diff-6d2f781e55f3719389dbf8e5b5b4eee45ef0e36fbaa5cbea0f03c93cb9422034L71-R107) [[5]](diffhunk://#diff-6d2f781e55f3719389dbf8e5b5b4eee45ef0e36fbaa5cbea0f03c93cb9422034R135-R156)

**Bard (ChurinBRD) Potion Timing Improvements:**

* Refactored potion timing logic: removed the `Custom` enum value and now use a `CustomPotionTiming` boolean to control custom potion usage. Potion timings are now initialized based on both preset and custom values, and the logic for when potions are used has been made more flexible and robust, including support for using potions before combat starts (opener potions). [[1]](diffhunk://#diff-dc3c2c8c98b8d9674bafcd7d6b9ad0a7a85647049d94c3636b011728d5269b1aL43-R43) [[2]](diffhunk://#diff-dc3c2c8c98b8d9674bafcd7d6b9ad0a7a85647049d94c3636b011728d5269b1aL81-R114) [[3]](diffhunk://#diff-dc3c2c8c98b8d9674bafcd7d6b9ad0a7a85647049d94c3636b011728d5269b1aR215-R222) [[4]](diffhunk://#diff-dc3c2c8c98b8d9674bafcd7d6b9ad0a7a85647049d94c3636b011728d5269b1aL209-R236) [[5]](diffhunk://#diff-dc3c2c8c98b8d9674bafcd7d6b9ad0a7a85647049d94c3636b011728d5269b1aL664-L691)
* Updated related configuration fields to use the new hierarchical system, so custom potion options are only shown when relevant. Also, added `OpenerPotionTime` for precise control over early potion usage.
* Simplified and clarified internal logic for determining when to use potions, including new helper properties for two-minute and odd-minute potion windows. [[1]](diffhunk://#diff-dc3c2c8c98b8d9674bafcd7d6b9ad0a7a85647049d94c3636b011728d5269b1aR138-R139) [[2]](diffhunk://#diff-dc3c2c8c98b8d9674bafcd7d6b9ad0a7a85647049d94c3636b011728d5269b1aL664-L691)

**Dancer (ChurinDNC) Potion and Opener Step Customization:**

* Updated Dancer rotation configuration to use the new hierarchical config system for custom potion timings, ensuring that enabling/disabling options are displayed appropriately.
* Added `OpenerStandardStepTime` configuration, allowing users to control how many seconds before combat starts to use Standard Step. Adjusted logic to use this new configurable value. [[1]](diffhunk://#diff-47a4eb6c618e99b36d8294fb8cab1da42f6e3561e705aa2075ffe4f2a2549957L162-R187) [[2]](diffhunk://#diff-47a4eb6c618e99b36d8294fb8cab1da42f6e3561e705aa2075ffe4f2a2549957L200-R206)

**Miscellaneous:**

* Minor cleanups and reorganization of code comments and regions for clarity. [[1]](diffhunk://#diff-47a4eb6c618e99b36d8294fb8cab1da42f6e3561e705aa2075ffe4f2a2549957L119-R119) [[2]](diffhunk://#diff-dc3c2c8c98b8d9674bafcd7d6b9ad0a7a85647049d94c3636b011728d5269b1aL645) [[3]](diffhunk://#diff-dc3c2c8c98b8d9674bafcd7d6b9ad0a7a85647049d94c3636b011728d5269b1aL730-L731)