### PR TITLE
Expanded support for Monster Hunter duties in prep for 7.35, better automated movement abiltiy control, misc fixes

### DIFF
--- a/RotationSolver.Basic/Actions/ActionSetting.cs
+++ b/RotationSolver.Basic/Actions/ActionSetting.cs
@@ -23,7 +23,17 @@ public enum SpecialActionType : byte
     /// <summary>
     /// 
     /// </summary>
-    MovingForward,
+    HostileMovingForward,
+
+    /// <summary>
+    /// 
+    /// </summary>
+    FriendlyMovingForward,
+
+    /// <summary>
+    /// 
+    /// </summary>
+    HostileFriendlyMovingForward,
 }
 
 /// <summary>

--- a/RotationSolver.Basic/Actions/ActionTargetInfo.cs
+++ b/RotationSolver.Basic/Actions/ActionTargetInfo.cs
@@ -1188,24 +1188,72 @@ public struct ActionTargetInfo(IBaseAction action)
                 }
                 break;
 
-            case SpecialActionType.MovingForward:
+            case SpecialActionType.HostileMovingForward:
                 if (Service.Config != null)
                 {
                     if (DataCenter.MergedStatus.HasFlag(AutoStatus.MoveForward) || Service.CountDownTime > 0)
                     {
-                        type = TargetType.Move;
+                        if (Svc.Targets.Target is IBattleChara IsHostiletarg && IsHostiletarg.IsHostile())
+                        {
+                            return IsHostiletarg;
+                        }
+                    }
+                    if (DataCenter.MergedStatus.HasFlag(AutoStatus.Intercepting))
+                    {
+                        if (Svc.Targets.Target is IBattleChara IsHostiletarg && IsHostiletarg.IsHostile())
+                        {
+                            return IsHostiletarg;
+                        }
                     }
                     else
                     {
                         var filtered = new List<IBattleChara>();
                         foreach (var t in battleChara)
                         {
-                            if (t.DistanceToPlayer() < Service.Config.DistanceForMoving)
+                            if (t.DistanceToPlayer() < Service.Config.DistanceForMoving2)
                             {
                                 filtered.Add(t);
                             }
                         }
                         battleChara = filtered;
+                    }
+                }
+                break;
+
+            case SpecialActionType.FriendlyMovingForward:
+                if (Svc.Targets.FocusTarget != null)
+                {
+                    if (Svc.Targets.FocusTarget is IBattleChara focus && focus.IsParty())
+                    {
+                        return focus;
+                    }
+                }
+                else if (Svc.Targets.FocusTarget == null && Svc.Targets.Target != null)
+                {
+                    if (Svc.Targets.Target is IBattleChara IsPartytarg && IsPartytarg.IsParty())
+                    {
+                        return IsPartytarg;
+                    }
+                }
+                break;
+
+            case SpecialActionType.HostileFriendlyMovingForward:
+                if (Svc.Targets.FocusTarget != null)
+                {
+                    if (Svc.Targets.FocusTarget is IBattleChara focus && focus.IsParty())
+                    {
+                        return focus;
+                    }
+                }
+                else if (Svc.Targets.FocusTarget == null && Svc.Targets.Target != null)
+                {
+                    if (Svc.Targets.Target is IBattleChara IsPartytarg && IsPartytarg.IsParty())
+                    {
+                        return IsPartytarg;
+                    }
+                    if (Svc.Targets.Target is IBattleChara IsHostiletarg && IsHostiletarg.IsHostile())
+                    {
+                        return IsHostiletarg;
                     }
                 }
                 break;
@@ -1233,6 +1281,13 @@ public struct ActionTargetInfo(IBaseAction action)
                         if (Svc.Targets.FocusTarget is IBattleChara focus && focus.IsParty())
                         {
                             return focus;
+                        }
+                    }
+                    else if (Svc.Targets.Target != null)
+                    {
+                        if (Svc.Targets.Target is IBattleChara targ && targ.IsParty())
+                        {
+                            return targ;
                         }
                     }
                 }
@@ -1746,7 +1801,7 @@ public struct ActionTargetInfo(IBaseAction action)
                 List<IBattleChara> filteredTargets = [];
                 foreach (var t in battleChara)
                 {
-                    if (t.DistanceToPlayer() > Service.Config.DistanceForMoving)
+                    if (t.DistanceToPlayer() > Service.Config.DistanceForMoving2)
                     {
                         continue;
                     }
@@ -1777,7 +1832,7 @@ public struct ActionTargetInfo(IBaseAction action)
                 List<IBattleChara> filteredTargets = [];
                 foreach (var t in battleChara)
                 {
-                    if (t.DistanceToPlayer() > Service.Config.DistanceForMoving)
+                    if (t.DistanceToPlayer() > Service.Config.DistanceForMoving2)
                     {
                         continue;
                     }

--- a/RotationSolver.Basic/Configuration/Configs.cs
+++ b/RotationSolver.Basic/Configuration/Configs.cs
@@ -176,6 +176,11 @@ internal partial class Configs : IPluginConfiguration
     Filter = AutoActionUsage)]
     private static readonly bool _usePhoenixDown = false;
 
+    [UI("Use damaging gap closer abilites if the distance to your target is less than this.",
+        Filter = AutoActionUsage)]
+    [Range(0, 30, ConfigUnitType.Yalms, 1f)]
+    public float DistanceForMoving2 { get; set; } = 3f;
+
     [ConditionBool, UI("Allow the use of AOEs against priority-marked targets.",
     Description = "Enable to allow AoE actions to hit targets with priority markers.",
     Parent = nameof(ChooseAttackMark))]
@@ -248,18 +253,6 @@ internal partial class Configs : IPluginConfiguration
 
     [ConditionBool, UI("Debug Mode", Filter = Debug)]
     private static readonly bool _inDebug = false;
-
-    [ConditionBool, UI("Load default rotations", Description = "Load the rotations provided by the Combat Reborn team", Filter = Rotations)]
-    private static readonly bool _loadDefaultRotations = true;
-
-    [ConditionBool, UI("Download custom rotations from the internet",
-               Description = "This will allow RSR to download custom rotations from the internet. This is a security risk and should only be enabled if you trust the source of the rotations.",
-               Filter = Rotations)]
-    private static readonly bool _downloadCustomRotations = true;
-
-    [ConditionBool, UI("Monitor local rotations for changes (Developer Mode)",
-               Filter = Rotations)]
-    private static readonly bool _autoReloadRotations = false;
 
     [ConditionBool, UI("Make /rotation Manual a toggle command.",
         Filter = BasicParams)]
@@ -787,10 +780,6 @@ internal partial class Configs : IPluginConfiguration
     Filter = TargetConfig)]
     private static readonly bool _ignoreNonFateInFate = true;
 
-    [ConditionBool, UI("Prevent targeting invalid targets in Bozjan Southern Front and Zadnor",
-        Filter = TargetConfig)]
-    private static readonly bool _bozjaCEmobtargeting = false;
-
     [ConditionBool, UI("Move to the furthest position for targeting area movement actions.",
         Filter = TargetConfig, Section = 2)]
     private static readonly bool _moveAreaActionFarthest = false;
@@ -864,11 +853,6 @@ internal partial class Configs : IPluginConfiguration
                 Filter = TargetConfig, Section = 1)]
     [Range(0, 0.1f, ConfigUnitType.Percent, 0.01f)]
     public float IsDyingConfig { get; set; } = 0.02f;
-
-    [UI("Use gapcloser as a damage ability if the distance to your target is less than this.",
-        Filter = TargetConfig, Section = 2)]
-    [Range(0, 30, ConfigUnitType.Yalms, 1f)]
-    public float DistanceForMoving { get; set; } = 1.2f;
 
     [ConditionBool, UI("Prioritize Low HP targets instead of High HP targets when using Small Target and multiple Small targets present.",
         Filter = TargetConfig)]

--- a/RotationSolver.Basic/Data/AutoStatus.cs
+++ b/RotationSolver.Basic/Data/AutoStatus.cs
@@ -105,4 +105,9 @@ public enum AutoStatus : uint
     /// Stop taking actions.
     /// </summary>
     NoCasting = 1 << 18,
+
+    /// <summary>
+    /// Intercepting indicator.
+    /// </summary>
+    Intercepting = 1 << 19,
 }

--- a/RotationSolver.Basic/Data/RSCommandType.cs
+++ b/RotationSolver.Basic/Data/RSCommandType.cs
@@ -88,6 +88,12 @@ public enum SpecialCommandType : byte
     /// </summary>
     [Description("Open a window to do not use the casting action.")]
     NoCasting,
+
+    /// <summary>
+    /// Intercepting action.
+    /// </summary>
+    [Description("Indicator for when RSR is intercepting action.")]
+    Intercepting,
 }
 
 /// <summary>

--- a/RotationSolver.Basic/DataCenter.cs
+++ b/RotationSolver.Basic/DataCenter.cs
@@ -469,6 +469,27 @@ internal static class DataCenter
     public static bool InVariantDungeon => AloaloIsland || MountRokkon || SildihnSubterrane;
     #endregion
 
+    #region Misc Duty Info
+    /// <summary>
+    /// 
+    /// </summary>
+    public static bool RathalosNormal => IsInTerritory(761);
+
+    /// <summary>
+    /// 
+    /// </summary>
+    public static bool RathalosEX => IsInTerritory(762);
+
+    //public static bool ArkveldNormal => IsInTerritory(?);
+
+    //public static bool ArkveldEX => IsInTerritory(?);
+
+    /// <summary>
+    /// 
+    /// </summary>
+    public static bool InMonsterHunterDuty => RathalosNormal || RathalosEX;
+    #endregion
+
     #region Job Info
     public static Job Job => Player.Job;
 

--- a/RotationSolver.Basic/Helpers/ObjectHelper.cs
+++ b/RotationSolver.Basic/Helpers/ObjectHelper.cs
@@ -202,7 +202,7 @@ public static class ObjectHelper
 
             if (isInCE)
             {
-                if (!battleChara.IsBozjanCEMob())
+                if (!battleChara.IsBozjanCEMob() && battleChara.GetBattleNPCSubKind() != BattleNpcSubKind.BattleNpcPart)
                 {
                     return false;
                 }
@@ -411,6 +411,28 @@ public static class ObjectHelper
         }
 
         if (ActionManager.CanUseActionOnTarget((uint)ActionID.BlizzardPvE, obj.Struct()))
+        {
+            return true;
+        }
+
+        return false;
+    }
+
+    internal static uint TargetCharaCondition(this IBattleChara obj)
+    {
+        uint statusId = obj.OnlineStatus.RowId;
+        if (statusId != 0)
+        {
+            return statusId;
+        }
+
+        return 0;
+    }
+
+    internal static bool IsConditionCannotTarget(this IBattleChara obj)
+    {
+        uint statusId = obj.OnlineStatus.RowId;
+        if (statusId == 15 || statusId == 5)
         {
             return true;
         }

--- a/RotationSolver.Basic/Helpers/TargetHelper.cs
+++ b/RotationSolver.Basic/Helpers/TargetHelper.cs
@@ -139,6 +139,8 @@ namespace RotationSolver.Basic.Helpers
 
             if (!battleChara.IsTargetable) return false;
 
+            if (!battleChara.IsEnemy() && battleChara.IsConditionCannotTarget()) return false;
+
             try
             {
                 if (battleChara.StatusList == null) return false;

--- a/RotationSolver.Basic/Rotations/Basic/AstrologianRotation.cs
+++ b/RotationSolver.Basic/Rotations/Basic/AstrologianRotation.cs
@@ -618,7 +618,7 @@ public partial class AstrologianRotation
 
     static partial void ModifyEpicyclePvP(ref ActionSetting setting)
     {
-        setting.SpecialType = SpecialActionType.MovingForward;
+        //setting.SpecialType = SpecialActionType.MovingForward;
         setting.IsFriendly = true;
     }
 

--- a/RotationSolver.Basic/Rotations/Basic/BlackMageRotation.cs
+++ b/RotationSolver.Basic/Rotations/Basic/BlackMageRotation.cs
@@ -329,7 +329,7 @@ public partial class BlackMageRotation
 
     static partial void ModifyAetherialManipulationPvE(ref ActionSetting setting)
     {
-        setting.TargetType = TargetType.FriendMove;
+        setting.SpecialType = SpecialActionType.FriendlyMovingForward;
     }
 
     static partial void ModifyFlarePvE(ref ActionSetting setting)
@@ -530,7 +530,7 @@ public partial class BlackMageRotation
 
     static partial void ModifyAetherialManipulationPvP(ref ActionSetting setting)
     {
-        setting.SpecialType = SpecialActionType.MovingForward;
+        setting.SpecialType = SpecialActionType.FriendlyMovingForward;
     }
 
     static partial void ModifyElementalWeavePvP(ref ActionSetting setting)

--- a/RotationSolver.Basic/Rotations/Basic/BlueMageRotation.cs
+++ b/RotationSolver.Basic/Rotations/Basic/BlueMageRotation.cs
@@ -290,7 +290,7 @@ public partial class BlueMageRotation
 
     static partial void ModifyFlyingFrenzyPvE(ref ActionSetting setting)
     {
-        setting.SpecialType = SpecialActionType.MovingForward;
+        //setting.SpecialType = SpecialActionType.MovingForward;
         setting.CreateConfig = () => new ActionConfig()
         {
             AoeCount = 3,
@@ -317,7 +317,7 @@ public partial class BlueMageRotation
 
     static partial void ModifyLoomPvE(ref ActionSetting setting)
     {
-        setting.SpecialType = SpecialActionType.MovingForward;
+        //setting.SpecialType = SpecialActionType.MovingForward;
         setting.IsFriendly = true;
         setting.CreateConfig = () => new ActionConfig()
         {

--- a/RotationSolver.Basic/Rotations/Basic/DancerRotation.cs
+++ b/RotationSolver.Basic/Rotations/Basic/DancerRotation.cs
@@ -366,6 +366,7 @@ public partial class DancerRotation
 
     static partial void ModifyEnAvantPvE(ref ActionSetting setting)
     {
+        setting.TargetType = TargetType.Move;
         setting.IsFriendly = true;
     }
 
@@ -578,14 +579,11 @@ public partial class DancerRotation
         setting.StatusProvide = [StatusID.ClosedPosition];
         setting.TargetStatusProvide = [StatusID.DancePartner];
         setting.TargetType = TargetType.DancePartner;
-        setting.CreateConfig = () => new ActionConfig()
-        {
-        };
     }
 
     static partial void ModifyEnAvantPvP(ref ActionSetting setting)
     {
-        setting.SpecialType = SpecialActionType.MovingForward;
+        //setting.SpecialType = SpecialActionType.MovingForward;
         setting.IsFriendly = true;
         setting.StatusProvide = [StatusID.EnAvant];
         setting.CreateConfig = () => new ActionConfig()

--- a/RotationSolver.Basic/Rotations/Basic/DarkKnightRotation.cs
+++ b/RotationSolver.Basic/Rotations/Basic/DarkKnightRotation.cs
@@ -283,7 +283,7 @@ public partial class DarkKnightRotation
     static partial void ModifyShadowstridePvE(ref ActionSetting setting)
     {
         setting.UnlockedByQuestID = 67597;
-        //setting.SpecialType = SpecialActionType.MovingForward;
+        setting.SpecialType = SpecialActionType.HostileMovingForward;
     }
 
     static partial void ModifyAbyssalDrainPvE(ref ActionSetting setting)
@@ -483,7 +483,7 @@ public partial class DarkKnightRotation
     }
     static partial void ModifyPlungePvP(ref ActionSetting setting)
     {
-        setting.SpecialType = SpecialActionType.MovingForward;
+        //setting.SpecialType = SpecialActionType.MovingForward;
     }
 
     static partial void ModifyScarletDeliriumPvP(ref ActionSetting setting)

--- a/RotationSolver.Basic/Rotations/Basic/DragoonRotation.cs
+++ b/RotationSolver.Basic/Rotations/Basic/DragoonRotation.cs
@@ -184,7 +184,7 @@ public partial class DragoonRotation
 
     static partial void ModifyWingedGlidePvE(ref ActionSetting setting)
     {
-        //setting.SpecialType = SpecialActionType.MovingForward;
+        setting.SpecialType = SpecialActionType.HostileMovingForward;
         setting.UnlockedByQuestID = 66607;
     }
 
@@ -406,7 +406,7 @@ public partial class DragoonRotation
 
     static partial void ModifyHighJumpPvP(ref ActionSetting setting)
     {
-        setting.SpecialType = SpecialActionType.MovingForward;
+        //setting.SpecialType = SpecialActionType.MovingForward;
     }
 
     static partial void ModifyElusiveJumpPvP(ref ActionSetting setting)

--- a/RotationSolver.Basic/Rotations/Basic/GunbreakerRotation.cs
+++ b/RotationSolver.Basic/Rotations/Basic/GunbreakerRotation.cs
@@ -291,7 +291,7 @@ public partial class GunbreakerRotation
 
     static partial void ModifyTrajectoryPvE(ref ActionSetting setting)
     {
-        //setting.SpecialType = SpecialActionType.MovingForward;
+        setting.SpecialType = SpecialActionType.HostileMovingForward;
     }
 
     static partial void ModifyGnashingFangPvE(ref ActionSetting setting)
@@ -510,7 +510,7 @@ public partial class GunbreakerRotation
 
     static partial void ModifyRoughDividePvP(ref ActionSetting setting)
     {
-        setting.SpecialType = SpecialActionType.MovingForward;
+        //setting.SpecialType = SpecialActionType.MovingForward;
     }
 
     static partial void ModifyBlastingZonePvP(ref ActionSetting setting)

--- a/RotationSolver.Basic/Rotations/Basic/MonkRotation.cs
+++ b/RotationSolver.Basic/Rotations/Basic/MonkRotation.cs
@@ -313,7 +313,7 @@ public partial class MonkRotation
 
     static partial void ModifyThunderclapPvE(ref ActionSetting setting)
     {
-        //setting.SpecialType = SpecialActionType.MovingForward;
+        setting.SpecialType = SpecialActionType.HostileFriendlyMovingForward;
         setting.UnlockedByQuestID = 66598;
         setting.IsFriendly = false;
     }
@@ -662,7 +662,7 @@ public partial class MonkRotation
 
     static partial void ModifyThunderclapPvP(ref ActionSetting setting)
     {
-        setting.SpecialType = SpecialActionType.MovingForward;
+        //setting.SpecialType = SpecialActionType.MovingForward;
     }
 
 

--- a/RotationSolver.Basic/Rotations/Basic/NinjaRotation.cs
+++ b/RotationSolver.Basic/Rotations/Basic/NinjaRotation.cs
@@ -669,7 +669,7 @@ public partial class NinjaRotation
 
     static partial void ModifyShukuchiPvP(ref ActionSetting setting)
     {
-        setting.SpecialType = SpecialActionType.MovingForward;
+        //setting.SpecialType = SpecialActionType.MovingForward;
     }
     #endregion
 

--- a/RotationSolver.Basic/Rotations/Basic/PaladinRotation.cs
+++ b/RotationSolver.Basic/Rotations/Basic/PaladinRotation.cs
@@ -322,7 +322,7 @@ public partial class PaladinRotation
 
     static partial void ModifyIntervenePvE(ref ActionSetting setting)
     {
-        //setting.SpecialType = SpecialActionType.MovingForward;
+        setting.SpecialType = SpecialActionType.HostileMovingForward;
     }
 
     static partial void ModifyAtonementPvE(ref ActionSetting setting)
@@ -507,7 +507,7 @@ public partial class PaladinRotation
 
     static partial void ModifyIntervenePvP(ref ActionSetting setting)
     {
-        setting.SpecialType = SpecialActionType.MovingForward;
+        //setting.SpecialType = SpecialActionType.MovingForward;
     }
 
     static partial void ModifyBladeOfFaithPvP(ref ActionSetting setting)

--- a/RotationSolver.Basic/Rotations/Basic/PictomancerRotation.cs
+++ b/RotationSolver.Basic/Rotations/Basic/PictomancerRotation.cs
@@ -398,7 +398,7 @@ public partial class PictomancerRotation
 
     static partial void ModifySmudgePvE(ref ActionSetting setting)
     {
-        //setting.SpecialType = SpecialActionType.MovingForward;
+        //setting.TargetType = TargetType.Move;
         setting.IsFriendly = true;
     }
 

--- a/RotationSolver.Basic/Rotations/Basic/ReaperRotation.cs
+++ b/RotationSolver.Basic/Rotations/Basic/ReaperRotation.cs
@@ -497,7 +497,7 @@ public partial class ReaperRotation
 
     static partial void ModifyHellsIngressPvP(ref ActionSetting setting)
     {
-        setting.SpecialType = SpecialActionType.MovingForward;
+        //setting.SpecialType = SpecialActionType.MovingForward;
         setting.IsFriendly = true;
     }
 

--- a/RotationSolver.Basic/Rotations/Basic/RedMageRotation.cs
+++ b/RotationSolver.Basic/Rotations/Basic/RedMageRotation.cs
@@ -235,7 +235,7 @@ public partial class RedMageRotation
 
     static partial void ModifyCorpsacorpsPvE(ref ActionSetting setting)
     {
-        
+        setting.SpecialType = SpecialActionType.HostileMovingForward;
     }
 
     static partial void ModifyVeraeroPvE(ref ActionSetting setting)
@@ -557,6 +557,7 @@ public partial class RedMageRotation
     static partial void ModifyCorpsacorpsPvP(ref ActionSetting setting)
     {
         setting.TargetStatusProvide = [StatusID.Monomachy_3242];
+        setting.SpecialType = SpecialActionType.HostileMovingForward;
     }
 
     static partial void ModifyDisplacementPvP(ref ActionSetting setting)

--- a/RotationSolver.Basic/Rotations/Basic/SageRotation.cs
+++ b/RotationSolver.Basic/Rotations/Basic/SageRotation.cs
@@ -177,7 +177,7 @@ public partial class SageRotation
 
     static partial void ModifyIcarusPvE(ref ActionSetting setting)
     {
-        //setting.SpecialType = SpecialActionType.MovingForward;
+        setting.SpecialType = SpecialActionType.HostileFriendlyMovingForward;
     }
 
     static partial void ModifyDruocholePvE(ref ActionSetting setting)
@@ -434,7 +434,7 @@ public partial class SageRotation
 
     static partial void ModifyIcarusPvP(ref ActionSetting setting)
     {
-        setting.SpecialType = SpecialActionType.MovingForward;
+        //setting.SpecialType = SpecialActionType.MovingForward;
     }
 
     static partial void ModifyToxikonPvP(ref ActionSetting setting)

--- a/RotationSolver.Basic/Rotations/Basic/SamuraiRotation.cs
+++ b/RotationSolver.Basic/Rotations/Basic/SamuraiRotation.cs
@@ -352,7 +352,7 @@ public partial class SamuraiRotation
 
     static partial void ModifyHissatsuGyotenPvE(ref ActionSetting setting)
     {
-        //setting.SpecialType = SpecialActionType.MovingForward;
+        setting.SpecialType = SpecialActionType.HostileMovingForward;
         setting.ActionCheck = () => Kenki >= 10;
         setting.CreateConfig = () => new ActionConfig()
         {

--- a/RotationSolver.Basic/Rotations/Basic/SummonerRotation.cs
+++ b/RotationSolver.Basic/Rotations/Basic/SummonerRotation.cs
@@ -657,6 +657,7 @@ public partial class SummonerRotation
 
     static partial void ModifyCrimsonCyclonePvE(ref ActionSetting setting)
     {
+        //setting.SpecialType = SpecialActionType.HostileMovingForward;
         setting.StatusProvide = [StatusID.CrimsonStrikeReady_4403];
         setting.StatusNeed = [StatusID.IfritsFavor];
         setting.ActionCheck = () => InIfrit;
@@ -780,7 +781,7 @@ public partial class SummonerRotation
 
     static partial void ModifyCrimsonCyclonePvP(ref ActionSetting setting)
     {
-        //setting.SpecialType = SpecialActionType.MovingForward;
+        //setting.SpecialType = SpecialActionType.HostileMovingForward;
         setting.StatusProvide = [StatusID.CrimsonStrikeReady_4403];
         setting.CreateConfig = () => new ActionConfig()
         {

--- a/RotationSolver.Basic/Rotations/Basic/ViperRotation.cs
+++ b/RotationSolver.Basic/Rotations/Basic/ViperRotation.cs
@@ -449,6 +449,7 @@ public partial class ViperRotation
 
     static partial void ModifySlitherPvE(ref ActionSetting setting)
     {
+        setting.SpecialType = SpecialActionType.HostileFriendlyMovingForward;
         setting.IsFriendly = false;
     }
 

--- a/RotationSolver.Basic/Rotations/Basic/WarriorRotation.cs
+++ b/RotationSolver.Basic/Rotations/Basic/WarriorRotation.cs
@@ -242,7 +242,7 @@ public partial class WarriorRotation
 
     static partial void ModifyOnslaughtPvE(ref ActionSetting setting)
     {
-        //setting.SpecialType = SpecialActionType.MovingForward;
+        setting.SpecialType = SpecialActionType.HostileMovingForward;
     }
 
     static partial void ModifyUpheavalPvE(ref ActionSetting setting)
@@ -296,6 +296,7 @@ public partial class WarriorRotation
 
     static partial void ModifyPrimalRendPvE(ref ActionSetting setting)
     {
+        //setting.SpecialType = SpecialActionType.HostileMovingForward;
         setting.StatusNeed = [StatusID.PrimalRendReady];
         setting.StatusProvide = [StatusID.PrimalRuinationReady];
         setting.MPOverride = () => 0;
@@ -364,7 +365,7 @@ public partial class WarriorRotation
 
     static partial void ModifyPrimalRendPvP(ref ActionSetting setting)
     {
-        setting.SpecialType = SpecialActionType.MovingForward;
+        //setting.SpecialType = SpecialActionType.MovingForward;
         setting.CreateConfig = () => new ActionConfig()
         {
             AoeCount = 1,
@@ -383,12 +384,12 @@ public partial class WarriorRotation
 
     static partial void ModifyBlotaPvP(ref ActionSetting setting)
     {
-        setting.SpecialType = SpecialActionType.MovingForward;
+        //setting.SpecialType = SpecialActionType.MovingForward;
     }
 
     static partial void ModifyOnslaughtPvP(ref ActionSetting setting)
     {
-        setting.SpecialType = SpecialActionType.MovingForward;
+        //setting.SpecialType = SpecialActionType.MovingForward;
     }
 
     static partial void ModifyFellCleavePvP(ref ActionSetting setting)

--- a/RotationSolver.Basic/Rotations/Basic/WhiteMageRotation.cs
+++ b/RotationSolver.Basic/Rotations/Basic/WhiteMageRotation.cs
@@ -183,7 +183,7 @@ public partial class WhiteMageRotation
 
     static partial void ModifyAetherialShiftPvE(ref ActionSetting setting)
     {
-        //setting.SpecialType = SpecialActionType.MovingForward;
+        setting.TargetType = TargetType.Move;
         setting.IsFriendly = true;
     }
 
@@ -406,7 +406,7 @@ public partial class WhiteMageRotation
 
     static partial void ModifySeraphStrikePvP(ref ActionSetting setting)
     {
-        setting.SpecialType = SpecialActionType.MovingForward;
+        //setting.SpecialType = SpecialActionType.MovingForward;
         setting.CreateConfig = () => new ActionConfig()
         {
             AoeCount = 1,

--- a/RotationSolver.Basic/Rotations/CustomRotation_Ability.cs
+++ b/RotationSolver.Basic/Rotations/CustomRotation_Ability.cs
@@ -126,9 +126,12 @@ public partial class CustomRotation
             {
                 return true;
             }
-            if (HealAreaAbility(nextGCD, out act))
+            if (!Player.HasStatus(false, StatusID.Scalebound))
             {
-                return true;
+                if (HealAreaAbility(nextGCD, out act))
+                {
+                    return true;
+                }
             }
             IBaseAction.AllEmpty = false;
             IBaseAction.ShouldEndSpecial = false;
@@ -141,9 +144,12 @@ public partial class CustomRotation
             {
                 return true;
             }
-            if (HealAreaAbility(nextGCD, out act))
+            if (!Player.HasStatus(false, StatusID.Scalebound))
             {
-                return true;
+                if (HealAreaAbility(nextGCD, out act))
+                {
+                    return true;
+                }
             }
             IBaseAction.AutoHealCheck = false;
         }
@@ -156,9 +162,12 @@ public partial class CustomRotation
             {
                 return true;
             }
-            if (HealSingleAbility(nextGCD, out act))
+            if (!Player.HasStatus(false, StatusID.Scalebound))
             {
-                return true;
+                if (HealSingleAbility(nextGCD, out act))
+                {
+                    return true;
+                }
             }
             IBaseAction.AllEmpty = false;
             IBaseAction.ShouldEndSpecial = false;
@@ -171,9 +180,12 @@ public partial class CustomRotation
             {
                 return true;
             }
-            if (HealSingleAbility(nextGCD, out act))
+            if (!Player.HasStatus(false, StatusID.Scalebound))
             {
-                return true;
+                if (HealSingleAbility(nextGCD, out act))
+                {
+                    return true;
+                }
             }
             IBaseAction.AutoHealCheck = false;
         }

--- a/RotationSolver.Basic/Rotations/CustomRotation_GCD.cs
+++ b/RotationSolver.Basic/Rotations/CustomRotation_GCD.cs
@@ -185,9 +185,12 @@ public partial class CustomRotation
                 if (DataCenter.CurrentDutyRotation?.HealAreaGCD(out act) == true)
                     return act;
 
-                if (HealAreaGCD(out IAction? action))
+                if (!Player.HasStatus(false, StatusID.Scalebound))
                 {
-                    return action;
+                    if (HealAreaGCD(out IAction? action))
+                    {
+                        return action;
+                    }
                 }
                 IBaseAction.AutoHealCheck = false;
             }
@@ -202,9 +205,12 @@ public partial class CustomRotation
 
                 if (CanHealAreaSpell)
                 {
-                    if (HealAreaGCD(out IAction? action))
+                    if (!Player.HasStatus(false, StatusID.Scalebound))
                     {
-                        return action;
+                        if (HealAreaGCD(out IAction? action))
+                        {
+                            return action;
+                        }
                     }
                 }
 
@@ -217,9 +223,12 @@ public partial class CustomRotation
                 if (DataCenter.CurrentDutyRotation?.HealSingleGCD(out act) == true)
                     return act;
 
-                if (HealSingleGCD(out IAction? action))
+                if (!Player.HasStatus(false, StatusID.Scalebound))
                 {
-                    return action;
+                    if (HealSingleGCD(out IAction? action))
+                    {
+                        return action;
+                    }
                 }
                 IBaseAction.AutoHealCheck = false;
             }
@@ -237,9 +246,12 @@ public partial class CustomRotation
 
                 if (CanHealSingleSpell)
                 {
-                    if (HealSingleGCD(out IAction? action))
+                    if (!Player.HasStatus(false, StatusID.Scalebound))
                     {
-                        return action;
+                        if (HealSingleGCD(out IAction? action))
+                        {
+                            return action;
+                        }
                     }
                 }
 

--- a/RotationSolver.Basic/Rotations/Duties/DutyRotation.cs
+++ b/RotationSolver.Basic/Rotations/Duties/DutyRotation.cs
@@ -171,6 +171,16 @@ public partial class DutyRotation : IDisposable
     /// <summary>
     /// 
     /// </summary>
+    public static bool RathalosEX => DataCenter.RathalosEX;
+
+    /// <summary>
+    /// 
+    /// </summary>
+    public static bool RathalosNormal => DataCenter.RathalosNormal;
+
+    /// <summary>
+    /// 
+    /// </summary>
     public static bool SildihnSubterrane => DataCenter.SildihnSubterrane;
 
     /// <summary>

--- a/RotationSolver.Basic/Rotations/Duties/EmanationRotation.cs
+++ b/RotationSolver.Basic/Rotations/Duties/EmanationRotation.cs
@@ -3,7 +3,7 @@
 /// <summary>
 /// The variant action.
 /// </summary>
-[DutyTerritory(263, 264)] // 263: Emanation, 264: Emanation Extreme
+[DutyTerritory(719, 720)]
 public abstract class EmanationRotation : DutyRotation
 {
 }
@@ -17,6 +17,7 @@ public partial class DutyRotation
     static partial void ModifyVrilPvE(ref ActionSetting setting)
     {
         setting.StatusFromSelf = true;
+        setting.TargetType = TargetType.Self;
         setting.TargetStatusProvide = [StatusID.Vril];
     }
 
@@ -27,6 +28,7 @@ public partial class DutyRotation
     static partial void ModifyVrilPvE_9345(ref ActionSetting setting)
     {
         setting.StatusFromSelf = true;
+        setting.TargetType = TargetType.Self;
         setting.TargetStatusProvide = [StatusID.Vril];
     }
 }

--- a/RotationSolver.Basic/Rotations/Duties/MonsterHunterRotation.cs
+++ b/RotationSolver.Basic/Rotations/Duties/MonsterHunterRotation.cs
@@ -1,0 +1,23 @@
+﻿namespace RotationSolver.Basic.Rotations.Duties;
+
+/// <summary>
+/// Represents a rotation for variant duties in the game.
+/// </summary>
+[DutyTerritory(761, 762)]
+public abstract class MonsterHunterRotation : DutyRotation
+{
+}
+
+public partial class DutyRotation
+{
+    /// <summary>
+    /// Modifies the settings for MegaPotionPvE.
+    /// </summary>
+    /// <param name="setting">The action setting to modify.</param>
+    static partial void ModifyMegaPotionPvE(ref ActionSetting setting)
+    {
+        setting.TargetType = TargetType.Self;
+        setting.IsFriendly = true;
+        setting.StatusNeed = [StatusID.Scalebound];
+    }
+}

--- a/RotationSolver/Commands/RSCommands_StateSpecialCommand.cs
+++ b/RotationSolver/Commands/RSCommands_StateSpecialCommand.cs
@@ -307,7 +307,7 @@ namespace RotationSolver.Commands
             UpdateToast();
         }
 
-        private static void DoSpecialCommandType(SpecialCommandType specialType, bool sayout = true)
+        public static void DoSpecialCommandType(SpecialCommandType specialType, bool sayout = true)
         {
             DoOneCommandType((type, role) => type.ToSpecialString(role), role =>
             {

--- a/RotationSolver/RebornRotations/Duty/EmanationDefault.cs
+++ b/RotationSolver/RebornRotations/Duty/EmanationDefault.cs
@@ -1,0 +1,48 @@
+﻿using RotationSolver.Basic.Rotations.Duties;
+
+namespace RotationSolver.RebornRotations.Duty;
+
+[Rotation("Beauty's Wicked Wiles", CombatType.PvE)]
+
+internal class EmanationDefault : EmanationRotation
+{
+    public override void DisplayDutyStatus()
+    {
+        ImGui.Spacing();
+        ImGui.Text($"VrilPvE Slotted: {VrilPvE.Info.IsOnSlot}");
+        ImGui.Text($"VrilPvE Charges: {VrilPvE.Cooldown.CurrentCharges}");
+        ImGui.Spacing();
+        ImGui.Text($"VrilPvE_9345 Slotted: {VrilPvE_9345.Info.IsOnSlot}");
+        ImGui.Text($"VrilPvE_9345 Charges: {VrilPvE_9345.Cooldown.CurrentCharges}");
+        ImGui.Spacing();
+    }
+
+    #region Configs
+    [RotationConfig(CombatType.PvE, Name = "Auto Use Vril")]
+    public bool AllowVril { get; set; } = false;
+    #endregion
+
+    public override bool EmergencyAbility(IAction nextGCD, out IAction? act)
+    {
+        if (AllowVril)
+        {
+            if (VrilPvE.Cooldown.CurrentCharges > 0)
+            {
+                if (VrilPvE.CanUse(out act))
+                {
+                    return true;
+                }
+            }
+
+            if (VrilPvE_9345.Cooldown.CurrentCharges > 0)
+            {
+                if (VrilPvE_9345.CanUse(out act))
+                {
+                    return true;
+                }
+            }
+        }
+
+        return base.EmergencyAbility(nextGCD, out act);
+    }
+}

--- a/RotationSolver/RebornRotations/Duty/MonsterHunterDefault.cs
+++ b/RotationSolver/RebornRotations/Duty/MonsterHunterDefault.cs
@@ -1,0 +1,35 @@
+﻿using RotationSolver.Basic.Rotations.Duties;
+
+namespace RotationSolver.RebornRotations.Duty;
+
+[Rotation("Monster Hunter", CombatType.PvE)]
+
+internal class MonsterHunterDefault : MonsterHunterRotation
+{
+    public override void DisplayDutyStatus()
+    {
+        ImGui.Spacing();
+        ImGui.Text($"MegaPotionPvE Slotted: {MegaPotionPvE.Info.IsOnSlot}");
+        ImGui.Text($"MegaPotionPvE Charges: {MegaPotionPvE.Cooldown.CurrentCharges}");
+        ImGui.Spacing();
+        ImGui.Spacing();
+        ImGui.Text($"Rathalos Normal: {RathalosNormal}");
+        ImGui.Text($"Rathalos EX: {RathalosEX}");
+        //ImGui.Text($"Arkveld Normal: {ArkveldNormal}");
+        //ImGui.Text($"Arkveld EX: {ArkveldEX}");
+        ImGui.Spacing();
+    }
+
+    public override bool HealSingleAbility(IAction nextGCD, out IAction? act)
+    {
+        if (MegaPotionPvE.Cooldown.CurrentCharges > 0)
+        {
+            if (MegaPotionPvE.CanUse(out act))
+            {
+                return true;
+            }
+        }
+
+        return base.HealSingleAbility(nextGCD, out act);
+    }
+}

--- a/RotationSolver/RebornRotations/Magical/RDM_Reborn.cs
+++ b/RotationSolver/RebornRotations/Magical/RDM_Reborn.cs
@@ -26,13 +26,6 @@ public sealed class RDM_Reborn : RedMageRotation
 
     [RotationConfig(CombatType.PvE, Name = "Use Displacement after Engagement (use at own risk).")]
     public bool SuicideByDumber { get; set; } = false;
-
-    [RotationConfig(CombatType.PvE, Name = "Use Corps-a-corps when standing still (use at own risk). (Ignores the below setting)")]
-    public bool SuicideByDumb { get; set; } = false;
-
-    [Range(0, 25, ConfigUnitType.Yalms)]
-    [RotationConfig(CombatType.PvE, Name = "Distance to target to use Corps-a-corps automatically")]
-    public float CorpsDistance { get; set; } = 3f;
     #endregion
 
     private static BaseAction VeraeroPvEStartUp { get; } = new BaseAction(ActionID.VeraeroPvE, false);
@@ -232,15 +225,7 @@ public sealed class RDM_Reborn : RedMageRotation
             return true;
         }
 
-        if (CorpsacorpsPvE.CanUse(out act, usedUp: HasEmbolden || !EmboldenPvE.EnoughLevel || CorpsacorpsPvE.Cooldown.WillHaveXChargesGCD(2, 1)))
-        {
-            if (CorpsacorpsPvE.Target.Target != null && CorpsacorpsPvE.Target.Target.DistanceToPlayer() <= CorpsDistance)
-            {
-                return true;
-            }
-        }
-
-        if (SuicideByDumb && !IsMoving && CorpsacorpsPvE.CanUse(out act, usedUp: HasEmbolden || !EmboldenPvE.EnoughLevel || CorpsacorpsPvE.Cooldown.WillHaveXChargesGCD(2, 1)))
+        if (!IsMoving && CorpsacorpsPvE.CanUse(out act, usedUp: HasEmbolden || !EmboldenPvE.EnoughLevel || CorpsacorpsPvE.Cooldown.WillHaveXChargesGCD(2, 1)))
         {
             return true;
         }

--- a/RotationSolver/RebornRotations/Tank/WAR_Reborn.cs
+++ b/RotationSolver/RebornRotations/Tank/WAR_Reborn.cs
@@ -19,7 +19,7 @@ public sealed class WAR_Reborn : WarriorRotation
     [RotationConfig(CombatType.PvE, Name = "Use both stacks of Onslaught during burst while standing still")]
     public bool YEETBurst { get; set; } = true;
 
-    [RotationConfig(CombatType.PvE, Name = "Use a stack of Onslaught during when its about to overcap while standing still")]
+    [RotationConfig(CombatType.PvE, Name = "Use a stack of Onslaught when its about to overcap while standing still")]
     public bool YEETCooldown { get; set; } = false;
 
     [RotationConfig(CombatType.PvE, Name = "Use Primal Rend while moving (Dangerous)")]

--- a/RotationSolver/UI/RotationConfigWindow.cs
+++ b/RotationSolver/UI/RotationConfigWindow.cs
@@ -476,6 +476,7 @@ public partial class RotationConfigWindow : Window
                         var _ when DataCenter.IsInOccultCrescentOp => $"Duty - {DutyRotation.ActivePhantomJob}",
                         var _ when DataCenter.InVariantDungeon => "Duty - Variant",
                         var _ when DataCenter.IsInBozja => "Duty - Bozja",
+                        var _ when DataCenter.InMonsterHunterDuty => "Duty - Monster Hunter",
                         _ => "Duty",
                     };
                 }
@@ -3599,6 +3600,7 @@ public partial class RotationConfigWindow : Window
             ImGui.Spacing();
             ImGui.Text($"NamePlate Icon ID: {battleChara.GetNamePlateIcon()}");
             ImGui.Text($"Event Type: {battleChara.GetEventType()}");
+            ImGui.Text($"TargetCharaCondition: {battleChara.TargetCharaCondition()}");
             //ImGui.Text($"GetMarkerNumber: {MarkingHelper.GetMarkerNumber((long)battleChara.GameObjectId)}");
             ImGui.Text($"Name Id: {battleChara.NameId}");
             ImGui.Text($"Data Id: {battleChara.DataId}");

--- a/RotationSolver/Updaters/ActionQueueManager.cs
+++ b/RotationSolver/Updaters/ActionQueueManager.cs
@@ -3,6 +3,7 @@ using ECommons.DalamudServices;
 using ECommons.GameHelpers;
 using ECommons.Logging;
 using FFXIVClientStructs.FFXIV.Client.Game;
+using RotationSolver.Commands;
 
 namespace RotationSolver.Updaters
 {
@@ -185,8 +186,17 @@ namespace RotationSolver.Updaters
         {
             try
             {
+                // Abandoned idea
+                //if (matchingAction is IBaseAction baseAction && baseAction.Setting.SpecialType == SpecialActionType.HostileMovingForward)
+                //{
+                //    RSCommands.DoSpecialCommandType(SpecialCommandType.Intercepting);
+                //    DataCenter.AddCommandAction(matchingAction, Service.Config.InterceptActionTime);
+                //    return; // Do not queue the original action; open the special window instead
+                //}
+
                 // Use DataCenter.AddCommandAction directly instead of going through RSCommands.DoActionCommand
                 // This avoids the string parsing overhead and potential format issues
+                RSCommands.DoSpecialCommandType(SpecialCommandType.Intercepting);
                 DataCenter.AddCommandAction(matchingAction, Service.Config.InterceptActionTime);
 
                 PluginLog.Debug($"[ActionQueueManager] Intercepted and queued action: {matchingAction.Name} (OriginalID: {actionID}, AdjustedID: {matchingAction.AdjustedID})");

--- a/RotationSolver/Updaters/StateUpdater.cs
+++ b/RotationSolver/Updaters/StateUpdater.cs
@@ -514,6 +514,7 @@ internal static class StateUpdater
             SpecialCommandType.AntiKnockback => AutoStatus.AntiKnockback,
             SpecialCommandType.Burst => AutoStatus.Burst,
             SpecialCommandType.Speed => AutoStatus.Speed,
+            SpecialCommandType.Intercepting => AutoStatus.Intercepting,
             _ => AutoStatus.None,
         };
 

--- a/RotationSolver/Updaters/TargetUpdater.cs
+++ b/RotationSolver/Updaters/TargetUpdater.cs
@@ -90,11 +90,7 @@ internal static partial class TargetUpdater
                 FFXIVClientStructs.FFXIV.Client.Game.Character.Character* character = member.Character();
                 if (character == null) continue;
 
-                byte status = character->CharacterData.OnlineStatus;
-                if (status != 15 && status != 5 && member.IsTargetable)
-                {
-                    members.Add(member);
-                }
+                members.Add(member);
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
- Monster Hunter duty support
- Rework for movement abilities
- Added indicator for intercepted actions
- Fix for not counting players in cutscene as party members
- Fix for Bozja CLL boss part not being attacked
- Removed a couple dead settings that didn't actually change anything