### PR TITLE
Fixed CancelState triggering on death in PvP zones

### DIFF
--- a/RotationSolver/Commands/RSCommands_Actions.cs
+++ b/RotationSolver/Commands/RSCommands_Actions.cs
@@ -238,8 +238,8 @@ namespace RotationSolver.Commands
 
                 // Combine conditions to reduce redundant checks
                 if (Svc.Condition[ConditionFlag.LoggingOut] ||
-                    (Service.Config.AutoOffWhenDead && !(DataCenter.Territory?.IsPvP ?? false) && Player.Object.CurrentHp == 0) ||
-                    (Service.Config.AutoOffWhenDeadPvP && (DataCenter.Territory?.IsPvP ?? false) && Player.Object.CurrentHp == 0) ||
+                    (Service.Config.AutoOffWhenDead && DataCenter.Territory != null && !DataCenter.Territory.IsPvP && Player.Object.CurrentHp == 0) ||
+                    (Service.Config.AutoOffWhenDeadPvP && DataCenter.Territory != null && DataCenter.Territory.IsPvP && Player.Object.CurrentHp == 0) ||
                     (Service.Config.AutoOffPvPMatchEnd && Svc.Condition[ConditionFlag.PvPDisplayActive]) ||
                     (Service.Config.AutoOffCutScene && Svc.Condition[ConditionFlag.OccupiedInCutSceneEvent]) ||
                     (Service.Config.AutoOffSwitchClass && Player.Job != _previousJob) ||


### PR DESCRIPTION
RSCommands_Actions.cs:

Fixed RSR auto mode being turned off by config 'AutoOffWhenDead' when in PvP 