### PR TITLE
Fix for icon pulsing showing on macros, new system for preventing actions against mobs, fix for viper main combo bricking

### DIFF
--- a/RotationSolver.Basic/Actions/ActionConfig.cs
+++ b/RotationSolver.Basic/Actions/ActionConfig.cs
@@ -27,6 +27,17 @@ public class ActionConfig()
         set => _isIntercepted = value;
     }
 
+    private bool _isRestrictedDOT = false;
+
+    /// <summary>
+    /// 
+    /// </summary>
+    public bool IsRestrictedDOT
+    {
+        get => _isRestrictedDOT;
+        set => _isRestrictedDOT = value;
+    }
+
     /// <summary>
     /// Should check the status for this action.
     /// </summary>

--- a/RotationSolver.Basic/Actions/ActionTargetInfo.cs
+++ b/RotationSolver.Basic/Actions/ActionTargetInfo.cs
@@ -71,6 +71,18 @@ public struct ActionTargetInfo(IBaseAction action)
                 continue;
             }
 
+            // When this action is flagged as Restricted DoT, skip targets on the restricted list
+            if (action.IsRestrictedDOT && DataCenter.RestrictedDotNameIds != null)
+            {
+                for (int i = 0; i < DataCenter.RestrictedDotNameIds.Count; i++)
+                {
+                    if (target.NameId == DataCenter.RestrictedDotNameIds[i])
+                    {
+                        continue;
+                    }
+                }
+            }
+
             var statusCheck = CheckStatus(target, skipStatusProvideCheck, skipTargetStatusNeedCheck);
             var ttkCheck = CheckTimeToKill(target);
             var resistanceCheck = CheckResistance(target);
@@ -133,6 +145,21 @@ public struct ActionTargetInfo(IBaseAction action)
             if (type == TargetType.Heal && tar.GetHealthRatio() >= 1)
             {
                 continue;
+            }
+
+            // When this action is flagged as Restricted DoT, skip targets on the restricted list
+            if (action.IsRestrictedDOT && DataCenter.RestrictedDotNameIds != null)
+            {
+                bool isRestricted = false;
+                for (int i = 0; i < DataCenter.RestrictedDotNameIds.Count; i++)
+                {
+                    if (tar.NameId == DataCenter.RestrictedDotNameIds[i])
+                    {
+                        isRestricted = true;
+                        break;
+                    }
+                }
+                if (isRestricted) continue;
             }
 
             if (CheckStatus(tar, skipStatusProvideCheck, skipTargetStatusNeedCheck) && CheckTimeToKill(tar) && CheckResistance(tar))

--- a/RotationSolver.Basic/Actions/BaseAction.cs
+++ b/RotationSolver.Basic/Actions/BaseAction.cs
@@ -80,6 +80,15 @@ public class BaseAction : IBaseAction
         set => Config.IsIntercepted = value;
     }
 
+    /// <summary>
+    /// 
+    /// </summary>
+    public bool IsRestrictedDOT
+    {
+        get => Config.IsRestrictedDOT;
+        set => Config.IsRestrictedDOT = value;
+    }
+
     /// <inheritdoc/>
     public bool IsOnCooldownWindow
     {

--- a/RotationSolver.Basic/Actions/BaseItem.cs
+++ b/RotationSolver.Basic/Actions/BaseItem.cs
@@ -1,6 +1,5 @@
 ﻿using ECommons.GameHelpers;
 using FFXIVClientStructs.FFXIV.Client.Game;
-using FFXIVClientStructs.FFXIV.Client.Game.Object;
 using Lumina.Excel.Sheets;
 
 namespace RotationSolver.Basic.Actions;
@@ -88,6 +87,15 @@ public class BaseItem : IBaseItem
     {
         get => Config.IsIntercepted;
         set => Config.IsIntercepted = value;
+    }
+
+    /// <summary>
+    /// 
+    /// </summary>
+    public bool IsRestrictedDOT
+    {
+        get => Config.IsRestrictedDOT;
+        set => Config.IsRestrictedDOT = value;
     }
 
     /// <summary>

--- a/RotationSolver.Basic/Actions/ItemConfig.cs
+++ b/RotationSolver.Basic/Actions/ItemConfig.cs
@@ -29,4 +29,9 @@ public class ItemConfig
     /// 
     /// </summary>
     public bool IsIntercepted { get; set; }
+
+    /// <summary>
+    /// 
+    /// </summary>
+    public bool IsRestrictedDOT { get; set; }
 }

--- a/RotationSolver.Basic/Configuration/Configs.cs
+++ b/RotationSolver.Basic/Configuration/Configs.cs
@@ -591,7 +591,7 @@ internal partial class Configs : IPluginConfiguration
         Filter = HealingActionCondition, Section = 3)]
     private static readonly bool _friendlyPartyNPCHealRaise3 = true;
 
-    [ConditionBool, UI("Heal/Dance partner your chocobo", Description = "Experimental.",
+    [ConditionBool, UI("Treat your chocobo as a party member",
         Filter = HealingActionCondition, Section = 3)]
     private static readonly bool _chocoboPartyMember = false;
 

--- a/RotationSolver.Basic/DataCenter.cs
+++ b/RotationSolver.Basic/DataCenter.cs
@@ -60,6 +60,11 @@ internal static class DataCenter
     internal static List<uint> PrioritizedNameIds { get; set; } = [];
     internal static List<uint> BlacklistedNameIds { get; set; } = [];
 
+    /// <summary>
+    /// List of hostile NameIds that should be excluded as valid targets when an action opts-in via IsRestrictedDOT.
+    /// </summary>
+    internal static List<uint> RestrictedDotNameIds { get; set; } = [9214];
+
     internal static ConcurrentQueue<VfxNewData> VfxDataQueue { get; } = new();
 
     /// <summary>

--- a/RotationSolver.Basic/Helpers/IActionHelper.cs
+++ b/RotationSolver.Basic/Helpers/IActionHelper.cs
@@ -6,7 +6,7 @@
 public static class IActionHelper
 {
     internal static ActionID[] MovingActions { get; } =
-    {
+    [
         ActionID.EnAvantPvE,
         //ActionID.PlungePvE,
         ActionID.RoughDividePvE,
@@ -20,10 +20,10 @@ public static class IActionHelper
         ActionID.OnslaughtPvE,
         //ActionID.SpineshatterDivePvE,
         ActionID.DragonfireDivePvE,
-    };
+    ];
     
     internal static ActionID[] HealingActions { get; } =
-    {
+    [
         // AST
         ActionID.BeneficIiPvE,
         ActionID.BeneficPvE,
@@ -57,7 +57,7 @@ public static class IActionHelper
         ActionID.PhysickPvE,
         ActionID.PhysickPvE_11192,
         ActionID.PhysickPvE_16230
-    };
+    ];
 
     /// <summary>
     /// Determines if the last GCD action matches any of the provided actions.

--- a/RotationSolver.Basic/Helpers/MarkingHelper.cs
+++ b/RotationSolver.Basic/Helpers/MarkingHelper.cs
@@ -1,5 +1,4 @@
 ﻿using FFXIVClientStructs.FFXIV.Client.Game.UI;
-using Dalamud.Game.ClientState.Objects.SubKinds; // Added for IPlayerCharacter
 
 namespace RotationSolver.Basic.Helpers
 {

--- a/RotationSolver.Basic/Helpers/ReflectionHelper.cs
+++ b/RotationSolver.Basic/Helpers/ReflectionHelper.cs
@@ -3,7 +3,7 @@
     /// <summary>
     /// Helper class for reflection-related operations.
     /// </summary>
-internal static class ReflectionHelper
+    internal static class ReflectionHelper
     {
         private static readonly System.Collections.Concurrent.ConcurrentDictionary<(Type type, Type ofT), PropertyInfo[]> s_staticPropsCache = new();
         private static readonly System.Collections.Concurrent.ConcurrentDictionary<Type, MethodInfo[]> s_methodsCache = new();
@@ -14,7 +14,7 @@ internal static class ReflectionHelper
         /// <typeparam name="T">The type of the properties to get.</typeparam>
         /// <param name="type">The type to get the properties from.</param>
         /// <returns>An array of static properties of the specified type.</returns>
-internal static PropertyInfo[] GetStaticProperties<T>(this Type? type)
+        internal static PropertyInfo[] GetStaticProperties<T>(this Type? type)
         {
             if (type == null)
             {
@@ -56,7 +56,7 @@ internal static PropertyInfo[] GetStaticProperties<T>(this Type? type)
         /// </summary>
         /// <param name="type">The type to get the methods from.</param>
         /// <returns>An enumerable of method information.</returns>
-internal static IEnumerable<MethodInfo> GetAllMethodInfo(this Type? type)
+        internal static IEnumerable<MethodInfo> GetAllMethodInfo(this Type? type)
         {
             if (type == null)
             {
@@ -81,14 +81,14 @@ internal static IEnumerable<MethodInfo> GetAllMethodInfo(this Type? type)
             IEnumerable<MethodInfo> baseMethods = type.BaseType?.GetAllMethodInfo() ?? [];
 
             // Combine filteredMethods and baseMethods without LINQ
-            List<MethodInfo> resultList = new List<MethodInfo>(filteredMethods.Count + 8);
+            List<MethodInfo> resultList = new(filteredMethods.Count + 8);
             resultList.AddRange(filteredMethods);
             foreach (var m in baseMethods)
             {
                 resultList.Add(m);
             }
 
-            MethodInfo[] result = resultList.ToArray();
+            MethodInfo[] result = [.. resultList];
             s_methodsCache[type] = result;
             return result;
         }

--- a/RotationSolver.Basic/Helpers/TargetFilter.cs
+++ b/RotationSolver.Basic/Helpers/TargetFilter.cs
@@ -9,7 +9,7 @@ namespace RotationSolver.Basic.Helpers;
 public static class TargetFilter
 {
     private static Dictionary<JobRole, HashSet<byte>>? _roleJobs;
-    private static readonly object _roleJobsLock = new();
+    private static readonly Lock _roleJobsLock = new();
 
     private static Dictionary<JobRole, HashSet<byte>> GetRoleMap()
     {

--- a/RotationSolver.Basic/Helpers/TargetHelper.cs
+++ b/RotationSolver.Basic/Helpers/TargetHelper.cs
@@ -11,7 +11,7 @@ namespace RotationSolver.Basic.Helpers
     /// </summary>
     public static class TargetHelper
     {
-        private static readonly HashSet<long> s_emptyStopTargets = new();
+        private static readonly HashSet<long> s_emptyStopTargets = [];
 
         /// <summary>
         /// Retrieves a collection of valid battle characters that can be targeted based on the specified criteria.

--- a/RotationSolver.Basic/ITexture.cs
+++ b/RotationSolver.Basic/ITexture.cs
@@ -32,4 +32,9 @@ public interface ITexture
     /// 
     /// </summary>
     bool IsIntercepted { get; set; }
+
+    /// <summary>
+    /// 
+    /// </summary>
+    bool IsRestrictedDOT { get; set; }
 }

--- a/RotationSolver.Basic/RotationSolver.Basic.csproj
+++ b/RotationSolver.Basic/RotationSolver.Basic.csproj
@@ -75,7 +75,7 @@
         <Using Include="Dalamud.Bindings.ImGui" />
         <Using Include="Newtonsoft.Json" />
 
-        <PackageReference Include="ECommons" Version="3.0.1.23" />
+        <PackageReference Include="ECommons" Version="3.0.1.26" />
 
         <PackageReference Include="System.Drawing.Common" Version="9.0.10" />
         <ProjectReference Include="..\RotationSolver.SourceGenerators\RotationSolver.SourceGenerators.csproj" OutputItemType="Analyzer" ExcludeAssets="All" />

--- a/RotationSolver.Basic/Rotations/CustomRotation_BasicInfo.cs
+++ b/RotationSolver.Basic/Rotations/CustomRotation_BasicInfo.cs
@@ -55,6 +55,9 @@ public partial class CustomRotation : ICustomRotation
     public bool IsIntercepted { get; set; }
 
     /// <inheritdoc/>
+    public bool IsRestrictedDOT { get; set; }
+
+    /// <inheritdoc/>
     public uint IconID { get; }
 
     /// <inheritdoc/>

--- a/RotationSolver.Basic/Traits/BaseTrait.cs
+++ b/RotationSolver.Basic/Traits/BaseTrait.cs
@@ -46,6 +46,11 @@ public class BaseTrait : IBaseTrait
     public bool IsIntercepted { get; set; }
 
     /// <summary>
+    /// 
+    /// </summary>
+    public bool IsRestrictedDOT { get; set; }
+
+    /// <summary>
     /// Gets the ID of this trait.
     /// </summary>
     public uint ID { get; }

--- a/RotationSolver.Basic/packages.lock.json
+++ b/RotationSolver.Basic/packages.lock.json
@@ -4,9 +4,9 @@
     "net9.0-windows7.0": {
       "ECommons": {
         "type": "Direct",
-        "requested": "[3.0.1.23, )",
-        "resolved": "3.0.1.23",
-        "contentHash": "U3H/XCdSHlKWubXPeenZNDteZQ6nS7vitkFP9hMUkACb456PUwp7ryjhmujhytlFlXHKoCNnvbgQGyFThynf/g=="
+        "requested": "[3.0.1.26, )",
+        "resolved": "3.0.1.26",
+        "contentHash": "uPmrlihq3EVWy9ahfuKSuywoeDz3dkTHhxvFGSwiG7DAKmSmMANHN2ZZm39GnuCa5v0LwrAGZCsVPaUigdbDfg=="
       },
       "Svg": {
         "type": "Direct",

--- a/RotationSolver/Data/UiString.cs
+++ b/RotationSolver/Data/UiString.cs
@@ -127,6 +127,9 @@ namespace RotationSolver.Data
         [Description("Allow action to be intercepted by the intercept system")]
         ConfigWindow_Actions_IsIntercepted,
 
+        [Description("Prevent this action against a curated list of mobs (ie. Jagd Dolls)")]
+        ConfigWindow_Actions_IsRestrictedDOT,
+
         [Description("Allow action to be restricted by the minimum HP feature")]
         ConfigWindow_Actions_MinHPFeature,
 

--- a/RotationSolver/RotationSolver.csproj
+++ b/RotationSolver/RotationSolver.csproj
@@ -15,7 +15,7 @@
 	<NoWarn>1591</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="ECommons" Version="3.0.1.23" />
+    <PackageReference Include="ECommons" Version="3.0.1.26" />
   </ItemGroup>
   <ItemGroup>
 	  <Reference Include="Dalamud.Common">

--- a/RotationSolver/TextureItems/StatusTexture.cs
+++ b/RotationSolver/TextureItems/StatusTexture.cs
@@ -37,6 +37,11 @@ internal class StatusTexture(Status status) : ITexture
     public bool IsIntercepted { get; set; } = true;
 
     /// <summary>
+    /// 
+    /// </summary>
+    public bool IsRestrictedDOT { get; set; } = false;
+
+    /// <summary>
     /// Initializes a new instance of the <see cref="StatusTexture"/> class with the specified status ID.
     /// </summary>
     /// <param name="id">The ID of the status.</param>

--- a/RotationSolver/UI/HighlightTeachingMode/DrawingHighlightHotbar.cs
+++ b/RotationSolver/UI/HighlightTeachingMode/DrawingHighlightHotbar.cs
@@ -63,10 +63,10 @@ public class DrawingHighlightHotbar : DrawingHighlightHotbarBase
     {
         if (_texture == null)
         {
-            return Array.Empty<IDrawing2D>();
+            return [];
         }
 
-        List<IDrawing2D> result = new();
+        List<IDrawing2D> result = [];
 
         int hotBarIndex = 0;
         foreach (nint intPtr in EnumerateHotbarAddons())

--- a/RotationSolver/UI/RotationConfigWindow.cs
+++ b/RotationSolver/UI/RotationConfigWindow.cs
@@ -8,7 +8,6 @@ using Dalamud.Interface.Utility.Raii;
 using Dalamud.Interface.Windowing;
 using Dalamud.Utility;
 using ECommons;
-using ECommons.Configuration;
 using ECommons.DalamudServices;
 using ECommons.ExcelServices;
 using ECommons.GameFunctions;
@@ -89,9 +88,15 @@ public partial class RotationConfigWindow : Window
         "About > Macros lists available chat/macro commands and helpful syntax.",
         "About > Links: open config folder, GitHub, Ko-fi, and Discord.",
         "Extra > Internal: Backup/Restore configs safely.",
-        "Extra: optional tweaks like removing animation/cooldown delay and cactbot timeline integration.",
+        "Extra: optional tweaks like removing animation/cooldown delay.",
         "Click the cube icon at the bottom-left of the sidebar to copy diagnostic info to clipboard.",
-        "Timeline window can visualize recent actions (UI > Windows)."
+        "Timeline window can visualize recent actions (UI > Windows).",
+        "Do damage, don't die",
+        "Healing Tip: the only HP that matters is the last one",
+        "Be kind",
+        "The icons for Combat Reborn were made by a player named Altan",
+        "Tip: you can remove some self-buffs with “/statusoff <Name>” (e.g., Peloton) when needed.",
+        "Tip: RSR works best with Legacy Type movement settings."
     ];
     private int _hintIndex = 0;
     private float _lastHintSwitch = 0f;
@@ -2472,6 +2477,12 @@ public partial class RotationConfigWindow : Window
             if (ImGui.Checkbox($"{UiString.ConfigWindow_Actions_MinHPFeature.GetDescription()}##{_activeAction.Name}", ref minHPFeatureSet))
             {
                 _activeAction.MinHPFeature = minHPFeatureSet;
+            }
+
+            bool isRestrictedDOT = _activeAction.IsRestrictedDOT;
+            if (ImGui.Checkbox($"{UiString.ConfigWindow_Actions_IsRestrictedDOT.GetDescription()}##{_activeAction.Name}", ref isRestrictedDOT))
+            {
+                _activeAction.IsRestrictedDOT = isRestrictedDOT;
             }
 
             float minHPPercentSet = _activeAction.MinHPPercent;

--- a/RotationSolver/Updaters/MiscUpdater.cs
+++ b/RotationSolver/Updaters/MiscUpdater.cs
@@ -231,6 +231,16 @@ internal static class MiscUpdater
             {
                 return false;
             }
+
+            if (hot.Value.OriginalApparentSlotType == RaptureHotbarModule.HotbarSlotType.Macro)
+            {
+                return false;
+            }
+
+            if (hot.Value.ApparentSlotType == RaptureHotbarModule.HotbarSlotType.Macro)
+            {
+                return false;
+            }
         }
 
         return Service.GetAdjustedActionId((uint)slot.ActionId) == actionID;

--- a/RotationSolver/packages.lock.json
+++ b/RotationSolver/packages.lock.json
@@ -16,9 +16,9 @@
       },
       "ECommons": {
         "type": "Direct",
-        "requested": "[3.0.1.23, )",
-        "resolved": "3.0.1.23",
-        "contentHash": "U3H/XCdSHlKWubXPeenZNDteZQ6nS7vitkFP9hMUkACb456PUwp7ryjhmujhytlFlXHKoCNnvbgQGyFThynf/g=="
+        "requested": "[3.0.1.26, )",
+        "resolved": "3.0.1.26",
+        "contentHash": "uPmrlihq3EVWy9ahfuKSuywoeDz3dkTHhxvFGSwiG7DAKmSmMANHN2ZZm39GnuCa5v0LwrAGZCsVPaUigdbDfg=="
       },
       "ExCSS": {
         "type": "Transitive",
@@ -92,7 +92,7 @@
       "RotationSolverReborn.Basic": {
         "type": "Project",
         "dependencies": {
-          "ECommons": "[3.0.1.23, )",
+          "ECommons": "[3.0.1.26, )",
           "RotationSolver.SourceGenerators": "[1.0.0, )",
           "Svg": "[3.4.7, )",
           "System.Drawing.Common": "[9.0.10, )"


### PR DESCRIPTION
This pull request introduces a new `IsRestrictedDOT` flag to actions and items, which allows the system to exclude certain targets (such as specific mobs) when using actions that opt-in to this restriction. Several interfaces, configuration classes, and helper methods have been updated to support this feature. Additionally, there are minor codebase improvements and updates to dependencies.

### Restricted DoT Targeting Feature

* Added `IsRestrictedDOT` property to `BaseAction`, `BaseItem`, `ActionConfig`, `ItemConfig`, `ITexture`, `BaseTrait`, and `CustomRotation_BasicInfo` to enable opt-in exclusion of certain targets for specific actions. [[1]](diffhunk://#diff-500196860eeba9ff3fd4934443f0f987f451d4b3cb320ca2ff78d3634b0bdb2bR30-R40) [[2]](diffhunk://#diff-000d1e45e7939f4622a2ad4655686067d62cb99416b0e0c1a1bb9a27889a7ceeR83-R91) [[3]](diffhunk://#diff-6dda74a3dbf4bb88d2757a8cfcc0999dd6c3cbd9801131bd6b3d327aa72a3d28R92-R100) [[4]](diffhunk://#diff-4f3d150aabe3bf92d100b46bdfa96b85c725cf8ca85e90dba7246a0f103022fcR32-R36) [[5]](diffhunk://#diff-724c2b50cf9f40aed878c6cd5caba693be383b1917e008f45b79f665f06655a5R35-R39) [[6]](diffhunk://#diff-229bdc17a30c476f969e0727c187b68dc318ac57dfa3b6ec9f9b623df72e2670R48-R52) [[7]](diffhunk://#diff-1428c2c77184bb0af12c9f722a34f1e53f9c51082d326195c515153f324d5487R57-R59)
* Updated targeting logic in `ActionTargetInfo.cs` (`GetCanTargets` and `GetCanAffects`) to skip targets whose `NameId` is in `DataCenter.RestrictedDotNameIds` when `IsRestrictedDOT` is set. [[1]](diffhunk://#diff-c48c5d8b4fd41fe622aa573e5ca583106eb40f1fc24db44fcc12935cd35c1774R74-R85) [[2]](diffhunk://#diff-c48c5d8b4fd41fe622aa573e5ca583106eb40f1fc24db44fcc12935cd35c1774R150-R164)
* Introduced `RestrictedDotNameIds` to `DataCenter` as a curated list of hostile target IDs to be excluded for restricted DoT actions.
* Added UI string for the new configuration option: "Prevent this action against a curated list of mobs (ie. Jagd Dolls)".

### Dependency and Codebase Updates

* Updated the `ECommons` package dependency to version `3.0.1.26` in project and lock files. [[1]](diffhunk://#diff-5c70343fad24929f3f36286ec07f4a9d9a718df3748cfe49ccaf6ccdb8151bbfL78-R78) [[2]](diffhunk://#diff-53b3c4ef89f9c632a8578ec45c06ebc13025edd42cf9c70533d20d1105d48162L7-R9)
* Minor code improvements: replaced explicit constructors with collection expressions, improved array initializations, and made small cleanups in helpers and reflection logic. [[1]](diffhunk://#diff-333c108442b27894d85abff9232de9517c4e6bfc04a43894584d7669db7844fbL9-R9) [[2]](diffhunk://#diff-333c108442b27894d85abff9232de9517c4e6bfc04a43894584d7669db7844fbL23-R26) [[3]](diffhunk://#diff-333c108442b27894d85abff9232de9517c4e6bfc04a43894584d7669db7844fbL60-R60) [[4]](diffhunk://#diff-ccea30e8bcfaeee3e2cb31ae2bb31e708d96388751c10380dc81854805d062f3L84-R91) [[5]](diffhunk://#diff-1a62321bdc26f45aad1858ec3a69470a36d496371ea4906b3caadfdad7a8e154L12-R12) [[6]](diffhunk://#diff-4e8d7a6ea83f4b40f471d56a3c235b142f16861befd9f733c4b4c7e6071de919L14-R14)

### Rotation Logic Adjustments

* Removed experimental rotation configuration options from `VPR_Reborn` and simplified conditional logic in `GeneralGCD`. Also, changed calls to `CanUse` to skip AOE checks where appropriate. [[1]](diffhunk://#diff-dffc3db2a71bead5714960e3c248987db114455b80afa29bbcfd35cd972c0c96L40-L48) [[2]](diffhunk://#diff-dffc3db2a71bead5714960e3c248987db114455b80afa29bbcfd35cd972c0c96L303-R294) [[3]](diffhunk://#diff-dffc3db2a71bead5714960e3c248987db114455b80afa29bbcfd35cd972c0c96L313-R304) [[4]](diffhunk://#diff-dffc3db2a71bead5714960e3c248987db114455b80afa29bbcfd35cd972c0c96L413-R404) [[5]](diffhunk://#diff-dffc3db2a71bead5714960e3c248987db114455b80afa29bbcfd35cd972c0c96L429) [[6]](diffhunk://#diff-dffc3db2a71bead5714960e3c248987db114455b80afa29bbcfd35cd972c0c96L459-R457) [[7]](diffhunk://#diff-dffc3db2a71bead5714960e3c248987db114455b80afa29bbcfd35cd972c0c96L479-R495)