### PR TITLE
DNC hotfix

### DIFF
--- a/RotationSolver/ExtraRotations/Ranged/ChurinDNC.cs
+++ b/RotationSolver/ExtraRotations/Ranged/ChurinDNC.cs
@@ -90,8 +90,7 @@ public sealed class ChurinDNC : DancerRotation
                 {
                     return AreDanceTargetsInRange;
                 }
-
-                return true;
+                else return true;
             }
             
             if (TechHoldStrategy == HoldStrategy.HoldFinishOnly)
@@ -100,12 +99,13 @@ public sealed class ChurinDNC : DancerRotation
                 {
                     return AreDanceTargetsInRange;
                 }
-                return true;
+                else return true;
             }
             if (TechHoldStrategy == HoldStrategy.HoldStepAndFinish)
             {
                 return AreDanceTargetsInRange;
             }
+
             if (TechHoldStrategy == HoldStrategy.DontHoldStepAndFinish)
             {
                 return true;
@@ -119,7 +119,7 @@ public sealed class ChurinDNC : DancerRotation
                 {
                     return AreDanceTargetsInRange;
                 }
-                return true;
+                else return true;
             }
             if (StandardHoldStrategy == HoldStrategy.HoldFinishOnly)
             {
@@ -128,7 +128,7 @@ public sealed class ChurinDNC : DancerRotation
                     return AreDanceTargetsInRange;
                 }
 
-                return true;
+                else return true;
             }
             if (StandardHoldStrategy == HoldStrategy.HoldStepAndFinish)
             {
@@ -471,7 +471,7 @@ public sealed class ChurinDNC : DancerRotation
         act = null;
         if (!HasStandardStep || HasFinishingMove) return false;
 
-        var shouldFinish = CompletedSteps == 2 && CanUseStepHoldCheck(StandardHoldStrategy);
+        var shouldFinish = HasStandardStep && CompletedSteps == 2 && CanUseStepHoldCheck(StandardHoldStrategy);
         var aboutToTimeOut = Player.WillStatusEnd(1, true, StatusID.StandardStep);
 
         if ((shouldFinish || aboutToTimeOut) && DoubleStandardFinishPvE.CanUse(out act, skipAoeCheck: true))
@@ -487,7 +487,7 @@ public sealed class ChurinDNC : DancerRotation
         act = null;
         if (!HasTechnicalStep) return false;
 
-        var shouldFinish = CompletedSteps == 4 && CanUseStepHoldCheck(TechHoldStrategy);
+        var shouldFinish = HasTechnicalStep && CompletedSteps == 4 && CanUseStepHoldCheck(TechHoldStrategy);
         var aboutToTimeOut = Player.WillStatusEnd(1, true, StatusID.TechnicalStep);
 
         if ((shouldFinish || aboutToTimeOut) && QuadrupleTechnicalFinishPvE.CanUse(out act, skipAoeCheck: true))


### PR DESCRIPTION
This pull request makes several small but important adjustments to the logic in the `ChurinDNC.cs` file, primarily improving the correctness and clarity of step finishing conditions and the `CanUseStepHoldCheck` method. The main focus is on ensuring that checks for finishing steps are more robust and that conditional branches are explicit.

Logic improvements for step finishing:

* In both `TryFinishStandard` and `TryFinishTech`, the `shouldFinish` condition now explicitly checks for the presence of the relevant step (`HasStandardStep` or `HasTechnicalStep`) before allowing a finish, preventing incorrect finishes when the step is not active. [[1]](diffhunk://#diff-47a4eb6c618e99b36d8294fb8cab1da42f6e3561e705aa2075ffe4f2a2549957L474-R474) [[2]](diffhunk://#diff-47a4eb6c618e99b36d8294fb8cab1da42f6e3561e705aa2075ffe4f2a2549957L490-R490)

Code clarity and control flow in hold check logic:

* In the `CanUseStepHoldCheck` method, added explicit `else` branches before returning `true` in several places to clarify intent and make the control flow more readable. This doesn't change functionality but improves code clarity and maintainability. [[1]](diffhunk://#diff-47a4eb6c618e99b36d8294fb8cab1da42f6e3561e705aa2075ffe4f2a2549957L93-R93) [[2]](diffhunk://#diff-47a4eb6c618e99b36d8294fb8cab1da42f6e3561e705aa2075ffe4f2a2549957L103-R108) [[3]](diffhunk://#diff-47a4eb6c618e99b36d8294fb8cab1da42f6e3561e705aa2075ffe4f2a2549957L122-R122) [[4]](diffhunk://#diff-47a4eb6c618e99b36d8294fb8cab1da42f6e3561e705aa2075ffe4f2a2549957L131-R131)