### PR TITLE
Changes to Intercept System and AST

### DIFF
--- a/RotationSolver.Basic/Rotations/Basic/AstrologianRotation.cs
+++ b/RotationSolver.Basic/Rotations/Basic/AstrologianRotation.cs
@@ -249,7 +249,8 @@ public partial class AstrologianRotation
 
     static partial void ModifyAspectedBeneficPvE(ref ActionSetting setting)
     {
-        setting.StatusProvide = [StatusID.AspectedBenefic];
+        setting.TargetStatusProvide = [StatusID.AspectedBenefic];
+        setting.IsFriendly = true;
     }
 
     static partial void ModifyAspectedHeliosPvE(ref ActionSetting setting)
@@ -259,7 +260,7 @@ public partial class AstrologianRotation
         setting.IsFriendly = true;
         setting.CreateConfig = () => new ActionConfig()
         {
-            AoeCount = 1,
+            AoeCount = 2,
         };
     }
 

--- a/RotationSolver/RebornRotations/Healer/AST_Reborn.cs
+++ b/RotationSolver/RebornRotations/Healer/AST_Reborn.cs
@@ -139,7 +139,7 @@ public sealed class AST_Reborn : AstrologianRotation
 
         if (nextGCD.IsTheSameTo(false, HeliosConjunctionPvE, HeliosPvE))
         {
-            if (HoroscopePvE.CanUse(out act))
+            if (PartyMembersAverHP < HoroscopeHeal && HoroscopePvE.CanUse(out act))
             {
                 return true;
             }
@@ -307,12 +307,12 @@ public sealed class AST_Reborn : AstrologianRotation
             return true;
         }
 
-        if (HoroscopePvE_16558.CanUse(out act))
+        if (PartyMembersAverHP < HoroscopeHeal && HoroscopePvE_16558.CanUse(out act))
         {
             return true;
         }
 
-        if (HoroscopePvE.CanUse(out act))
+        if (PartyMembersAverHP < HoroscopeHeal && HoroscopePvE.CanUse(out act))
         {
             return true;
         }

--- a/RotationSolver/Updaters/ActionQueueManager.cs
+++ b/RotationSolver/Updaters/ActionQueueManager.cs
@@ -109,7 +109,7 @@ namespace RotationSolver.Updaters
                             {
                                 if (matchingAction.IsIntercepted)
                                 {
-                                    if (matchingAction.EnoughLevel && (matchingAction.Cooldown.CurrentCharges > 0 || Service.Config.InterceptCooldown))
+                                    if (matchingAction.EnoughLevel && CanInterceptAction(matchingAction))
                                     {
                                         HandleInterceptedAction(matchingAction, actionID);
                                         return false; // Block the original action
@@ -176,6 +176,17 @@ namespace RotationSolver.Updaters
 
             return true;
         }
+
+        private static bool CanInterceptAction(IAction action)
+        {
+            if (Service.Config.InterceptCooldown || action.Cooldown.CurrentCharges > 0) return true;
+
+            // We check if the skill will fit inside the intercept action time window
+            var gcdCount = (byte)Math.Floor(Service.Config.InterceptActionTime / DataCenter.DefaultGCDTotal);
+
+            return action is IBaseAction baseAction && baseAction.Cooldown.CooldownCheck(false, (byte)(gcdCount < 1 ? 1 : gcdCount));
+        }
+
 
         private static void HandleInterceptedAction(IAction matchingAction, uint actionID)
         {


### PR DESCRIPTION
- Change default aspected helios to AoE count of 2
- Refactored `CanInterceptAction` into its own function. Now works with GCDs that always have `0 charges` upon entering combat, like Benefic [I/II]
- Added `TargetStatusProvide` to AspectedBenefic so it doesn't recast it unless the status drops off.