### PR TITLE
Inital work on cactbot intergration, fixes for VPR and SAM, multihit AOE detection added, etc

### DIFF
--- a/RotationSolver.Basic/Actions/PheonixDownItem.cs
+++ b/RotationSolver.Basic/Actions/PheonixDownItem.cs
@@ -5,18 +5,25 @@ internal class PhoenixDownItem : BaseItem
 {
     public PhoenixDownItem(Item item) : base(item)
     {
-       
+        // Only allow when the current DeathTarget is actually raisable (range/LoS/flags)
+        ItemCheck = () =>
+        {
+            var t = DataCenter.DeathTarget;
+            return t != null && RotationSolver.Basic.Helpers.ObjectHelper.CanBeRaised(t);
+        };
     }
 
-    private static bool AnyLivingHealerInParty()
+    private static bool AnyLivingRaiserInParty()
     {
         foreach (IBattleChara member in DataCenter.PartyMembers)
         {
-            if (member.IsJobCategory(JobRole.Healer) && !member.IsDead)
-                return true;
+            if (member.IsDead) continue;
+            if (member.IsJobCategory(JobRole.Healer)) return true;
+            if (member.IsJobs(ECommons.ExcelServices.Job.SMN)) return true;
+            if (member.IsJobs(ECommons.ExcelServices.Job.RDM)) return true;
         }
         return false;
     }
 
-    protected override bool CanUseThis => Service.Config.UsePhoenixDown && !AnyLivingHealerInParty() && DataCenter.DeathTarget != null;
+    protected override bool CanUseThis => Service.Config.UsePhoenixDown && !AnyLivingRaiserInParty() && DataCenter.DeathTarget != null;
 }

--- a/RotationSolver.Basic/Configuration/Configs.cs
+++ b/RotationSolver.Basic/Configuration/Configs.cs
@@ -721,6 +721,17 @@ internal partial class Configs : IPluginConfiguration
     Filter = Extra)]
     private static readonly bool _removeCooldownDelay = false;
 
+    // Cactbot timeline integration
+    [ConditionBool, UI("Enable cactbot timeline integration (Extremely experimental)",
+        Description = "Connects to OverlayPlugin's WebSocket server and reacts to cactbot broadcast messages (raidwide, tankbuster, knockback, downtime/untargetable).",
+        Filter = Extra)]
+    private static readonly bool _enableCactbotTimeline = false;
+
+    [ConditionBool, UI("Show cactbot event toasts (debug)",
+    Description = "Show a toast when a cactbot broadcast is received and mapped to a RotationSolver special.",
+    Filter = Extra)]
+    private static readonly bool _showCactbotToasts = false;
+
     [JobConfig, UI("The HP for using Guard.",
         Filter = PvPSpecificControls)]
     [Range(0, 1, ConfigUnitType.Percent, 0.02f)]

--- a/RotationSolver.Basic/DataCenter.cs
+++ b/RotationSolver.Basic/DataCenter.cs
@@ -8,10 +8,10 @@ using FFXIVClientStructs.FFXIV.Client.Game.Character;
 using FFXIVClientStructs.FFXIV.Client.Game.Fate;
 using FFXIVClientStructs.FFXIV.Client.Game.UI;
 using Lumina.Excel.Sheets;
-using System.Collections.Concurrent;
 using RotationSolver.Basic.Configuration;
 using RotationSolver.Basic.Configuration.Conditions;
 using RotationSolver.Basic.Rotations.Duties;
+using System.Collections.Concurrent;
 using Action = Lumina.Excel.Sheets.Action;
 using CharacterManager = FFXIVClientStructs.FFXIV.Client.Game.Character.CharacterManager;
 using CombatRole = RotationSolver.Basic.Data.CombatRole;
@@ -1176,6 +1176,30 @@ internal static class DataCenter
             }
         }
         return false;
+    }
+
+    public static bool IsCastingMultiHit()
+    {
+        return IsCastingVfx([.. VfxDataQueue], s =>
+        {
+            if (!Player.AvailableThreadSafe)
+            {
+                return false;
+            }
+
+            // For x6fe, ignore target and player role checks.
+            if (s.Path.StartsWith("vfx/lockon/eff/com_share5a1"))
+            {
+                return true;
+            }
+
+            if (s.Path.StartsWith("vfx/lockon/eff/m0922trg_t2w"))
+            {
+                return true;
+            }
+
+            return false;
+        });
     }
 
     public static bool IsCastingTankVfx()

--- a/RotationSolver.Basic/RotationSolver.Basic.csproj
+++ b/RotationSolver.Basic/RotationSolver.Basic.csproj
@@ -75,9 +75,9 @@
         <Using Include="Dalamud.Bindings.ImGui" />
         <Using Include="Newtonsoft.Json" />
 
-        <PackageReference Include="ECommons" Version="3.0.1.10" />
+        <PackageReference Include="ECommons" Version="3.0.1.14" />
 
-        <PackageReference Include="System.Drawing.Common" Version="9.0.8" />
+        <PackageReference Include="System.Drawing.Common" Version="9.0.9" />
         <ProjectReference Include="..\RotationSolver.SourceGenerators\RotationSolver.SourceGenerators.csproj" OutputItemType="Analyzer" ExcludeAssets="All" />
 
         <None Include="..\COPYING.LESSER">

--- a/RotationSolver.Basic/Rotations/Basic/SamuraiRotation.cs
+++ b/RotationSolver.Basic/Rotations/Basic/SamuraiRotation.cs
@@ -383,10 +383,10 @@ public partial class SamuraiRotation
         setting.IsFriendly = true;
     }
 
-    static partial void ModifyIkishotenPvE(ref ActionSetting setting)
+static partial void ModifyIkishotenPvE(ref ActionSetting setting)
     {
         setting.StatusProvide = [StatusID.OgiNamikiriReady, StatusID.ZanshinReady];
-        setting.ActionCheck = () => InCombat && Kenki <= 50;
+        setting.ActionCheck = () => InCombat && Kenki >= 50;
         setting.IsFriendly = true;
     }
 

--- a/RotationSolver.Basic/Rotations/CustomRotation_Items.cs
+++ b/RotationSolver.Basic/Rotations/CustomRotation_Items.cs
@@ -37,9 +37,10 @@ public partial class CustomRotation
     {
         act = null;
 
-        if (DataCenter.DeathTarget == null)
+        var target = DataCenter.DeathTarget;
+        if (target == null || !RotationSolver.Basic.Helpers.ObjectHelper.CanBeRaised(target))
         {
-            return act != null;
+            return false;
         }
 
         var prevOverride = IBaseAction.TargetOverride;
@@ -48,12 +49,19 @@ public partial class CustomRotation
         {
             foreach (PhoenixDownItem phoenixdown in PhoenixDowns)
             {
+                // Ensure we propagate the action outward if needed by upstream code
                 if (phoenixdown.CanUse(out act, true))
                 {
-                    ActionManager.Instance()->UseAction(ActionType.Item, 4570, DataCenter.DeathTarget.TargetObjectId);
+                    // Use() handles HQ/NQ and correct target GameObjectId
+                    if (phoenixdown.Use())
+                    {
+                        return true;
+                    }
+                    // If use failed, clear and continue scanning
+                    act = null;
                 }
             }
-            return act != null;
+            return false;
         }
         finally
         {

--- a/RotationSolver.Basic/Rotations/CustomRotation_OtherInfo.cs
+++ b/RotationSolver.Basic/Rotations/CustomRotation_OtherInfo.cs
@@ -549,6 +549,12 @@ public partial class CustomRotation
         return false;
     }
 
+    /// <summary>
+    ///
+    /// </summary>
+    [Description("Is an enemy casting a multihit AOE party stack")]
+    public static bool IsCastingMultiHit => DataCenter.IsCastingMultiHit();
+
     #endregion
 
     #region Target

--- a/RotationSolver.Basic/packages.lock.json
+++ b/RotationSolver.Basic/packages.lock.json
@@ -4,9 +4,9 @@
     "net9.0-windows7.0": {
       "ECommons": {
         "type": "Direct",
-        "requested": "[3.0.1.10, )",
-        "resolved": "3.0.1.10",
-        "contentHash": "EHFFs6YlI+DQemaGCyVvcLSYbkDFXds4yndVhS6V96TJ02bFrUiERx6C4erYiYZ25V9C3JblDHcRIhGLfAivuQ=="
+        "requested": "[3.0.1.14, )",
+        "resolved": "3.0.1.14",
+        "contentHash": "lqe2BlFaB6BS2MFXQsu33pIr/axjGmz4K4PoJwYwgcZGvt3JJqFIGLXTHUTYeWvT3eEfByPT0FQ7IdTCHQNdhA=="
       },
       "Svg": {
         "type": "Direct",
@@ -20,11 +20,11 @@
       },
       "System.Drawing.Common": {
         "type": "Direct",
-        "requested": "[9.0.8, )",
-        "resolved": "9.0.8",
-        "contentHash": "ineIJmF+yuBEHGft9R153J9kmBFaeEfFL5Put5nzENneRcGGPUb3MvM8zrZ5pERQ0jPPSE3Wqw/clXvOq2F/Kw==",
+        "requested": "[9.0.9, )",
+        "resolved": "9.0.9",
+        "contentHash": "BS17VFUf4RS9G/JoA6br+79jAjyTj0UaomgXCVNJJn9EWIvmHkn0ZCqAynxwloO00yPIvWgXBF9SBjcM06bl1w==",
         "dependencies": {
-          "Microsoft.Win32.SystemEvents": "9.0.8"
+          "Microsoft.Win32.SystemEvents": "9.0.9"
         }
       },
       "ExCSS": {
@@ -60,8 +60,8 @@
       },
       "Microsoft.Win32.SystemEvents": {
         "type": "Transitive",
-        "resolved": "9.0.8",
-        "contentHash": "64oQBN8I8EOcyHGNt6+rlcqm4tlcKfqOpswtBCJZnpzBQ15L6IFKqjnbjbOWBpG9wKq9A/aC2LFSmSqplbwTYA=="
+        "resolved": "9.0.9",
+        "contentHash": "eJU9vZbN710Cc25p/jPecPEL+gFcnynAvznNRnEvMU7i7u0PSjFXlGO4SOlaIUvkykTlS2N++M9B/coxYT7aPw=="
       },
       "System.Collections.Immutable": {
         "type": "Transitive",

--- a/RotationSolver/Helpers/CactbotTimelineBridge.cs
+++ b/RotationSolver/Helpers/CactbotTimelineBridge.cs
@@ -1,0 +1,191 @@
+using System.Net.WebSockets;
+using System.Text;
+using ECommons.DalamudServices;
+using ECommons.Logging;
+using Newtonsoft.Json.Linq;
+
+namespace RotationSolver.Helpers;
+
+/// <summary>
+/// Connects to OverlayPlugin's WS server and consumes cactbot broadcast messages to drive RotationSolver states.
+/// Expected broadcast payload example from cactbot overlay:
+/// callOverlayHandler({ call: 'broadcast', msg: { key: 'rotationsolver', payload: { type: 'raidwide', duration: 6 }}})
+/// </summary>
+internal sealed class CactbotTimelineBridge : IDisposable
+{
+    private readonly CancellationTokenSource? _cts;
+    private readonly Task? _loopTask;
+
+    public CactbotTimelineBridge()
+    {
+        if (!Service.Config.EnableCactbotTimeline)
+            return;
+
+        _cts = new CancellationTokenSource();
+        _loopTask = Task.Run(() => ConnectLoop(_cts.Token));
+        PluginLog.Information("CactbotTimelineBridge: started");
+    }
+
+    private static async Task ConnectLoop(CancellationToken ct)
+    {
+        var url = "ws://127.0.0.1:10501/ws";
+
+        var backoffMs = 1000;
+        while (!ct.IsCancellationRequested)
+        {
+            try
+            {
+                await ConnectAndListenAsync(new Uri(url), ct);
+                backoffMs = 1000; // reset after a successful session ends
+            }
+            catch (OperationCanceledException)
+            {
+                break;
+            }
+            catch (Exception ex)
+            {
+                PluginLog.Warning($"CactbotTimelineBridge: connection error: {ex.Message}");
+            }
+
+            try
+            {
+                await Task.Delay(backoffMs, ct);
+            }
+            catch (OperationCanceledException)
+            {
+                break;
+            }
+            backoffMs = Math.Min(backoffMs * 2, 30000);
+        }
+    }
+
+    private static async Task ConnectAndListenAsync(Uri uri, CancellationToken ct)
+    {
+        using var ws = new ClientWebSocket();
+        ws.Options.KeepAliveInterval = TimeSpan.FromSeconds(10);
+
+        await ws.ConnectAsync(uri, ct);
+        PluginLog.Information($"CactbotTimelineBridge: connected to {uri}");
+        if (Service.Config.InDebug)
+            Svc.Toasts.ShowNormal($"RSR cactbot: connected {uri}");
+
+        // Try to subscribe to BroadcastMessage events (OverlayPlugin convention)
+        var subscribe = Encoding.UTF8.GetBytes("{\"call\":\"subscribe\",\"events\":[\"BroadcastMessage\"]}");
+        await ws.SendAsync(new ArraySegment<byte>(subscribe), WebSocketMessageType.Text, true, ct);
+        if (Service.Config.InDebug)
+            PluginLog.Debug("CactbotTimelineBridge: subscribed to BroadcastMessage");
+
+        var buffer = new byte[16 * 1024];
+        var sb = new StringBuilder();
+
+        while (ws.State == WebSocketState.Open && !ct.IsCancellationRequested)
+        {
+            var result = await ws.ReceiveAsync(new ArraySegment<byte>(buffer), ct);
+            if (result.MessageType == WebSocketMessageType.Close)
+                break;
+
+            if (result.MessageType != WebSocketMessageType.Text)
+                continue;
+
+            sb.Append(Encoding.UTF8.GetString(buffer, 0, result.Count));
+            if (!result.EndOfMessage) continue;
+
+            var json = sb.ToString();
+            sb.Clear();
+            if (Service.Config.InDebug)
+                PluginLog.Debug($"CactbotTimelineBridge: recv: {json}");
+            HandleMessage(json);
+        }
+    }
+
+    private static void HandleMessage(string json)
+    {
+        try
+        {
+            var jobj = JObject.Parse(json);
+            // Common shapes: { type: 'BroadcastMessage', msg: {...} } or { event: 'broadcast', message: {...} }
+            var eventType = (string?)jobj["type"] ?? (string?)jobj["event"];
+            if (eventType == null)
+                return;
+
+            if (!eventType.Equals("BroadcastMessage", StringComparison.OrdinalIgnoreCase)
+                && !eventType.Equals("broadcast", StringComparison.OrdinalIgnoreCase))
+            {
+                return;
+            }
+
+            var msg = jobj["msg"] ?? jobj["message"] ?? jobj["data"];
+            if (msg is not JObject m)
+                return;
+
+            var payload = m["payload"] ?? m["data"] ?? m["detail"] ?? m["message"] ?? m;
+            if (payload is not JObject p)
+                return;
+
+            var kind = ((string?)p["type"] ?? (string?)p["event"])?.Trim();
+            var duration = p["duration"]?.Value<double>() ?? p["durationSeconds"]?.Value<double>() ?? 0.0;
+            if (string.IsNullOrEmpty(kind))
+                return;
+
+            if (Service.Config.InDebug)
+                PluginLog.Debug($"CactbotTimelineBridge: kind='{kind}', duration={duration}");
+
+            ProcessEvent(kind!, duration);
+        }
+        catch (Exception ex)
+        {
+            if (Service.Config.InDebug)
+                PluginLog.Debug($"CactbotTimelineBridge: parse error: {ex.Message}\n{json}");
+        }
+    }
+
+    private static void ProcessEvent(string kind, double durationSeconds)
+    {
+        SpecialCommandType? special = kind.ToLowerInvariant() switch
+        {
+            "raidwide" or "aoe" or "raidwide_aoe" => SpecialCommandType.DefenseArea,
+            "tankbuster" or "buster" => SpecialCommandType.DefenseSingle,
+            "knockback" => SpecialCommandType.AntiKnockback,
+            "untargetable_soon" or "immune_soon" or "downtime_soon" => SpecialCommandType.NoCasting,
+            "clear" or "end" or "targetable" => SpecialCommandType.EndSpecial,
+            _ => null,
+        };
+
+        if (special == null)
+            return;
+
+        if (special == SpecialCommandType.EndSpecial)
+        {
+            DataCenter.SpecialType = SpecialCommandType.EndSpecial;
+            if (Service.Config.InDebug)
+                PluginLog.Information($"CactbotTimelineBridge: clear special (from '{kind}')");
+            if (Service.Config.ShowCactbotToasts)
+                Svc.Toasts.ShowNormal("RSR: cactbot clear");
+            return;
+        }
+
+        DataCenter.SpecialType = special.Value;
+        PluginLog.Information($"CactbotTimelineBridge: '{kind}' -> {special} ({durationSeconds:F1}s)");
+        if (Service.Config.ShowCactbotToasts)
+            Svc.Toasts.ShowNormal($"RSR cactbot: {kind} → {special} ({durationSeconds:F1}s)");
+
+        if (durationSeconds > 0)
+        {
+            var delay = TimeSpan.FromSeconds(durationSeconds);
+            _ = Svc.Framework.RunOnTick(() =>
+            {
+                if (DataCenter.SpecialType == special)
+                {
+                    DataCenter.SpecialType = SpecialCommandType.EndSpecial;
+                    if (Service.Config.InDebug)
+                        PluginLog.Information($"CactbotTimelineBridge: auto-clear {special} after {durationSeconds:F1}s");
+                }
+            }, delay);
+        }
+    }
+
+    public void Dispose()
+    {
+        try { _cts?.Cancel(); } catch { }
+    }
+}

--- a/RotationSolver/RebornRotations/Healer/AST_Reborn.cs
+++ b/RotationSolver/RebornRotations/Healer/AST_Reborn.cs
@@ -8,6 +8,9 @@ namespace RotationSolver.RebornRotations.Healer;
 public sealed class AST_Reborn : AstrologianRotation
 {
     #region Config Options
+    [RotationConfig(CombatType.PvE, Name = "Limit Macrocosmos to multihit party stacks")]
+    public bool MultiHitRestrict { get; set; } = false;
+
     [RotationConfig(CombatType.PvE, Name = "Enable Swiftcast Restriction Logic to attempt to prevent actions other than Raise when you have swiftcast")]
     public bool SwiftLogic { get; set; } = true;
 
@@ -458,7 +461,6 @@ public sealed class AST_Reborn : AstrologianRotation
     #endregion
 
     #region GCD Logic
-    [RotationDesc(ActionID.MacrocosmosPvE)]
     protected override bool DefenseSingleGCD(out IAction? act)
     {
         if (BubbleProtec && HasCollectiveUnconscious)
@@ -499,9 +501,12 @@ public sealed class AST_Reborn : AstrologianRotation
             return true;
         }
 
-        if (MacrocosmosPvE.CanUse(out act))
+        if ((MultiHitRestrict && IsCastingMultiHit) || !MultiHitRestrict)
         {
-            return true;
+            if (MacrocosmosPvE.CanUse(out act))
+            {
+                return true;
+            }
         }
 
         return base.DefenseAreaGCD(out act);

--- a/RotationSolver/RebornRotations/Healer/SCH_Reborn.cs
+++ b/RotationSolver/RebornRotations/Healer/SCH_Reborn.cs
@@ -8,6 +8,9 @@ namespace RotationSolver.RebornRotations.Healer;
 public sealed class SCH_Reborn : ScholarRotation
 {
     #region Config Options
+    [RotationConfig(CombatType.PvE, Name = "Limit Seraphism to multihit party stacks")]
+    public bool MultiHitRestrict { get; set; } = false;
+
     [Range(0, 1, ConfigUnitType.Percent)]
     [RotationConfig(CombatType.PvE, Name = "Remove Aetherpact if the linked party member's HP is above this percentage")]
     public float AetherpactRemove { get; set; } = 0.9f;
@@ -407,9 +410,12 @@ public sealed class SCH_Reborn : ScholarRotation
         }
 
         // Seraphism is really good but we want to save it if we can, and should alternate it with Summon Seraph outside of the hardest content
-        if ((SummonSeraphPvE.Cooldown.IsCoolingDown || CurrentMp <= EmergencyHealingMPThreshold) && SeraphismPvE.CanUse(out act))
+        if ((MultiHitRestrict && IsCastingMultiHit) || !MultiHitRestrict)
         {
-            return true;
+            if ((SummonSeraphPvE.Cooldown.IsCoolingDown || CurrentMp <= EmergencyHealingMPThreshold) && SeraphismPvE.CanUse(out act))
+            {
+                return true;
+            }
         }
 
         if (WhisperingDawnPvE.Cooldown.IsCoolingDown && FeyBlessingPvE.Cooldown.IsCoolingDown)

--- a/RotationSolver/RebornRotations/Healer/SGE_Reborn.cs
+++ b/RotationSolver/RebornRotations/Healer/SGE_Reborn.cs
@@ -18,6 +18,9 @@ public sealed class SGE_Reborn : SageRotation
     [RotationConfig(CombatType.PvE, Name = "Use Rhizomata when out of combat")]
     public bool OOCRhizomata { get; set; } = false;
 
+    [RotationConfig(CombatType.PvE, Name = "Limit Panhaima to multihit party stacks")]
+    public bool MultiHitRestrict { get; set; } = false;
+
     [RotationConfig(CombatType.PvE, Name = "Use GCDs to heal. (Ignored if you are the only healer in party)")]
     public bool GCDHeal { get; set; } = false;
 
@@ -174,9 +177,12 @@ public sealed class SGE_Reborn : SageRotation
 
         if (Addersgall <= 1)
         {
-            if (PanhaimaPvE.CanUse(out act))
+            if ((MultiHitRestrict && IsCastingMultiHit) || !MultiHitRestrict)
             {
-                return true;
+                if (PanhaimaPvE.CanUse(out act))
+                {
+                    return true;
+                }
             }
         }
 

--- a/RotationSolver/RebornRotations/Healer/WHM_Reborn.cs
+++ b/RotationSolver/RebornRotations/Healer/WHM_Reborn.cs
@@ -8,6 +8,9 @@ namespace RotationSolver.RebornRotations.Healer;
 public sealed class WHM_Reborn : WhiteMageRotation
 {
     #region Config Options
+    [RotationConfig(CombatType.PvE, Name = "Limit Liturgy Of The Bell to multihit party stacks")]
+    public bool MultiHitRestrict { get; set; } = false;
+
     [RotationConfig(CombatType.PvE, Name = "Use Tincture/Gemdraught when about to use Presence of Mind")]
     public bool UseMedicine { get; set; } = true;
 
@@ -148,6 +151,14 @@ public sealed class WHM_Reborn : WhiteMageRotation
             return base.DefenseAreaAbility(nextGCD, out act);
         }
 
+        if (MultiHitRestrict && IsCastingMultiHit)
+        {
+            if (LiturgyOfTheBellPvE.CanUse(out act, skipAoeCheck: true))
+            {
+                return true;
+            }
+        }
+
         if (TemperancePvE.CanUse(out act))
         {
             return true;
@@ -158,9 +169,12 @@ public sealed class WHM_Reborn : WhiteMageRotation
             return true;
         }
 
-        if (LiturgyOfTheBellPvE.CanUse(out act, skipAoeCheck: true))
+        if ((MultiHitRestrict && IsCastingMultiHit) || !MultiHitRestrict)
         {
-            return true;
+            if (LiturgyOfTheBellPvE.CanUse(out act, skipAoeCheck: true))
+            {
+                return true;
+            }
         }
 
         return base.DefenseAreaAbility(nextGCD, out act);

--- a/RotationSolver/RebornRotations/Melee/VPR_Reborn.cs
+++ b/RotationSolver/RebornRotations/Melee/VPR_Reborn.cs
@@ -257,10 +257,19 @@ public sealed class VPR_Reborn : ViperRotation
     #region GCD Logic
     protected override bool GeneralGCD(out IAction? act)
     {
-        act = null;
         if (AbilityPrio2 &&
             !NoAbilityReady)
         {
+            if ((UFGhosting || (!UFGhosting && NoAbilityReady)) && !HasHostilesInRange && UncoiledFuryPvE.CanUse(out act, usedUp: true))
+            {
+                return true;
+            }
+
+            if ((UFGhosting || (!UFGhosting && NoAbilityReady)) && !HasHostilesInRange && WrithingSnapPvE.CanUse(out act))
+            {
+                return true;
+            }
+
             return base.GeneralGCD(out act);
         }
             

--- a/RotationSolver/RotationSolver.csproj
+++ b/RotationSolver/RotationSolver.csproj
@@ -15,7 +15,7 @@
 	<NoWarn>1591</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="ECommons" Version="3.0.1.10" />
+    <PackageReference Include="ECommons" Version="3.0.1.14" />
   </ItemGroup>
   <ItemGroup>
 	  <Reference Include="Dalamud.Common">

--- a/RotationSolver/RotationSolverPlugin.cs
+++ b/RotationSolver/RotationSolverPlugin.cs
@@ -91,6 +91,20 @@ public sealed class RotationSolverPlugin : IDalamudPlugin, IDisposable
         _changelogWindow = new();
         _overlayWindow = new();
 
+        // Start cactbot bridge if enabled
+        try
+        {
+            if (Service.Config.EnableCactbotTimeline)
+            {
+                var cactbotBridge = new Helpers.CactbotTimelineBridge();
+                _dis.Add(cactbotBridge);
+            }
+        }
+        catch (Exception ex)
+        {
+            PluginLog.Warning($"Failed to start CactbotTimelineBridge: {ex.Message}");
+        }
+
         windowSystem = new WindowSystem(Name);
         windowSystem.AddWindow(_rotationConfigWindow);
         windowSystem.AddWindow(_controlWindow);

--- a/RotationSolver/RotationSolverPlugin.cs
+++ b/RotationSolver/RotationSolverPlugin.cs
@@ -92,18 +92,18 @@ public sealed class RotationSolverPlugin : IDalamudPlugin, IDisposable
         _overlayWindow = new();
 
         // Start cactbot bridge if enabled
-        try
-        {
-            if (Service.Config.EnableCactbotTimeline)
-            {
-                var cactbotBridge = new Helpers.CactbotTimelineBridge();
-                _dis.Add(cactbotBridge);
-            }
-        }
-        catch (Exception ex)
-        {
-            PluginLog.Warning($"Failed to start CactbotTimelineBridge: {ex.Message}");
-        }
+        //try
+        //{
+        //    if (Service.Config.EnableCactbotTimeline)
+        //    {
+        //        var cactbotBridge = new Helpers.CactbotTimelineBridge();
+        //        _dis.Add(cactbotBridge);
+        //    }
+        //}
+        //catch (Exception ex)
+        //{
+        //    PluginLog.Warning($"Failed to start CactbotTimelineBridge: {ex.Message}");
+        //}
 
         windowSystem = new WindowSystem(Name);
         windowSystem.AddWindow(_rotationConfigWindow);

--- a/RotationSolver/UI/RotationConfigWindow.cs
+++ b/RotationSolver/UI/RotationConfigWindow.cs
@@ -3484,6 +3484,7 @@ public partial class RotationConfigWindow : Window
         ImGui.Text($"MountRokkon: {DataCenter.MountRokkon}");
         ImGui.Text($"SildihnSubterrane: {DataCenter.SildihnSubterrane}");
         ImGui.Spacing();
+        ImGui.Text($"IsCastingMultiHit: {DataCenter.IsCastingMultiHit()}");
     }
 
     private static unsafe void DrawParty()

--- a/RotationSolver/UI/RotationConfigWindow.cs
+++ b/RotationSolver/UI/RotationConfigWindow.cs
@@ -6,6 +6,7 @@ using Dalamud.Interface.Textures.TextureWraps;
 using Dalamud.Interface.Utility;
 using Dalamud.Interface.Utility.Raii;
 using Dalamud.Interface.Windowing;
+using Dalamud.Plugin.Services;
 using Dalamud.Utility;
 using ECommons;
 using ECommons.DalamudServices;
@@ -114,10 +115,6 @@ public partial class RotationConfigWindow : Window
             if (p.IsInstalled && p.IsEnabled)
             {
                 _enabledIncompatiblePlugins.Add(p);
-                if ((int)p.Type == 5)
-                {
-                    _crashPlugins.Add(p);
-                }
             }
         }
 
@@ -283,7 +280,6 @@ public partial class RotationConfigWindow : Window
     private void DrawDiagnosticInfoCube()
     {
         StringBuilder diagInfo = new();
-        Vector4 diagColor = new(1f, 1f, 1f, .3f);
 
         if (_cachedDiagInfo == null && DalamudReflector.TryGetDalamudStartInfo(out Dalamud.Common.DalamudStartInfo? startinfo, Svc.PluginInterface))
         {
@@ -306,15 +302,41 @@ public partial class RotationConfigWindow : Window
             _ = diagInfo.AppendLine($"Intercept: {Service.Config.InterceptAction2}");
         }
 
-        if (_enabledIncompatiblePlugins.Count > 0)
+        // Ensure that IncompatiblePlugins is not null
+        IncompatiblePlugin[] incompatiblePlugins = DownloadHelper.IncompatiblePlugins ?? [];
+
+        bool anyCrash = false;
+        _ = diagInfo.AppendLine("\nPlugins:");
+        foreach (IncompatiblePlugin item in incompatiblePlugins)
         {
-            _ = diagInfo.AppendLine("\nPlugins:");
+            if (item.IsEnabled)
+            {
+                string name = item.Name ?? "Unnamed Incompatible Plugin";
+
+                // Flag that at least one crash-prone plugin is enabled so the info marker pulses red
+                if (item.Type.HasFlag(CompatibleType.Crash))
+                {
+                    anyCrash = true;
+                }
+
+                // List all enabled incompatible plugins
+                _ = diagInfo.AppendLine($"{name}");
+            }
         }
 
-        foreach (IncompatiblePlugin plugin in _enabledIncompatiblePlugins)
+        // Pulse red if any crash-flagged plugin is enabled, otherwise yellow for general incompatibles
+        Vector4 diagColor;
+        if (anyCrash)
         {
-            _ = diagInfo.AppendLine(value: plugin.Name ?? "Unnamed Incompatible Plugin");
-            diagColor = (int)plugin.Type == 5 ? new Vector4(1f, 0f, 0f, .3f) : new Vector4(1f, 1f, .4f, .3f);
+            // Alpha pulses between ~0.25 and ~0.70 at a comfortable speed
+            float t = (float)ImGui.GetTime();
+            float pulse = (MathF.Sin(t * 4f) + 1f) * 0.5f; // 0..1
+            float alpha = 0.25f + (0.45f * pulse);
+            diagColor = new Vector4(1f, 0f, 0f, alpha);
+        }
+        else
+        {
+            diagColor = new Vector4(1f, 1f, .4f, .3f);
         }
 
         ImGui.SetCursorPosY(ImGui.GetWindowSize().Y - 20);

--- a/RotationSolver/packages.lock.json
+++ b/RotationSolver/packages.lock.json
@@ -16,9 +16,9 @@
       },
       "ECommons": {
         "type": "Direct",
-        "requested": "[3.0.1.10, )",
-        "resolved": "3.0.1.10",
-        "contentHash": "EHFFs6YlI+DQemaGCyVvcLSYbkDFXds4yndVhS6V96TJ02bFrUiERx6C4erYiYZ25V9C3JblDHcRIhGLfAivuQ=="
+        "requested": "[3.0.1.14, )",
+        "resolved": "3.0.1.14",
+        "contentHash": "lqe2BlFaB6BS2MFXQsu33pIr/axjGmz4K4PoJwYwgcZGvt3JJqFIGLXTHUTYeWvT3eEfByPT0FQ7IdTCHQNdhA=="
       },
       "ExCSS": {
         "type": "Transitive",
@@ -53,8 +53,8 @@
       },
       "Microsoft.Win32.SystemEvents": {
         "type": "Transitive",
-        "resolved": "9.0.8",
-        "contentHash": "64oQBN8I8EOcyHGNt6+rlcqm4tlcKfqOpswtBCJZnpzBQ15L6IFKqjnbjbOWBpG9wKq9A/aC2LFSmSqplbwTYA=="
+        "resolved": "9.0.9",
+        "contentHash": "eJU9vZbN710Cc25p/jPecPEL+gFcnynAvznNRnEvMU7i7u0PSjFXlGO4SOlaIUvkykTlS2N++M9B/coxYT7aPw=="
       },
       "Svg": {
         "type": "Transitive",
@@ -72,10 +72,10 @@
       },
       "System.Drawing.Common": {
         "type": "Transitive",
-        "resolved": "9.0.8",
-        "contentHash": "ineIJmF+yuBEHGft9R153J9kmBFaeEfFL5Put5nzENneRcGGPUb3MvM8zrZ5pERQ0jPPSE3Wqw/clXvOq2F/Kw==",
+        "resolved": "9.0.9",
+        "contentHash": "BS17VFUf4RS9G/JoA6br+79jAjyTj0UaomgXCVNJJn9EWIvmHkn0ZCqAynxwloO00yPIvWgXBF9SBjcM06bl1w==",
         "dependencies": {
-          "Microsoft.Win32.SystemEvents": "9.0.8"
+          "Microsoft.Win32.SystemEvents": "9.0.9"
         }
       },
       "System.Reflection.Metadata": {
@@ -92,10 +92,10 @@
       "RotationSolverReborn.Basic": {
         "type": "Project",
         "dependencies": {
-          "ECommons": "[3.0.1.10, )",
+          "ECommons": "[3.0.1.14, )",
           "RotationSolver.SourceGenerators": "[1.0.0, )",
           "Svg": "[3.4.7, )",
-          "System.Drawing.Common": "[9.0.8, )"
+          "System.Drawing.Common": "[9.0.9, )"
         }
       }
     }


### PR DESCRIPTION
This pull request introduces several improvements and fixes across the codebase, focusing on Phoenix Down item logic, experimental Cactbot timeline integration, and support for detecting multihit AOEs. It also updates some dependency versions and corrects a configuration issue in the Samurai rotation logic.

**Phoenix Down item improvements:**

* The logic for using Phoenix Down now checks if the death target can actually be raised (e.g., within range, line of sight, and appropriate flags), both in the item class and in the custom rotation logic. This prevents attempts to use the item on unraisable targets. [[1]](diffhunk://#diff-5c428cf0244ae7a4e827986ab514ac6f011a4878baa58c50116c0d0fbadc546eL8-R28) [[2]](diffhunk://#diff-d5c667a2c94bd136eb15eca3fb65c7376adce18f9b0072540691681bb6335ddaL40-R43)
* The check for whether a Phoenix Down can be used now considers not just living healers, but also SMN and RDM jobs, as they can raise as well.
* The action execution logic for Phoenix Down is improved to ensure proper propagation and retry if usage fails.

**Cactbot timeline integration (experimental):**

* Adds new configuration options to enable Cactbot timeline integration and debug toasts, allowing the plugin to react to Cactbot broadcast messages for raid mechanics.

**Multihit AOE detection:**

* Adds a new method and property to detect if an enemy is casting a multihit AOE party stack, based on visual effect data. [[1]](diffhunk://#diff-2c3e758beb8d040501567ca05ffcedd46534840df24596c1119e971896e8eb42R1181-R1204) [[2]](diffhunk://#diff-dcfd2506d1ce54221fa2d12787392346547585e896b48e48de6d5fa8be631af4R552-R557)

**Dependency and version updates:**

* Updates `ECommons` to version `3.0.1.14` and `System.Drawing.Common` to `9.0.9` in both the project and lock files. [[1]](diffhunk://#diff-5c70343fad24929f3f36286ec07f4a9d9a718df3748cfe49ccaf6ccdb8151bbfL78-R80) [[2]](diffhunk://#diff-53b3c4ef89f9c632a8578ec45c06ebc13025edd42cf9c70533d20d1105d48162L7-R9) [[3]](diffhunk://#diff-53b3c4ef89f9c632a8578ec45c06ebc13025edd42cf9c70533d20d1105d48162L23-R27) [[4]](diffhunk://#diff-53b3c4ef89f9c632a8578ec45c06ebc13025edd42cf9c70533d20d1105d48162L63-R64)

**Other fixes and updates:**

* Fixes a logic error in the Samurai rotation: `Ikishoten` is now only used when Kenki is 50 or greater, instead of 50 or less.
* Updates opcode values and descriptions in the resource file