### PR TITLE
Optimization Pass

### DIFF
--- a/RotationSolver.Basic/Rotations/Basic/DarkKnightRotation.cs
+++ b/RotationSolver.Basic/Rotations/Basic/DarkKnightRotation.cs
@@ -26,7 +26,7 @@ public partial class DarkKnightRotation
     /// <summary>
     /// 
     /// </summary>
-    public static bool HasDelirium => Player.HasStatus(true, StatusID.Delirium_3836);
+    public static bool HasDelirium => DeliriumStacks > 0;
 
     private static float DarkSideTimeRemainingRaw => JobGauge.DarksideTimeRemaining / 1000f;
 


### PR DESCRIPTION
This pull request introduces significant improvements to potion usage logic and configuration for both the Summoner (`ChurinSMN`) and Bard (`ChurinBRD`) custom rotations, as well as general code and documentation enhancements. The main focus is on standardizing and enhancing how potion timings are configured and used, making the system more flexible and maintainable. Additionally, there are improvements to status effect tracking and some minor code cleanups.

**Key changes include:**

### Potion Usage System Overhaul

* Replaced the old, rigid potion timing logic in both `ChurinSMN` and `ChurinBRD` with a new, unified system based on a `Potions` manager class. This allows for more flexible potion timing configuration via presets or custom timings, and exposes these options through new config properties. (`RotationSolver/ExtraRotations/Magical/ChurinSMN.cs` [[1]](diffhunk://#diff-1434c622049ab2019c991b0333810a315a4b4d6ddfda27a1efcc5fa630b5a09aR76-R157) [[2]](diffhunk://#diff-1434c622049ab2019c991b0333810a315a4b4d6ddfda27a1efcc5fa630b5a09aR280-R284) [[3]](diffhunk://#diff-1434c622049ab2019c991b0333810a315a4b4d6ddfda27a1efcc5fa630b5a09aL729-R847); `RotationSolver/ExtraRotations/Ranged/ChurinBRD.cs` [[4]](diffhunk://#diff-dc3c2c8c98b8d9674bafcd7d6b9ad0a7a85647049d94c3636b011728d5269b1aL32-R61) [[5]](diffhunk://#diff-dc3c2c8c98b8d9674bafcd7d6b9ad0a7a85647049d94c3636b011728d5269b1aL136-R80) [[6]](diffhunk://#diff-dc3c2c8c98b8d9674bafcd7d6b9ad0a7a85647049d94c3636b011728d5269b1aL158-R173)
* Added new configuration options for enabling/disabling potion usage, selecting usage strategies, and specifying up to three custom potion timings for both jobs. (`RotationSolver/ExtraRotations/Magical/ChurinSMN.cs` [[1]](diffhunk://#diff-1434c622049ab2019c991b0333810a315a4b4d6ddfda27a1efcc5fa630b5a09aR76-R157); `RotationSolver/ExtraRotations/Ranged/ChurinBRD.cs` [[2]](diffhunk://#diff-dc3c2c8c98b8d9674bafcd7d6b9ad0a7a85647049d94c3636b011728d5269b1aL158-R173)
* Implemented job-specific potion condition logic (e.g., only allowing potion use during certain phases and when late-weaving is possible) to maximize effectiveness and prevent waste. (`RotationSolver/ExtraRotations/Magical/ChurinSMN.cs` [RotationSolver/ExtraRotations/Magical/ChurinSMN.csL729-R847](diffhunk://#diff-1434c622049ab2019c991b0333810a315a4b4d6ddfda27a1efcc5fa630b5a09aL729-R847))

### Status Effect and Buff Tracking Enhancements

* Improved the documentation and logic for checking buffs and debuffs relevant to party composition, making the code easier to understand and maintain. (`RotationSolver.Basic/Rotations/CustomRotation_OtherInfo.cs` [[1]](diffhunk://#diff-dcfd2506d1ce54221fa2d12787392346547585e896b48e48de6d5fa8be631af4L117-R126) [[2]](diffhunk://#diff-dcfd2506d1ce54221fa2d12787392346547585e896b48e48de6d5fa8be631af4L169-R225)
* Added a new property to get the maximum remaining duration of relevant party buffs/debuffs, which can be used to optimize rotation decisions. (`RotationSolver.Basic/Rotations/CustomRotation_OtherInfo.cs` [RotationSolver.Basic/Rotations/CustomRotation_OtherInfo.csL169-R225](diffhunk://#diff-dcfd2506d1ce54221fa2d12787392346547585e896b48e48de6d5fa8be631af4L169-R225))

### Code Quality and Consistency Improvements

* Standardized floating-point literals and variable naming for timing-related values, improving readability and reducing potential bugs from implicit conversions. (`RotationSolver/ExtraRotations/Ranged/ChurinBRD.cs` [[1]](diffhunk://#diff-dc3c2c8c98b8d9674bafcd7d6b9ad0a7a85647049d94c3636b011728d5269b1aL32-R61) [[2]](diffhunk://#diff-dc3c2c8c98b8d9674bafcd7d6b9ad0a7a85647049d94c3636b011728d5269b1aL136-R80) [[3]](diffhunk://#diff-dc3c2c8c98b8d9674bafcd7d6b9ad0a7a85647049d94c3636b011728d5269b1aL158-R173)
* Refactored the calculation of the late weave window in both Summoner and Bard rotations to use a consistent formula based on weapon delay. (`RotationSolver/ExtraRotations/Magical/ChurinSMN.cs` [[1]](diffhunk://#diff-1434c622049ab2019c991b0333810a315a4b4d6ddfda27a1efcc5fa630b5a09aL17-R19); `RotationSolver/ExtraRotations/Ranged/ChurinBRD.cs` [[2]](diffhunk://#diff-dc3c2c8c98b8d9674bafcd7d6b9ad0a7a85647049d94c3636b011728d5269b1aL32-R61)

### Minor Fixes

* Updated the `HasDelirium` property in Dark Knight rotation to check stack count instead of status presence for improved accuracy. (`RotationSolver.Basic/Rotations/Basic/DarkKnightRotation.cs` [RotationSolver.Basic/Rotations/Basic/DarkKnightRotation.csL29-R29](diffhunk://#diff-ecd9f64077bcd927c9d821bbd2c8afae56fc79b5f881f3089103393ddd8b5af5L29-R29))
* Fixed minor inconsistencies in method calls and float usage in Bard rotation. (`RotationSolver/ExtraRotations/Ranged/ChurinBRD.cs` [RotationSolver/ExtraRotations/Ranged/ChurinBRD.csL136-R80](diffhunk://#diff-dc3c2c8c98b8d9674bafcd7d6b9ad0a7a85647049d94c3636b011728d5269b1aL136-R80))

These changes collectively make potion usage more robust, easier to configure, and better integrated with each job's optimal rotation logic, while also improving code maintainability and clarity.