### PR TITLE
ChurinDNC optimization

### DIFF
--- a/RotationSolver.Basic/Rotations/CustomRotation_OtherInfo.cs
+++ b/RotationSolver.Basic/Rotations/CustomRotation_OtherInfo.cs
@@ -828,7 +828,7 @@ public partial class CustomRotation
                 return false;
 
             // Finally, attempt to use the burst medicine
-            return rotation.UseBurstMedicine(out act);
+            return IsConditionMet() && CanUseAtTime() && rotation.UseBurstMedicine(out act);
         }
 
         /// <summary>


### PR DESCRIPTION
This pull request makes significant updates to the Dancer (DNC) rotation logic in the `ChurinDNC` class, focusing on improving skill usage decisions, especially around step actions, burst phases, and potion timing. The changes refine conditional checks for ability usage, enhance the logic for burst and filler actions, and corrects some edge cases for step and potion usage.

Key changes include:

**Step and Ability Usage Logic Improvements:**

* Refined the logic for when to use `Technical Step`, `Standard Step`, and `Finishing Move`, ensuring better prioritization and coordination between these actions [[1]](diffhunk://#diff-47a4eb6c618e99b36d8294fb8cab1da42f6e3561e705aa2075ffe4f2a2549957R61) [[2]](diffhunk://#diff-47a4eb6c618e99b36d8294fb8cab1da42f6e3561e705aa2075ffe4f2a2549957L151-R167) [[3]](diffhunk://#diff-47a4eb6c618e99b36d8294fb8cab1da42f6e3561e705aa2075ffe4f2a2549957L171-R198) [[4]](diffhunk://#diff-47a4eb6c618e99b36d8294fb8cab1da42f6e3561e705aa2075ffe4f2a2549957L194-R209).
* Improved the logic for using `Tillana`, `Last Dance`, and `Starfall Dance` to account for new conditions and cooldown overlaps, preventing premature or wasted usage [[1]](diffhunk://#diff-47a4eb6c618e99b36d8294fb8cab1da42f6e3561e705aa2075ffe4f2a2549957L549-R622) [[2]](diffhunk://#diff-47a4eb6c618e99b36d8294fb8cab1da42f6e3561e705aa2075ffe4f2a2549957L613-R634) [[3]](diffhunk://#diff-47a4eb6c618e99b36d8294fb8cab1da42f6e3561e705aa2075ffe4f2a2549957L622-R663) [[4]](diffhunk://#diff-47a4eb6c618e99b36d8294fb8cab1da42f6e3561e705aa2075ffe4f2a2549957L654-R675).
* Updated the filler and basic GCD logic to avoid using GCD actions when step actions are available, and to better sequence procs and resource spenders [[1]](diffhunk://#diff-47a4eb6c618e99b36d8294fb8cab1da42f6e3561e705aa2075ffe4f2a2549957L666-L680) [[2]](diffhunk://#diff-47a4eb6c618e99b36d8294fb8cab1da42f6e3561e705aa2075ffe4f2a2549957L689-R717) [[3]](diffhunk://#diff-47a4eb6c618e99b36d8294fb8cab1da42f6e3561e705aa2075ffe4f2a2549957L746-R771) [[4]](diffhunk://#diff-47a4eb6c618e99b36d8294fb8cab1da42f6e3561e705aa2075ffe4f2a2549957L771-R803).

**Potion and Burst Logic Updates:**

* Improved the burst GCD logic to ensure actions are only used during the correct phase and when step actions are not available.
* Updated the custom potion logic in `ChurinDNCPotions` to more accurately check for completed steps before allowing potion usage, preventing early or invalid potion use [[1]](diffhunk://#diff-47a4eb6c618e99b36d8294fb8cab1da42f6e3561e705aa2075ffe4f2a2549957L841-R880) [[2]](diffhunk://#diff-dcfd2506d1ce54221fa2d12787392346547585e896b48e48de6d5fa8be631af4L831-R831).

**General Code and Data Structure Adjustments:**

* Changed the base potion class used for DNC to a more specialized `ChurinDNCPotions` for greater control over DNC-specific potion logic.
* Added a missing import for Lua client structs, which may be required for new or updated logic.

These changes collectively improve the DNC rotation's efficiency, responsiveness, and correctness, especially in burst scenarios and step action management.