### PR TITLE
Fix for BLU crash, WAR status application, and various other fixes

### DIFF
--- a/RotationSolver.Basic/DataCenter.cs
+++ b/RotationSolver.Basic/DataCenter.cs
@@ -46,6 +46,11 @@ internal static class DataCenter
         return Player.AvailableThreadSafe && (State || IsManual || Service.Config.TeachingMode);
     }
 
+    public static bool PlayerAvailable()
+    {
+        return Player.AvailableThreadSafe;
+    }
+
     internal static IBattleChara? HostileTarget
     {
         get => Svc.Objects.SearchById(_hostileTargetId) as IBattleChara;

--- a/RotationSolver.Basic/Helpers/ObjectHelper.cs
+++ b/RotationSolver.Basic/Helpers/ObjectHelper.cs
@@ -1929,19 +1929,16 @@ public static class ObjectHelper
         DateTime startTime = DateTime.MinValue;
         float initialHpRatio = 0;
 
-        // Use a snapshot of the RecordedHP collection to avoid modification during enumeration
         (DateTime time, Dictionary<ulong, float> hpRatios)[] recordedHPCopy = [.. DataCenter.RecordedHP];
 
-        // Calculate a moving average of HP ratios
-        const int movingAverageWindow = 5; // TODO: Possibly this should be configurable?
+        const int movingAverageWindow = 5; 
         if (recordedHPCopy.Length == 0)
         {
-            return float.NaN; // No recorded HP data available
+            return float.NaN;
         }
 
         List<float> hpRatios = new(movingAverageWindow);
 
-        // We just need the first injured entry and last movingAverageWindow entries
         foreach ((DateTime time, Dictionary<ulong, float> hpRatiosDict) in recordedHPCopy)
         {
             if (hpRatiosDict != null && hpRatiosDict.TryGetValue(battleChara.GameObjectId, out float ratio) && ratio != 1)
@@ -1957,7 +1954,6 @@ public static class ObjectHelper
             return float.NaN;
         }
 
-        // Skip to just the last movingAverageWindow entries
         if (recordedHPCopy.Length > movingAverageWindow)
         {
             recordedHPCopy = recordedHPCopy[^movingAverageWindow..];
@@ -1977,7 +1973,6 @@ public static class ObjectHelper
             return float.NaN;
         }
 
-        // Manual average calculation to avoid LINQ
         float sum = 0;
         int count = 0;
         foreach (float r in hpRatios)

--- a/RotationSolver.Basic/Helpers/StatusHelper.cs
+++ b/RotationSolver.Basic/Helpers/StatusHelper.cs
@@ -287,7 +287,7 @@ public static class StatusHelper
         }
 
         float statusTime = battleChara.StatusTime(isFromSelf, statusIDs);
-        return !battleChara.HasStatus(isFromSelf, statusIDs) && statusTime <= time;
+        return (statusTime >= 0f || !battleChara.HasStatus(isFromSelf, statusIDs)) && statusTime <= time;
     }
 
     /// <summary>
@@ -318,12 +318,12 @@ public static class StatusHelper
 
                 found = true;
             }
-            return !found ? 0 : Math.Max(0, min - DataCenter.DefaultGCDRemain);
+            return !found ? 0f : Math.Max(0f, min - DataCenter.DefaultGCDRemain);
         }
         catch (Exception ex)
         {
             PluginLog.Error($"Failed to get status time: {ex.Message}");
-            return 0;
+            return 0f;
         }
     }
 

--- a/RotationSolver/Updaters/MajorUpdater.cs
+++ b/RotationSolver/Updaters/MajorUpdater.cs
@@ -128,6 +128,9 @@ internal static class MajorUpdater
         if (!_shouldRunThisCycle || !_isActivatedThisCycle)
             return;
 
+        if (!DataCenter.IsActivated())
+            return;
+
         try
         {
             bool canDoAction = ActionUpdater.CanDoAction();


### PR DESCRIPTION
- Added `PlayerAvailable` method to `DataCenter` for reusability.
- Simplified logic in `ObjectHelper` by removing redundant code.
- Adjusted `StatusHelper` to use consistent `float` return types to correct Player.WillStatusEnd check
- Enhanced `SetBlueMageActions` in `BlueMageRotation`:
  - Added configuration and state checks.
  - Used `Span` for memory efficiency.
  - Cached last applied actions to avoid redundant calls.
  - Improved error handling and logging.
- Renamed and optimized `GetBlueMageActions` to `GetBlueMageActionsInternal`.
- Updated `MajorUpdater` to check `DataCenter.IsActivated()`.