### PR TITLE
Rotation Command Enums fix.

### DIFF
--- a/RotationSolver.Basic/Configuration/RotationConfig/RotationConfigCombo.cs
+++ b/RotationSolver.Basic/Configuration/RotationConfig/RotationConfigCombo.cs
@@ -13,6 +13,11 @@ internal class RotationConfigCombo : RotationConfigBase
     public string[] DisplayValues { get; }
 
     /// <summary>
+    /// Gets the enum names for the combo box.
+    /// </summary>
+    private string[] EnumNames { get; }
+
+    /// <summary>
     /// Initializes a new instance of the <see cref="RotationConfigCombo"/> class.
     /// </summary>
     /// <param name="rotation">The custom rotation instance.</param>
@@ -26,17 +31,20 @@ internal class RotationConfigCombo : RotationConfigBase
         }
 
         List<string> names = [];
+        List<string> enumNames = [];
         foreach (Enum v in Enum.GetValues(property.PropertyType))
         {
             // Retrieve the Description attribute if it exists
             FieldInfo? fieldInfo = property.PropertyType.GetField(v.ToString());
             DescriptionAttribute? descriptionAttribute = fieldInfo?.GetCustomAttribute<DescriptionAttribute>();
             names.Add(descriptionAttribute?.Description ?? v.ToString());
+            enumNames.Add(v.ToString());
         }
 
         DisplayValues = names.ToArray();
+        EnumNames = enumNames.ToArray();
 
-        // Set the Value to the description of the default enum value
+        // Set the Value to the display value of the default enum value
         object? defaultEnumValue = property.GetValue(rotation);
         if (defaultEnumValue is Enum defaultEnum)
         {
@@ -64,17 +72,20 @@ internal class RotationConfigCombo : RotationConfigBase
         }
 
         List<string> names = [];
+        List<string> enumNames = [];
         foreach (Enum v in Enum.GetValues(property.PropertyType))
         {
             // Retrieve the Description attribute if it exists
             FieldInfo? fieldInfo = property.PropertyType.GetField(v.ToString());
             DescriptionAttribute? descriptionAttribute = fieldInfo?.GetCustomAttribute<DescriptionAttribute>();
             names.Add(descriptionAttribute?.Description ?? v.ToString());
+            enumNames.Add(v.ToString());
         }
 
         DisplayValues = names.ToArray();
+        EnumNames = enumNames.ToArray();
 
-        // Set the Value to the description of the default enum value
+        // Set the Value to the display value of the default enum value
         object? defaultEnumValue = property.GetValue(rotation);
         if (defaultEnumValue is Enum defaultEnum)
         {
@@ -94,8 +105,7 @@ internal class RotationConfigCombo : RotationConfigBase
     /// <returns>A string that represents the current object.</returns>
     public override string ToString()
     {
-        string indexStr = base.ToString();
-        return !int.TryParse(indexStr, out int index) || index < 0 || index >= DisplayValues.Length ? DisplayValues[0] : DisplayValues[index];
+        return Value;
     }
 
     /// <summary>
@@ -114,7 +124,9 @@ internal class RotationConfigCombo : RotationConfigBase
         string numStr = str[Name.Length..].Trim();
         int length = DisplayValues.Length;
 
-        int nextId = (int.Parse(Value) + 1) % length;
+        int currentIndex = Array.IndexOf(DisplayValues, Value);
+        if (currentIndex == -1) currentIndex = 0;
+        int nextId = (currentIndex + 1) % length;
         if (int.TryParse(numStr, out int num))
         {
             nextId = num % length;
@@ -123,7 +135,8 @@ internal class RotationConfigCombo : RotationConfigBase
         {
             for (int i = 0; i < length; i++)
             {
-                if (DisplayValues[i].Equals(str, StringComparison.OrdinalIgnoreCase))
+                if (DisplayValues[i].Equals(numStr, StringComparison.OrdinalIgnoreCase) ||
+                    EnumNames[i].Equals(numStr, StringComparison.OrdinalIgnoreCase))
                 {
                     nextId = i;
                     break;
@@ -131,7 +144,7 @@ internal class RotationConfigCombo : RotationConfigBase
             }
         }
 
-        Value = nextId.ToString();
+        Value = DisplayValues[nextId];
         return true;
     }
 }

--- a/RotationSolver/Commands/RSCommands_OtherCommand.cs
+++ b/RotationSolver/Commands/RSCommands_OtherCommand.cs
@@ -427,7 +427,8 @@ public static partial class RSCommands
         IRotationConfigSet configs = customCombo.Configs;
         foreach (IRotationConfig config in configs)
         {
-            if (config.DoCommand(configs, str))
+            bool result = config.DoCommand(configs, str);
+            if (result)
             {
                 if (Service.Config.ShowToggledSettingInChat)
                 {


### PR DESCRIPTION
This pull request refactors the handling of combo box configuration values in the rotation solver. The main improvements are to how enum values and their display names are managed and selected, making the code more robust and user-friendly. The changes ensure that the display value is consistently used for selection and output, and that both display names and enum names can be matched when processing commands.

**Combo box value and selection improvements:**

* Added a private `EnumNames` array to the `RotationConfigCombo` class to store the enum value names alongside their display values, allowing for more flexible matching and selection.
* Updated constructors in `RotationConfigCombo` to populate both `DisplayValues` and `EnumNames`, ensuring both are available for command processing. [[1]](diffhunk://#diff-ec295cb204749481923e23b14c2b140292aa891da1221aec0da42b7ff8592762R34-R47) [[2]](diffhunk://#diff-ec295cb204749481923e23b14c2b140292aa891da1221aec0da42b7ff8592762R75-R88)
* Refactored the `ToString()` method to return the current `Value` (the display value) instead of computing it from an index, improving clarity and consistency.

**Command processing enhancements:**

* Improved the `DoCommand` method to use the display value for selection, and to match both display values and enum names when processing input, allowing for more intuitive user commands. [[1]](diffhunk://#diff-ec295cb204749481923e23b14c2b140292aa891da1221aec0da42b7ff8592762L117-R129) [[2]](diffhunk://#diff-ec295cb204749481923e23b14c2b140292aa891da1221aec0da42b7ff8592762L126-R147)
* Minor adjustment in `RSCommands_OtherCommand.cs` to clarify the result of `DoCommand` and improve code readability.