### PR TITLE
UI cleanup in Action tab, Hard cast raise options cleaned up, melee class posititonal action fix

### DIFF
--- a/RotationSolver.Basic/Actions/ActionConfig.cs
+++ b/RotationSolver.Basic/Actions/ActionConfig.cs
@@ -93,4 +93,9 @@ public class ActionConfig()
     /// Is this action in the cd window.
     /// </summary>
     public bool IsOnCooldownWindow { get; set; } = true;
+
+    /// <summary>
+    /// One-time flag to indicate the AOE-count reset has been applied.
+    /// </summary>
+    public bool AoeResetDone { get; set; } = false;
 }

--- a/RotationSolver.Basic/Configuration/Configs.cs
+++ b/RotationSolver.Basic/Configuration/Configs.cs
@@ -488,29 +488,18 @@ internal partial class Configs : IPluginConfiguration
     public float HealthSelfRatio { get; set; } = 0.4f;
 
     #region
-    [JobConfig, UI("Hard cast Raise while Swiftcast is on cooldown if Swiftcast cooldown is higher than Raise cast time (Experimental)",
-        Filter = HealingActionCondition, Section = 2,
-        PvEFilter = JobFilterType.Raise, PvPFilter = JobFilterType.NoJob)]
-    private static readonly bool _raiseSwiftCooldown = false;
-
-    [JobConfig, UI("Hard cast Raise while Swiftcast is on cooldown if all other healers are dead (Experimental)",
-        Filter = HealingActionCondition, Section = 2,
-        PvEFilter = JobFilterType.Raise, PvPFilter = JobFilterType.NoJob)]
-    private static readonly bool _raiseHealerByCasting = false;
-
-    [JobConfig, UI("Hard cast Raise while Swiftcast is on cooldown",
-        Filter = HealingActionCondition, Section = 2,
-        PvEFilter = JobFilterType.Raise, PvPFilter = JobFilterType.NoJob)]
-    private static readonly bool _raisePlayerByCasting = true;
+    [JobConfig, UI("Prioritize raising dead players over Healing/Defense.",
+        Filter = HealingActionCondition, Section = 2)]
+    private static readonly bool _raisePlayerFirst = false;
 
     [JobConfig, UI("Raise player by using Swiftcast/Dualcast if available", Description = "If this is disabled, you will never use Swiftcast/Dualcast to raise players.",
         Filter = HealingActionCondition, Section = 2,
         PvEFilter = JobFilterType.Raise, PvPFilter = JobFilterType.NoJob)]
     private static readonly bool _raisePlayerBySwift = true;
 
-    [JobConfig, UI("Prioritize raising dead players over Healing/Defense.",
+    [JobConfig, UI("Hard cast Raise logic",
         Filter = HealingActionCondition, Section = 2)]
-    private static readonly bool _raisePlayerFirst = false;
+    private readonly HardCastRaiseType _HardCastRaiseType = HardCastRaiseType.HardCastNormal;
 
     [JobConfig, UI("Raise styles",
         Filter = HealingActionCondition, Section = 2)]

--- a/RotationSolver.Basic/Data/HardCastRaiseType.cs
+++ b/RotationSolver.Basic/Data/HardCastRaiseType.cs
@@ -1,0 +1,37 @@
+﻿namespace RotationSolver.Basic.Data;
+
+/// <summary>
+/// Hostile target.
+/// </summary>
+public enum HardCastRaiseType : byte
+{
+    /// <summary>
+    ///
+    /// </summary>
+    [Description("Do not hard cast Raise ")]
+    NoHardCast,
+
+    /// <summary>
+    ///
+    /// </summary>
+    [Description("Raise while Swiftcast is on cooldown")]
+    HardCastNormal,
+
+    /// <summary>
+    ///
+    /// </summary>
+    [Description("Raise while Swiftcast is on cooldown and other healers are dead")]
+    HardCastOnlyHealer,
+
+    /// <summary>
+    ///
+    /// </summary>
+    [Description("Raise while Swiftcast is on cooldown and cooldown is higher than raise cast time")]
+    HardCastSwiftCooldown,
+
+    /// <summary>
+    /// 
+    /// </summary>
+    [Description("Raise while Swiftcast is on cooldown and cooldown is higher than raise cast time and other healers are dead")]
+    HardCastOnlyHealerSwiftCooldown,
+}

--- a/RotationSolver.Basic/Rotations/CustomRotation_GCD.cs
+++ b/RotationSolver.Basic/Rotations/CustomRotation_GCD.cs
@@ -63,6 +63,8 @@ public partial class CustomRotation
 
             IBaseAction.TargetOverride = TargetType.Death;
 
+            HardCastRaiseType hardcastraisetype = Service.Config.HardCastRaiseType;
+
             if (Service.Config.RaisePlayerFirst)
             {                
                 if (RaiseSpell(out act, false))
@@ -70,7 +72,7 @@ public partial class CustomRotation
                     return act;
                 }
 
-                if (Service.Config.RaisePlayerByCasting && SwiftcastPvE.Cooldown.IsCoolingDown)
+                if (hardcastraisetype == HardCastRaiseType.HardCastNormal && SwiftcastPvE.Cooldown.IsCoolingDown)
                 {
                     if (RaiseSpell(out act, true))
                     {
@@ -78,7 +80,7 @@ public partial class CustomRotation
                     }
                 }
 
-                if (Service.Config.RaiseSwiftCooldown)
+                if (hardcastraisetype == HardCastRaiseType.HardCastSwiftCooldown)
                 {
                     if (SwiftcastPvE.Cooldown.IsCoolingDown && Raise != null && Raise.Info.CastTime < SwiftcastPvE.Cooldown.RecastTimeRemainOneCharge)
                     {
@@ -89,7 +91,7 @@ public partial class CustomRotation
                     }
                 }
 
-                if (Service.Config.RaiseHealerByCasting)
+                if (hardcastraisetype == HardCastRaiseType.HardCastOnlyHealer)
                 {
                     var deadhealers = new HashSet<IBattleChara>();
                     if (DataCenter.PartyMembers != null)
@@ -117,6 +119,40 @@ public partial class CustomRotation
                     if (RaiseSpell(out act, true) && deadhealers.Count == allhealers.Count && deadhealers.Count > 0)
                     {
                         return act;
+                    }
+                }
+
+                if (hardcastraisetype == HardCastRaiseType.HardCastOnlyHealerSwiftCooldown)
+                {
+                    if (SwiftcastPvE.Cooldown.IsCoolingDown && Raise != null && Raise.Info.CastTime < SwiftcastPvE.Cooldown.RecastTimeRemainOneCharge)
+                    {
+                        var deadhealers = new HashSet<IBattleChara>();
+                        if (DataCenter.PartyMembers != null)
+                        {
+                            foreach (var battleChara in DataCenter.PartyMembers.GetDeath())
+                            {
+                                if (TargetFilter.IsJobCategory(battleChara, JobRole.Healer) && !battleChara.IsPlayer())
+                                {
+                                    deadhealers.Add(battleChara);
+                                }
+                            }
+                        }
+
+                        var allhealers = new HashSet<IBattleChara>();
+                        if (DataCenter.PartyMembers != null)
+                        {
+                            foreach (var battleChara in DataCenter.PartyMembers)
+                            {
+                                if (TargetFilter.IsJobCategory(battleChara, JobRole.Healer) && !battleChara.IsPlayer())
+                                {
+                                    allhealers.Add(battleChara);
+                                }
+                            }
+                        }
+                        if (RaiseSpell(out act, true) && deadhealers.Count == allhealers.Count && deadhealers.Count > 0)
+                        {
+                            return act;
+                        }
                     }
                 }
             }
@@ -245,7 +281,7 @@ public partial class CustomRotation
                     return act;
                 }
 
-                if (Service.Config.RaisePlayerByCasting && SwiftcastPvE.Cooldown.IsCoolingDown)
+                if (hardcastraisetype == HardCastRaiseType.HardCastNormal && SwiftcastPvE.Cooldown.IsCoolingDown)
                 {
                     if (RaiseSpell(out act, true))
                     {
@@ -253,7 +289,7 @@ public partial class CustomRotation
                     }
                 }
 
-                if (Service.Config.RaiseSwiftCooldown)
+                if (hardcastraisetype == HardCastRaiseType.HardCastSwiftCooldown)
                 {
                     if (SwiftcastPvE.Cooldown.IsCoolingDown && Raise != null && Raise.Info.CastTime < SwiftcastPvE.Cooldown.RecastTimeRemainOneCharge)
                     {
@@ -264,7 +300,7 @@ public partial class CustomRotation
                     }
                 }
 
-                if (Service.Config.RaiseHealerByCasting)
+                if (hardcastraisetype == HardCastRaiseType.HardCastOnlyHealer)
                 {
                     var deadhealers = new HashSet<IBattleChara>();
                     if (DataCenter.PartyMembers != null)
@@ -289,9 +325,43 @@ public partial class CustomRotation
                             }
                         }
                     }
-                    if (RaiseSpell(out act, true) && deadhealers.Count == allhealers.Count)
+                    if (RaiseSpell(out act, true) && deadhealers.Count == allhealers.Count && deadhealers.Count > 0)
                     {
                         return act;
+                    }
+                }
+
+                if (hardcastraisetype == HardCastRaiseType.HardCastOnlyHealerSwiftCooldown)
+                {
+                    if (SwiftcastPvE.Cooldown.IsCoolingDown && Raise != null && Raise.Info.CastTime < SwiftcastPvE.Cooldown.RecastTimeRemainOneCharge)
+                    {
+                        var deadhealers = new HashSet<IBattleChara>();
+                        if (DataCenter.PartyMembers != null)
+                        {
+                            foreach (var battleChara in DataCenter.PartyMembers.GetDeath())
+                            {
+                                if (TargetFilter.IsJobCategory(battleChara, JobRole.Healer) && !battleChara.IsPlayer())
+                                {
+                                    deadhealers.Add(battleChara);
+                                }
+                            }
+                        }
+
+                        var allhealers = new HashSet<IBattleChara>();
+                        if (DataCenter.PartyMembers != null)
+                        {
+                            foreach (var battleChara in DataCenter.PartyMembers)
+                            {
+                                if (TargetFilter.IsJobCategory(battleChara, JobRole.Healer) && !battleChara.IsPlayer())
+                                {
+                                    allhealers.Add(battleChara);
+                                }
+                            }
+                        }
+                        if (RaiseSpell(out act, true) && deadhealers.Count == allhealers.Count && deadhealers.Count > 0)
+                        {
+                            return act;
+                        }
                     }
                 }
             }

--- a/RotationSolver/RebornRotations/Melee/NIN_Reborn.cs
+++ b/RotationSolver/RebornRotations/Melee/NIN_Reborn.cs
@@ -1033,6 +1033,10 @@ public sealed class NIN_Reborn : NinjaRotation
                 {
                     return true;
                 }
+                else if (Kazematoi < 4 && ArmorCrushPvE.CanUse(out act))
+                {
+                    return true;
+                }
             }
         }
 

--- a/RotationSolver/RebornRotations/Melee/RPR_Reborn.cs
+++ b/RotationSolver/RebornRotations/Melee/RPR_Reborn.cs
@@ -161,6 +161,10 @@ public sealed class RPR_Reborn : ReaperRotation
                             return true;
                         if (ExecutionersGibbetPvE.CanUse(out act, skipComboCheck: true) && ExecutionersGibbetPvE.Target.Target != null && CanHitPositional(EnemyPositional.Flank, ExecutionersGibbetPvE.Target.Target))
                             return true;
+                        if (ExecutionersGallowsPvE.CanUse(out act, skipComboCheck: true))
+                            return true;
+                        if (ExecutionersGibbetPvE.CanUse(out act, skipComboCheck: true))
+                            return true;
                         break;
                     case (true, false):
                         if (ExecutionersGallowsPvE.CanUse(out act, skipComboCheck: true))
@@ -315,6 +319,10 @@ public sealed class RPR_Reborn : ReaperRotation
                     if (GallowsPvE.CanUse(out act, skipComboCheck: true) && GallowsPvE.Target.Target != null && CanHitPositional(EnemyPositional.Rear, GallowsPvE.Target.Target))
                         return true;
                     if (GibbetPvE.CanUse(out act, skipComboCheck: true) && GibbetPvE.Target.Target != null && CanHitPositional(EnemyPositional.Flank, GibbetPvE.Target.Target))
+                        return true;
+                    if (GallowsPvE.CanUse(out act, skipComboCheck: true))
+                        return true;
+                    if (GibbetPvE.CanUse(out act, skipComboCheck: true))
                         return true;
                     break;
                 case (true, _):

--- a/RotationSolver/RebornRotations/Melee/SAM_Reborn.cs
+++ b/RotationSolver/RebornRotations/Melee/SAM_Reborn.cs
@@ -405,6 +405,16 @@ public sealed class SAM_Reborn : SamuraiRotation
                 return true;
             }
 
+            if (!HasFugetsu && JinpuPvE.CanUse(out act))
+            {
+                return true;
+            }
+
+            if (!HasFuka && ShifuPvE.CanUse(out act))
+            {
+                return true;
+            }
+
             if (!HasFugetsu)
             {
                 if (JinpuPvE.CanUse(out act))

--- a/RotationSolver/Updaters/TargetUpdater.cs
+++ b/RotationSolver/Updaters/TargetUpdater.cs
@@ -199,7 +199,7 @@ internal static partial class TargetUpdater
                         }
                     }
                 }
-                else if(raisetype == RaiseType.All || raisetype == RaiseType.AllOutOfDuty)
+                else if (raisetype == RaiseType.All || raisetype == RaiseType.AllOutOfDuty)
                 {
                     if (DataCenter.AllianceMembers != null)
                     {


### PR DESCRIPTION
- Actions in the actions tab no longer have the icons adjusted and now group together better depending on adjustID and level
- Hard cast raise options have been consolidated into a pick one drop down list (since this is a new config type it will reset user configs)
- SAM, RPR, and NIN have all had their positional action logic adjusted to account for targets that do not have positionals, fixing potential bricking that may occur with wall bosses
- A system for automatically resetting user configs for AOE count has been added to ensure everyone's configs are up to date with a single update