### PR TITLE
Various Updates to ChurinDNC and Churin SMN

### DIFF
--- a/RotationSolver.Basic/Rotations/Basic/SummonerRotation.cs
+++ b/RotationSolver.Basic/Rotations/Basic/SummonerRotation.cs
@@ -25,7 +25,9 @@ public partial class SummonerRotation
     /// <summary>
     /// 
     /// </summary>
-    public static byte Attunement => JobGauge.Attunement;
+    public static byte AttunementCount => JobGauge.AttunementCount;
+
+    
 
     /// <summary>
     /// 
@@ -188,7 +190,7 @@ public partial class SummonerRotation
     {
         ImGui.Text("ReturnSummons: " + ReturnSummons.ToString());
         ImGui.Text("HasAetherflowStacks: " + HasAetherflowStacks.ToString());
-        ImGui.Text("Attunement: " + Attunement.ToString());
+        ImGui.Text("Attunement: " + AttunementCount.ToString());
         ImGui.Spacing();
         ImGui.TextColored(IsSolarBahamutReady ? ImGuiColors.HealerGreen : ImGuiColors.DalamudWhite, "IsSolarBahamutReady: " + IsSolarBahamutReady.ToString());
         ImGui.TextColored(IsBahamutReady ? ImGuiColors.HealerGreen : ImGuiColors.DalamudWhite, "IsBahamutReady: " + IsBahamutReady.ToString());
@@ -466,7 +468,7 @@ public partial class SummonerRotation
 
     static partial void ModifyRubyRuinPvE(ref ActionSetting setting)
     {
-        setting.ActionCheck = () => Attunement > 0 && !AttunmentTimeEndAfter(ActionID.RubyRuinPvE.GetCastTime()) && InIfrit;
+        setting.ActionCheck = () => AttunementCount > 0 && !AttunmentTimeEndAfter(ActionID.RubyRuinPvE.GetCastTime()) && InIfrit;
     }
 
     static partial void ModifyEmeraldRuinPvE(ref ActionSetting setting)
@@ -481,7 +483,7 @@ public partial class SummonerRotation
 
     static partial void ModifyRubyRuinIiPvE(ref ActionSetting setting)
     {
-        setting.ActionCheck = () => Attunement > 0 && !AttunmentTimeEndAfter(ActionID.RubyRuinIiPvE.GetCastTime()) && InIfrit;
+        setting.ActionCheck = () => AttunementCount > 0 && !AttunmentTimeEndAfter(ActionID.RubyRuinIiPvE.GetCastTime()) && InIfrit;
     }
 
     static partial void ModifyEmeraldRuinIiPvE(ref ActionSetting setting)
@@ -496,7 +498,7 @@ public partial class SummonerRotation
 
     static partial void ModifyRubyRuinIiiPvE(ref ActionSetting setting)
     {
-        setting.ActionCheck = () => Attunement > 0 && !AttunmentTimeEndAfter(ActionID.RubyRuinIiiPvE.GetCastTime()) && InIfrit;
+        setting.ActionCheck = () => AttunementCount > 0 && !AttunmentTimeEndAfter(ActionID.RubyRuinIiiPvE.GetCastTime()) && InIfrit;
     }
 
     static partial void ModifyEmeraldRuinIiiPvE(ref ActionSetting setting)
@@ -511,12 +513,12 @@ public partial class SummonerRotation
 
     static partial void ModifyRubyRitePvE(ref ActionSetting setting)
     {
-        setting.ActionCheck = () => Attunement > 0 && !AttunmentTimeEndAfter(ActionID.RubyRitePvE.GetCastTime()) && InIfrit;
+        setting.ActionCheck = () => AttunementCount > 0 && !AttunmentTimeEndAfter(ActionID.RubyRitePvE.GetCastTime()) && InIfrit;
     }
 
     static partial void ModifyEmeraldRitePvE(ref ActionSetting setting)
     {
-        setting.ActionCheck = () => InGaruda;
+        setting.ActionCheck = () => AttunementCount > 0 && InGaruda;
     }
 
     static partial void ModifyTopazRitePvE(ref ActionSetting setting)
@@ -526,7 +528,7 @@ public partial class SummonerRotation
 
     static partial void ModifyRubyOutburstPvE(ref ActionSetting setting)
     {
-        setting.ActionCheck = () => Attunement > 0 && !AttunmentTimeEndAfter(ActionID.RubyOutburstPvE.GetCastTime()) && InIfrit;
+        setting.ActionCheck = () => AttunementCount > 0 && !AttunmentTimeEndAfter(ActionID.RubyOutburstPvE.GetCastTime()) && InIfrit;
         setting.CreateConfig = () => new ActionConfig()
         {
             AoeCount = 3,
@@ -553,7 +555,7 @@ public partial class SummonerRotation
 
     static partial void ModifyRubyDisasterPvE(ref ActionSetting setting)
     {
-        setting.ActionCheck = () => Attunement > 0 && !AttunmentTimeEndAfter(ActionID.RubyDisasterPvE.GetCastTime()) && InIfrit;
+        setting.ActionCheck = () => AttunementCount > 0 && !AttunmentTimeEndAfter(ActionID.RubyDisasterPvE.GetCastTime()) && InIfrit;
         setting.CreateConfig = () => new ActionConfig()
         {
             AoeCount = 3,
@@ -580,7 +582,7 @@ public partial class SummonerRotation
 
     static partial void ModifyRubyCatastrophePvE(ref ActionSetting setting)
     {
-        setting.ActionCheck = () => Attunement > 0 && !AttunmentTimeEndAfter(ActionID.RubyCatastrophePvE.GetCastTime()) && InIfrit;
+        setting.ActionCheck = () => AttunementCount > 0 && !AttunmentTimeEndAfter(ActionID.RubyCatastrophePvE.GetCastTime()) && InIfrit;
         setting.CreateConfig = () => new ActionConfig()
         {
             AoeCount = 3,
@@ -660,7 +662,6 @@ public partial class SummonerRotation
         //setting.SpecialType = SpecialActionType.HostileMovingForward;
         setting.StatusProvide = [StatusID.CrimsonStrikeReady_4403];
         setting.StatusNeed = [StatusID.IfritsFavor];
-        setting.ActionCheck = () => InIfrit;
         setting.CreateConfig = () => new ActionConfig()
         {
             AoeCount = 1,
@@ -669,7 +670,6 @@ public partial class SummonerRotation
 
     static partial void ModifyCrimsonStrikePvE(ref ActionSetting setting)
     {
-        setting.ActionCheck = () => InIfrit;
         setting.StatusNeed = [StatusID.CrimsonStrikeReady_4403];
         setting.CreateConfig = () => new ActionConfig()
         {
@@ -688,7 +688,9 @@ public partial class SummonerRotation
 
     static partial void ModifySlipstreamPvE(ref ActionSetting setting)
     {
-        setting.ActionCheck = () => Attunement > 0 && !AttunmentTimeEndAfter(ActionID.SlipstreamPvE.GetCastTime()) && InGaruda;
+        setting.ActionCheck = () => !HasSwift && !Player.WillStatusEnd(ActionID.SlipstreamPvE.GetCastTime(), true, StatusID.GarudasFavor) 
+                                    || HasSwift && !Player.WillStatusEndGCD(0, 0, true, StatusID.GarudasFavor);
+        setting.StatusNeed = [StatusID.GarudasFavor];
         setting.StatusProvide = [StatusID.Slipstream];
         setting.CreateConfig = () => new ActionConfig()
         {

--- a/RotationSolver/ExtraRotations/Magical/ChurinSMN.cs
+++ b/RotationSolver/ExtraRotations/Magical/ChurinSMN.cs
@@ -10,9 +10,24 @@ namespace RotationSolver.ExtraRotations.Magical;
 public sealed class ChurinSMN : SummonerRotation
 {
     #region Properties
+    private bool CanBurst => MergedStatus.HasFlag(AutoStatus.Burst) && SearingLightPvE.IsEnabled;
     private bool InBigSummon => !SummonBahamutPvE.EnoughLevel || InBahamut || InPhoenix || InSolarBahamut;
+    private static bool HasFurtherRuin => Player.HasStatus(true, StatusID.FurtherRuin_2701);
+    private static bool HasCrimsonStrike => Player.HasStatus(true, StatusID.CrimsonStrikeReady_4403);
+    private static bool HasRadiantAegis => Player.HasStatus(true, StatusID.RadiantAegis);
+    private static bool HasGarudaFavor => Player.HasStatus(true, StatusID.GarudasFavor);
+    private static bool HasIfritFavor => Player.HasStatus(true, StatusID.IfritsFavor);
+    private static bool HasTitanFavor => Player.HasStatus(true, StatusID.TitansFavor);
+    private static bool NoPrimalReady => !IsIfritReady && !IsGarudaReady && !IsTitanReady;
+    private static bool AnyPrimalReady => IsIfritReady || IsGarudaReady || IsTitanReady;
+    private static bool HasAnyFavor => HasGarudaFavor || HasIfritFavor || HasTitanFavor;
+    private static bool HasAnyAttunement => InGaruda || InIfrit || InTitan;
+    private static bool NoAttunement => !InIfrit && !InGaruda && !InTitan;
     private static bool InSolar => Player.Level == 100 ? !InBahamut && !InPhoenix && InSolarBahamut : InBahamut && !InPhoenix;
-    private bool BahamutBurst => (SummonSolarBahamutPvE.EnoughLevel && InSolarBahamut) || (!SummonSolarBahamutPvE.EnoughLevel && InBahamut) || !SummonBahamutPvE.EnoughLevel;
+    private bool BahamutBurst => ((SummonSolarBahamutPvE.EnoughLevel && InSolarBahamut) 
+    || (SummonSolarBahamutPvE.EnoughLevel && (InBahamut || InPhoenix)) 
+    || (!SummonSolarBahamutPvE.EnoughLevel && InBahamut) 
+    || !SummonBahamutPvE.EnoughLevel) && CanBurst;
     private static SMNGauge SummonerGauge => Svc.Gauges.Get<SMNGauge>();
     private static double LateWeaveWindow => (float)(WeaponTotal * 0.45);
     private static bool CanWeave => WeaponRemain > AnimationLock;
@@ -30,13 +45,23 @@ public sealed class ChurinSMN : SummonerRotation
 
         [Description("Emerald-Topaz-Ruby")] EmeraldTopazRuby,
 
+        [Description("Emerald-Ruby-Topaz")] EmeraldRubyTopaz,
+
         [Description("Ruby-Emerald-Topaz")] RubyEmeraldTopaz,
+
+        [Description("Ruby-Topaz-Emerald")] RubyTopazEmerald,
     }
 
-    [RotationConfig(CombatType.PvE, Name = "Use GCDs to heal. (Ignored if there are no healers alive in party)")]
-    public bool GCDHeal { get; set; } = false;
+    public enum FightPreset : ushort
+    {
+        [Description("None")] None,
+        [Description("AAC Cruiserweight M4 (Savage)")] CruiserweightM4S,
+        [Description("AAC Cruiserweight M3 (Savage) - WIP")] CruiserweightM3S,
+        [Description("AAC Cruiserweight M2 (Savage) - WIP")] CruiserweightM2S,
+        [Description("AAC Cruiserweight M1 (Savage) - WIP")] CruiserweightM1S,
+    }
 
-    [RotationConfig(CombatType.PvE, Name = "Use Crimson Cyclone at any range, regardless of saftey use with caution (Enabling this ignores the below distance setting).")]
+    [RotationConfig(CombatType.PvE, Name = "Use Crimson Cyclone at any range, regardless of safety use with caution (Enabling this ignores the below distance setting).")]
     public bool AddCrimsonCyclone { get; set; } = true;
 
     [Range(1, 20, ConfigUnitType.Yalms)]
@@ -46,17 +71,17 @@ public sealed class ChurinSMN : SummonerRotation
     [RotationConfig(CombatType.PvE, Name = "Use Crimson Cyclone when moving")]
     public bool AddCrimsonCycloneMoving { get; set; } = false;
 
-    [RotationConfig(CombatType.PvE, Name = "Use Swiftcast on ressurection")]
+    [RotationConfig(CombatType.PvE, Name = "Use Swiftcast on resurrection")]
     public bool AddSwiftcastOnRaise { get; set; } = true;
 
     [RotationConfig(CombatType.PvE, Name = "Use Swiftcast on Ruby Ruin when not enough level for Ruby Rite")]
-    public bool AddSwiftcastOnLowST { get; set; } = true;
+    public bool AddSwiftcastOnLowSt { get; set; } = true;
 
     [RotationConfig(CombatType.PvE, Name = "Use Swiftcast on Ruby Outburst when not enough level for Ruby Rite")]
     public bool AddSwiftcastOnLowAOE { get; set; } = true;
 
     [RotationConfig(CombatType.PvE, Name = "Use Swiftcast on Garuda")]
-    public bool AddSwiftcastOnGaruda { get; set; } = false;
+    public bool AddSwiftcastOnGaruda { get; set; }
 
     [RotationConfig(CombatType.PvE, Name = "Use Swiftcast on Ruby Rite if you are not high enough level for Garuda")]
     public bool AddSwiftcastOnRuby { get; set; } = false;
@@ -64,32 +89,20 @@ public sealed class ChurinSMN : SummonerRotation
     [RotationConfig(CombatType.PvE, Name = "Order")]
     public SummonOrderType SummonOrder { get; set; } = SummonOrderType.TopazEmeraldRuby;
 
-    [RotationConfig(CombatType.PvE, Name = "Use radiant on cooldown. But still keeping one charge")]
-    public bool RadiantOnCooldown { get; set; } = true;
-
-    [RotationConfig(CombatType.PvE, Name = "Use this if there's no other raid buff in your party")]
-    public bool SecondTypeOpenerLogic { get; set; } = false;
-
     [RotationConfig(CombatType.PvE, Name = "Use Physick above level 30")]
     public bool Healbot { get; set; } = false;
 
-    private static readonly ChurinSMNPotions _churinPotions = new();
-
-    private float _firstPotionTiming = 0;
-    private float _secondPotionTiming = 0;
-    private float _thirdPotionTiming = 0;
-
     [RotationConfig(CombatType.PvE, Name = "Enable Potion Usage")]
-    private bool PotionUsageEnabled
-    { get => _churinPotions.Enabled; set => _churinPotions.Enabled = value; }
+    private static bool PotionUsageEnabled
+    { get => ChurinPotions.Enabled; set => ChurinPotions.Enabled = value; }
 
     [RotationConfig(CombatType.PvE, Name = "Potion Usage Presets", Parent = nameof(PotionUsageEnabled))]
-    private PotionStrategy PotionUsagePresets
-    { get => _churinPotions.Strategy; set => _churinPotions.Strategy = value; }
+    private static PotionStrategy PotionUsagePresets
+    { get => ChurinPotions.Strategy; set => ChurinPotions.Strategy = value; }
 
-    [Range(0,20, ConfigUnitType.Seconds, 0)]
+    [Range(0, 20, ConfigUnitType.Seconds, 0)]
     [RotationConfig(CombatType.PvE, Name = "Use Opener Potion at minus (value in seconds)", Parent = nameof(PotionUsageEnabled))]
-    private static float OpenerPotionTime { get => _churinPotions.OpenerPotionTime; set => _churinPotions.OpenerPotionTime = value; }
+    private static float OpenerPotionTime { get => ChurinPotions.OpenerPotionTime; set => ChurinPotions.OpenerPotionTime = value; }
 
     [Range(0, 1200, ConfigUnitType.Seconds, 0)]
     [RotationConfig(CombatType.PvE, Name = "Use 1st Potion at (value in seconds - leave at 0 if using in opener)", Parent = nameof(PotionUsagePresets), ParentValue = "Use custom potion timings")]
@@ -126,31 +139,125 @@ public sealed class ChurinSMN : SummonerRotation
             UpdateCustomTimings();
         }
     }
+    
+    [RotationConfig(CombatType.PvE, Name = "Enable Fight Presets? (Experimental)")]
+    private bool EnableFightPresets {get; set;}
 
-    private void UpdateCustomTimings()
-    {
-        _churinPotions.CustomTimings = new Potions.CustomTimingsData
-        {
-            Timings = [FirstPotionTiming, SecondPotionTiming, ThirdPotionTiming]
-        };
-    }
-
+    [RotationConfig(CombatType.PvE, Name = "Choose a Fight", Parent = nameof(EnableFightPresets))]
+    public FightPreset FightPresets { get; set; } = FightPreset.None;
+     
     #endregion
 
     #region Tracking Properties
     public override void DisplayRotationStatus()
     {
-        ImGui.Text($"EnergyDrainPvE: Is Cooling Down: {EnergyDrainPvE.Cooldown.IsCoolingDown}");
+        // Big Summon Status
+        ImGui.Text("=== Big Summon Status ===");
         ImGui.Text($"Max GCDs in Big Summon: {BigSummonGCDLeft}");
-        ImGui.Text($"Is Condition Met for Potion: {_churinPotions.IsConditionMet()}");
+        ImGui.Text($"In Big Summon Count: {InBigSummonCount}");
+
+        ImGui.Separator();
+
+        // Attunement Status
+        ImGui.Text("=== Attunement Status ===");
+        ImGui.Text($"Current Attunement: {(InIfrit ? "Ifrit" : InGaruda ? "Garuda" : InTitan ? "Titan" : "None")}");
+        ImGui.Text($"Attunement Count: {AttunementCount}");
+        ImGui.NewLine();
+        ImGui.Text("Attunement Order:");
+        ImGui.NewLine();
+        if (_m4SOrderMap.Count > 0)
+        {
+            foreach (var kv in _m4SOrderMap.OrderBy(k => k.Key))
+            {
+                if (kv.Key < InBigSummonCount) continue;
+                ImGui.SameLine();
+                ImGui.Text($"#{kv.Key}:");
+                ImGui.SameLine();
+                var primals = GetPrimalsFromOrder(kv.Value);
+                const float iconSize = 22f;
+                for (var i = 0; i < primals.Length; i++)
+                {
+                    var act = primals[i];
+                    if (act.GetTexture(out var tex) && tex.Handle != IntPtr.Zero)
+                    {
+                        ImGui.Image(tex.Handle, new Vector2(iconSize, iconSize));
+                        if (ImGui.IsItemHovered()) ImGui.SetTooltip(act?.Name ?? kv.Value.ToString());
+                    }
+                    else
+                    {
+                        ImGui.Text(act?.Name ?? "?");
+                    }
+                    if (i < primals.Length - 1) ImGui.SameLine();
+                }
+                ImGui.NewLine();
+            }
+        }
+
+        ImGui.Separator();
+
+        //Ruin III Tracking
+        ImGui.Text("=== Ruin III Tracking ===");
+        ImGui.Text($"Ruin III Cast Count: {Ruin3Count}");
+        ImGui.Text($"Just Used Ruin III: {JustUsedRuin3}");
+
+        ImGui.Separator();
+
+        // Timing & Potions
+        ImGui.Text("=== Timing & Potions ===");
         ImGui.Text($"Can Late Weave: {CanLateWeave}");
+        ImGui.Text($"Is Condition Met for Potion: {ChurinPotions.IsConditionMet()}");
+
+        ImGui.Separator();
+
+        // Configuration
+        ImGui.Text("=== Configuration ===");
+        ImGui.Text($"Order: {SummonOrder}");
+        ImGui.Text($"Is Crimson Cyclone Target in Range: {CrimsonCyclonePvE.Target.Target.DistanceToPlayer() <= CrimsonCycloneDistance && HasIfritFavor}");
+        ImGui.Text($"Add Crimson Cyclone: {AddCrimsonCyclone}");
+        ImGui.Text($"Add Swiftcast on Garuda: {AddSwiftcastOnGaruda}");
+        ImGui.Text($"Skip Attunement: {SkipAttunement}");
+        
+        ImGui.Text($"Fight Preset Check: {FightPresetCheck(FightPresets)}");
     }
+
+    private const int M4SMaxOrderCount = 12;
+
+    private IAction?[] GetPrimalsFromOrder(SummonOrderType order)
+    {
+        return order switch
+        {
+            SummonOrderType.TopazEmeraldRuby => [SummonTitanPvE, SummonGarudaPvE, SummonIfritPvE],
+            SummonOrderType.TopazRubyEmerald => [SummonTitanPvE, SummonIfritPvE, SummonGarudaPvE],
+            SummonOrderType.EmeraldTopazRuby => [SummonGarudaPvE, SummonTitanPvE, SummonIfritPvE],
+            SummonOrderType.EmeraldRubyTopaz => [SummonGarudaPvE, SummonIfritPvE, SummonTitanPvE],
+            SummonOrderType.RubyEmeraldTopaz => [SummonIfritPvE, SummonGarudaPvE, SummonTitanPvE],
+            SummonOrderType.RubyTopazEmerald => [SummonIfritPvE, SummonTitanPvE, SummonGarudaPvE],
+            _ => [SummonIfritPvE, SummonGarudaPvE, SummonTitanPvE],
+        };
+    }
+
+    private static SummonOrderType GetOrderForCount(int count)
+    {
+        return count switch
+        {
+            <= 3 => SummonOrderType.TopazEmeraldRuby,
+            4 => SummonOrderType.RubyTopazEmerald,
+            <= 6 => SummonOrderType.RubyEmeraldTopaz,
+            <= 9 => SummonOrderType.TopazRubyEmerald,
+            10 => SummonOrderType.RubyTopazEmerald,
+            11 => SummonOrderType.TopazRubyEmerald,
+            _ => SummonOrderType.TopazEmeraldRuby
+        };
+    }
+
+
     #endregion
 
     #region Countdown Logic
     protected override IAction? CountDownAction(float remainTime)
     {
-        if (_churinPotions.ShouldUsePotion(this, out var potionAct))
+        UpdateCounts();
+        if (ChurinPotions.ShouldUsePotion(this, out var potionAct))
         {
             return potionAct;
         }
@@ -159,11 +266,13 @@ public sealed class ChurinSMN : SummonerRotation
         {
             return act;
         }
+
         if (HasSummon && remainTime <= RuinPvE.Info.CastTime + 0.8f && remainTime > RuinPvE.Info.CastTime && !InCombat
             && RuinPvE.CanUse(out act))
         {
             return act;
         }
+
         if (BigSummonTime(out act))
         {
             return act;
@@ -197,10 +306,16 @@ public sealed class ChurinSMN : SummonerRotation
     [RotationDesc(ActionID.LuxSolarisPvE)]
     protected override bool DefenseAreaAbility(IAction nextGCD, out IAction? act)
     {
-        if (!IsLastAction(false, RadiantAegisPvE) && RadiantAegisPvE.CanUse(out act, usedUp: true))
+        if (!HasRadiantAegis)
         {
-            return true;
+            return RadiantAegisPvE.CanUse(out act);
         }
+
+        if (HostileTarget != null && !HostileTarget.HasStatus(false, StatusID.Addle))
+        {
+            return AddlePvE.CanUse(out act);
+        }
+
         return base.DefenseAreaAbility(nextGCD, out act);
     }
     #endregion
@@ -240,78 +355,33 @@ public sealed class ChurinSMN : SummonerRotation
 
     protected override bool AttackAbility(IAction nextGCD, out IAction? act)
     {
-
-        if (TryUseSearingLight(out act))
-        {
-            return true;
-        }
-        if (TryUseEnergyDrain(out act))
-        {
-            return true;
-        }
-        if (TryUseEnkindle(out act))
-        {
-            return true;
-        }
-
-        if (TryUseAstralFlow(out act))
-        {
-            return true;
-        }
-
-        if (TryUseSearingFlash(out act))
-        {
-            return true;
-        }
-
-        if (TryUseAetherflow(out act))
-        {
-            return true;
-        }
-        if (MountainBusterPvE.CanUse(out act))
-        {
-            return true;
-        }
-        return base.AttackAbility(nextGCD, out act);
+        return  TryUseSearingFlash(out act)
+            || TryUseAetherflow(out act)
+            || MountainBusterPvE.CanUse(out act)
+            || base.AttackAbility(nextGCD, out act);
     }
 
     protected override bool EmergencyAbility(IAction nextGCD, out IAction? act)
     {
-        if (_churinPotions.ShouldUsePotion(this, out act))
+        if (EnableFightPresets)
         {
-            return true;
+            PresetEnabled(FightPresets);
         }
 
-        if (SwiftcastPvE.CanUse(out act))
-        {
-            if (AddSwiftcastOnRaise && nextGCD.IsTheSameTo(false, ResurrectionPvE))
-            {
-                return true;
-            }
-            if (AddSwiftcastOnLowST && !RubyRitePvE.EnoughLevel && nextGCD.IsTheSameTo(false, RubyRuinPvE, RubyRuinIiPvE, RubyRuinIiiPvE))
-            {
-                return true;
-            }
-            if (AddSwiftcastOnLowAOE && !RubyRitePvE.EnoughLevel && nextGCD.IsTheSameTo(false, RubyOutburstPvE))
-            {
-                return true;
-            }
-            if (AddSwiftcastOnRuby && nextGCD.IsTheSameTo(false, RubyRitePvE) && !ElementalMasteryTrait.EnoughLevel)
-            {
-                return true;
-            }
-            if (AddSwiftcastOnGaruda && nextGCD.IsTheSameTo(false, SlipstreamPvE) && ElementalMasteryTrait.EnoughLevel && !InBahamut && !InPhoenix && !InSolarBahamut)
-            {
-                return true;
-            }
-        }
-
-        return base.EmergencyAbility(nextGCD, out act);
+        UpdateCounts();
+        return ChurinPotions.ShouldUsePotion(this, out act)
+        || TryUseSwiftcast(nextGCD, out act)
+        || TryUseSearingLight(out act)
+        || TryUseEnergyDrain(out act)
+        || TryUseEnkindle(out act)
+        || TryUseAstralFlow(out act)
+        || base.EmergencyAbility(nextGCD, out act);
     }
 
     #endregion
 
     #region GCD Logic
+    
     [RotationDesc(ActionID.CrimsonCyclonePvE)]
     protected override bool MoveForwardGCD(out IAction? act)
     {
@@ -339,373 +409,567 @@ public sealed class ChurinSMN : SummonerRotation
             return true;
         }
 
-        if (BigSummonTime(out act))
-        {
-            return true;
-        }
-
-        if (SlipstreamPvE.CanUse(out act, skipCastingCheck: AddSwiftcastOnGaruda && ((!SwiftcastPvE.Cooldown.IsCoolingDown && IsMoving) || HasSwift)))
-        {
-            return true;
-        }
-
-        if ((!IsMoving || AddCrimsonCycloneMoving) && CrimsonCyclonePvE.CanUse(out act) && (AddCrimsonCyclone || CrimsonCyclonePvE.Target.Target.DistanceToPlayer() <= CrimsonCycloneDistance))
-        {
-            return true;
-        }
-
-        if (CrimsonStrikePvE.CanUse(out act))
-        {
-            return true;
-        }
-
-        if (PreciousBrillianceTime(out act))
-        {
-            return true;
-        }
-
-        if (GemshineTime(out act))
-        {
-            return true;
-        }
-
-        if (!InBahamut && !InPhoenix && !InSolarBahamut)
-        {
-            switch (SummonOrder)
-            {
-                case SummonOrderType.TopazEmeraldRuby:
-                default:
-                    if (TitanTime(out act))
-                    {
-                        return true;
-                    }
-
-                    if (GarudaTime(out act))
-                    {
-                        return true;
-                    }
-
-                    if (IfritTime(out act))
-                    {
-                        return true;
-                    }
-
-                    break;
-
-                case SummonOrderType.TopazRubyEmerald:
-                    if (TitanTime(out act))
-                    {
-                        return true;
-                    }
-
-                    if (IfritTime(out act))
-                    {
-                        return true;
-                    }
-
-                    if (GarudaTime(out act))
-                    {
-                        return true;
-                    }
-
-                    break;
-
-                case SummonOrderType.EmeraldTopazRuby:
-                    if (GarudaTime(out act))
-                    {
-                        return true;
-                    }
-
-                    if (TitanTime(out act))
-                    {
-                        return true;
-                    }
-
-                    if (IfritTime(out act))
-                    {
-                        return true;
-                    }
-
-                    break;
-
-                case SummonOrderType.RubyEmeraldTopaz:
-                    if (IfritTime(out act))
-                    {
-                        return true;
-                    }
-
-                    if (GarudaTime(out act))
-                    {
-                        return true;
-                    }
-
-                    if (TitanTime(out act))
-                    {
-                        return true;
-                    }
-
-                    break;
-            }
-        }
-
-        if (SummonTimeEndAfterGCD() && AttunmentTimeEndAfterGCD() && !InBahamut && !InPhoenix && !InSolarBahamut &&
-            RuinIvPvE.CanUse(out act, skipAoeCheck: true))
-        {
-            return true;
-        }
-
-        if (InIfrit && (!CrimsonCyclonePvE.CanUse(out _) || !CrimsonStrikePvE.CanUse(out _)) && IsMoving)
-        {
-            return RuinIvPvE.CanUse(out act);
-        }
-
-        if (BrandOfPurgatoryPvE.CanUse(out act))
-        {
-            return true;
-        }
-        if (UmbralFlarePvE.CanUse(out act))
-        {
-            return true;
-        }
-        if (AstralFlarePvE.CanUse(out act))
-        {
-            return true;
-        }
-        if (OutburstPvE.CanUse(out act))
-        {
-            return true;
-        }
-
-        if (FountainOfFirePvE.CanUse(out act))
-        {
-            return true;
-        }
-        if (UmbralImpulsePvE.CanUse(out act))
-        {
-            return true;
-        }
-        if (AstralImpulsePvE.CanUse(out act))
-        {
-            return true;
-        }
-        if (RuinIiiPvE.CanUse(out act))
-        {
-            return true;
-        }
-        if (RuinIiPvE.CanUse(out act))
-        {
-            return true;
-        }
-        if (RuinPvE.CanUse(out act))
-        {
-            return true;
-        }
-        return base.GeneralGCD(out act);
+        return BigSummonTime(out act)
+            || PrimalsFiller(out act)
+            || PrimalsTime(out act)
+            || SummonFiller(out act)
+            || base.GeneralGCD(out act);
     }
+    
     #endregion
 
     #region Extra Methods
 
-    #region Summons
-    private bool TitanTime(out IAction? act)
+    #region Summon GCD
+
+    private bool PrimalsTime(out IAction? act)
     {
-        if (SummonTitanIiPvE.CanUse(out act))
+        act = null;
+
+        if (((InBigSummon && !SummonTimeEndAfterGCD()) 
+        || (NoAttunement && (HasGarudaFavor || HasIfritFavor || HasTitanFavor))
+        || (AttunementCount > 0 && !AttunmentTimeEndAfterGCD()) 
+        || NoPrimalReady) && !SkipAttunement)
         {
-            return true;
+            return false;
         }
-        if (SummonTitanPvE.CanUse(out act))
+
+        if (UseRuin3 && Ruin3Count < 1)
         {
-            return true;
+            return RuinIiiPvE.CanUse(out act);
         }
-        if (SummonTopazPvE.CanUse(out act))
+
+        if (UseRuin4 && HasFurtherRuin)
         {
-            return true;
+            return RuinIvPvE.CanUse(out act);
+        }
+
+        return SummonOrder switch
+        {
+            SummonOrderType.TopazRubyEmerald =>
+                TitanTime(out act)
+                || IfritTime(out act)
+                || GarudaTime(out act),
+
+            SummonOrderType.TopazEmeraldRuby =>
+                TitanTime(out act)
+                || GarudaTime(out act)
+                || IfritTime(out act),
+
+            SummonOrderType.EmeraldTopazRuby =>
+                GarudaTime(out act)
+                || TitanTime(out act)
+                || IfritTime(out act),
+
+            SummonOrderType.EmeraldRubyTopaz =>
+                GarudaTime(out act)
+                || IfritTime(out act)
+                || TitanTime(out act),
+
+            SummonOrderType.RubyEmeraldTopaz =>
+                IfritTime(out act)
+                || GarudaTime(out act)
+                || TitanTime(out act),
+
+            SummonOrderType.RubyTopazEmerald =>
+                IfritTime(out act)
+                || TitanTime(out act)
+                || GarudaTime(out act),
+
+            _ => false,
+        };
+    }
+
+    private bool PrimalsFiller(out IAction? act)
+    {
+        act = null;
+
+        if (InBigSummon)
+        {
+            return false;
+        }
+
+        if (SkipAttunement)
+        {
+            return PrimalsTime(out act);
+        }
+        
+        return TitanAttunement(out act)
+        || GarudaAttunement(out act)
+        || IfritAttunement(out act);
+    }
+
+    private bool IfritAttunement(out IAction? act)
+    {
+        act = null;
+            
+        if (InTitan || InGaruda || HasGarudaFavor || HasTitanFavor || (!HasIfritFavor && !HasCrimsonStrike && AttunementCount < 1))
+        {
+            return false;
+        }
+
+        if (EnableFightPresets)
+        {
+            PresetEnabled(FightPresets);
+        }
+
+        if (HasCrimsonStrike)
+        {
+            return CrimsonStrikePvE.CanUse(out act);
+        }
+    
+        return IfritStrategy(IsMoving, out act);
+    }
+    
+    private bool IfritStrategy(bool isMoving, out IAction? act)
+    {
+        act = null;
+        var canUseCrimsonCyclone = AddCrimsonCyclone || CrimsonCyclonePvE.Target.Target.DistanceToPlayer() <= CrimsonCycloneDistance;
+        var cycloneAvailable = canUseCrimsonCyclone && HasIfritFavor;
+        var cycloneMoveAllowed = AddCrimsonCycloneMoving;
+        var cycloneBaseCondition = (UseCycloneFirst && AttunementCount > 1)
+                                    || (UseOneAttunement && AttunementCount == 1)
+                                    || (AttunementCount < 1 && UseBothAttunements && !UseOneAttunement);
+        var cycloneMoveCondition = cycloneAvailable && cycloneMoveAllowed && cycloneBaseCondition;
+    
+        if (isMoving)
+        {
+            if (EnableFightPresets)
+            {
+                if (UseRuin4 && HasFurtherRuin)
+                {
+                    return RuinIvPvE.CanUse(out act);
+                }
+    
+                if (cycloneMoveCondition)
+                {
+                    return CrimsonCyclonePvE.CanUse(out act);
+                }
+            }
+        
+            if (canUseCrimsonCyclone && AddCrimsonCycloneMoving)
+            {
+                return CrimsonCyclonePvE.CanUse(out act);
+            }
+
+            if (HasFurtherRuin)
+            {
+                return RuinIvPvE.CanUse(out act);
+            }
+    
+        }
+        else if (!isMoving)
+        {
+            if (EnableFightPresets)
+            {
+                PresetEnabled(FightPresets);
+
+                if (UseRuin3 && Ruin3Count < 1)
+                {
+                    return RuinIiiPvE.CanUse(out act);
+                }
+    
+                if (UseRuin4 && HasFurtherRuin)
+                {
+                    return RuinIvPvE.CanUse(out act);
+                }
+    
+                if (HasIfritFavor)
+                {
+                    if (AttunementCount > 1 && canUseCrimsonCyclone && UseCycloneFirst)
+                    {
+                        return CrimsonCyclonePvE.CanUse(out act);
+                    }
+    
+                    if ((UseOneAttunement && AttunementCount == 1 && (UseBothAttunements || !UseBothAttunements))
+                        || (AttunementCount < 1 && UseBothAttunements && !UseOneAttunement))
+                    {
+                        if (canUseCrimsonCyclone)
+                        {
+                            return CrimsonCyclonePvE.CanUse(out act);
+                        }
+                    }
+                }
+    
+                if (UseBothAttunements && AttunementCount > 0)
+                {
+                    return PreciousBrillianceTime(out act) || GemshineTime(out act);
+                }
+    
+                if (UseOneAttunement && AttunementCount == 2)
+                {
+                    return PreciousBrillianceTime(out act) || GemshineTime(out act);
+                }
+    
+                if (UseOneAttunement && UseBothAttunements && !HasIfritFavor && !HasCrimsonStrike && AttunementCount == 1)
+                {
+                    return PreciousBrillianceTime(out act) || GemshineTime(out act);
+                }
+    
+                if (UseOneAttunement && !UseBothAttunements && !HasIfritFavor && !HasCrimsonStrike && AttunementCount == 1)
+                {
+                    return false;
+                }
+            }
+    
+            if (AttunementCount > 0)
+            {
+                return PreciousBrillianceTime(out act) || GemshineTime(out act);
+            }
+    
+            if (HasIfritFavor && canUseCrimsonCyclone)
+            {
+                return CrimsonCyclonePvE.CanUse(out act);
+            }
+
+            if (HasFurtherRuin)
+            {
+                return RuinIvPvE.CanUse(out act);
+            }
+
+            if (Ruin3Count < 1)
+            {
+                return RuinIiiPvE.CanUse(out act);
+            }
         }
         return false;
+    }
+
+    private bool GarudaAttunement(out IAction? act)
+    {
+        act = null;
+        if (InTitan || InIfrit || HasIfritFavor || HasTitanFavor || (!HasGarudaFavor && AttunementCount < 1))
+        {
+            return false;
+        }
+
+        if (EnableFightPresets)
+        {
+            PresetEnabled(FightPresets);
+
+            if (UseRuin3 && Ruin3Count < 1)
+            {
+                return RuinIiiPvE.CanUse(out act);
+            }
+
+            if (UseRuin4 && HasFurtherRuin)
+            {
+                return RuinIvPvE.CanUse(out act);
+            }
+        }
+        
+        return GarudaStrategy(IsMoving, out act);
+    }
+
+    private bool GarudaStrategy(bool isMoving, out IAction? act)
+    {
+        act = null;
+        var canSwiftcastSlipstream = AddSwiftcastOnGaruda && (HasSwift || !SwiftcastPvE.Cooldown.IsCoolingDown);
+
+        if (isMoving)
+        {
+            if (HasGarudaFavor)
+            {
+                if (canSwiftcastSlipstream)
+                {
+                    return SlipstreamPvE.CanUse(out act, skipCastingCheck: true);
+                }
+
+                if (AttunementCount > 0)
+                {
+                    return PreciousBrillianceTime(out act) || GemshineTime(out act);
+                }
+
+                if (HasFurtherRuin)
+                {
+                    return RuinIvPvE.CanUse(out act);
+                }
+
+            }
+
+            if (AttunementCount > 0)
+            {
+                return PreciousBrillianceTime(out act) || GemshineTime(out act);
+            }
+
+            return false;
+        }
+        else
+        {
+            if (HasGarudaFavor && (canSwiftcastSlipstream || !AddSwiftcastOnGaruda))
+            {
+                return SlipstreamPvE.CanUse(out act, skipCastingCheck: AddSwiftcastOnGaruda);
+            }
+            
+            if (AttunementCount > 0)
+            {
+                return PreciousBrillianceTime(out act) || GemshineTime(out act);
+            }
+        }
+        return false;
+    }
+    
+    private bool TitanAttunement(out IAction? act)
+    {
+        act = null;
+        if (InIfrit || InGaruda || HasGarudaFavor || HasIfritFavor || !HasTitanFavor && AttunementCount < 1)
+        {
+            return false;
+        }
+
+        return PreciousBrillianceTime(out act)
+        || GemshineTime(out act);
+    }
+
+    private bool TitanTime(out IAction? act)
+    {
+        act = null;
+        if (!IsTitanReady || HasGarudaFavor || HasIfritFavor)
+        {
+            return false;
+        }
+        return SummonTitanPvE.CanUse(out act) 
+        || SummonTitanIiPvE.CanUse(out act) 
+        || SummonTopazPvE.CanUse(out act);
     }
 
     private bool GarudaTime(out IAction? act)
     {
-        if (SummonGarudaIiPvE.CanUse(out act))
+        act = null;
+        if (!IsGarudaReady || HasTitanFavor || HasIfritFavor)
         {
-            return true;
+            return false;
         }
-        if (SummonGarudaPvE.CanUse(out act))
-        {
-            return true;
-        }
-        if (SummonEmeraldPvE.CanUse(out act))
-        {
-            return true;
-        }
-        return false;
+        return SummonGarudaPvE.CanUse(out act) 
+        || SummonGarudaIiPvE.CanUse(out act) 
+        || SummonEmeraldPvE.CanUse(out act);
     }
 
     private bool IfritTime(out IAction? act)
     {
-        if (SummonIfritIiPvE.CanUse(out act))
+        act = null;
+        if (!IsIfritReady || HasGarudaFavor || HasTitanFavor)
         {
-            return true;
+            return false;
         }
-        if (SummonIfritPvE.CanUse(out act))
-        {
-            return true;
-        }
-        if (SummonRubyPvE.CanUse(out act))
-        {
-            return true;
-        }
-        return false;
+        return SummonIfritPvE.CanUse(out act) 
+        || SummonIfritIiPvE.CanUse(out act) 
+        || SummonRubyPvE.CanUse(out act);
     }
 
     private bool GemshineTime(out IAction? act)
     {
-        if (RubyRitePvE.CanUse(out act))
+        act = null;
+        if (InBigSummon || AttunementCount < 1)
         {
-            return true;
-        }
-        if (EmeraldRitePvE.CanUse(out act))
-        {
-            return true;
-        }
-        if (TopazRitePvE.CanUse(out act))
-        {
-            return true;
+            return false;
         }
 
-        if (RubyRuinIiiPvE.CanUse(out act))
+        if (InIfrit)
         {
-            return true;
-        }
-        if (EmeraldRuinIiiPvE.CanUse(out act))
-        {
-            return true;
-        }
-        if (TopazRuinIiiPvE.CanUse(out act))
-        {
-            return true;
+            return RubyRitePvE.CanUse(out act)
+            || RubyRuinIiiPvE.CanUse(out act)
+            || RubyRuinIiPvE.CanUse(out act)
+            || RubyRuinPvE.CanUse(out act);
         }
 
-        if (RubyRuinIiPvE.CanUse(out act))
+        if (InGaruda)
         {
-            return true;
-        }
-        if (EmeraldRuinIiPvE.CanUse(out act))
-        {
-            return true;
-        }
-        if (TopazRuinIiPvE.CanUse(out act))
-        {
-            return true;
+            return EmeraldRitePvE.CanUse(out act)
+            || EmeraldRuinIiiPvE.CanUse(out act)
+            || EmeraldRuinIiPvE.CanUse(out act)
+            || EmeraldRuinPvE.CanUse(out act);
         }
 
-        if (RubyRuinPvE.CanUse(out act))
+        if (InTitan)
         {
-            return true;
+            return TopazRitePvE.CanUse(out act)
+            || TopazRuinIiiPvE.CanUse(out act)
+            || TopazRuinIiPvE.CanUse(out act)
+            || TopazRuinPvE.CanUse(out act);
         }
-        if (EmeraldRuinPvE.CanUse(out act))
-        {
-            return true;
-        }
-        if (TopazRuinPvE.CanUse(out act))
-        {
-            return true;
-        }
+        
         return false;
     }
 
     private bool PreciousBrillianceTime(out IAction? act)
     {
-        if (RubyCatastrophePvE.CanUse(out act))
+        act = null;
+        if (InBigSummon || AttunementCount < 1)
         {
-            return true;
-        }
-        if (EmeraldCatastrophePvE.CanUse(out act))
-        {
-            return true;
-        }
-        if (TopazCatastrophePvE.CanUse(out act))
-        {
-            return true;
+            return false;
         }
 
-        if (RubyDisasterPvE.CanUse(out act))
+        if (InIfrit)
         {
-            return true;
+            return RubyCatastrophePvE.CanUse(out act)
+            || RubyDisasterPvE.CanUse(out act)
+            || RubyOutburstPvE.CanUse(out act);
         }
-        if (EmeraldDisasterPvE.CanUse(out act))
+        if (InGaruda)
         {
-            return true;
+            return EmeraldCatastrophePvE.CanUse(out act)
+            || EmeraldDisasterPvE.CanUse(out act)
+            || EmeraldOutburstPvE.CanUse(out act);
         }
-        if (TopazDisasterPvE.CanUse(out act))
+        if (InTitan)
         {
-            return true;
-        }
-
-        if (RubyOutburstPvE.CanUse(out act))
-        {
-            return true;
-        }
-        if (EmeraldOutburstPvE.CanUse(out act))
-        {
-            return true;
-        }
-        if (TopazOutburstPvE.CanUse(out act))
-        {
-            return true;
+            return TopazCatastrophePvE.CanUse(out act)
+            || TopazDisasterPvE.CanUse(out act)
+            || TopazOutburstPvE.CanUse(out act);
         }
         return false;
     }
 
     private bool BigSummonTime(out IAction? act)
     {
-        if (SummonSolarBahamutPvE.CanUse(out act))
+        act = null;
+        if (!SummonBahamutPvE.IsEnabled || !SummonSolarBahamutPvE.IsEnabled || !SummonPhoenixPvE.IsEnabled)
         {
-            return true;
+            return false;
         }
-        if (SummonBahamutPvE.EnoughLevel && SummonBahamutPvE.CanUse(out act)
-        || !SummonBahamutPvE.EnoughLevel && DreadwyrmTrancePvE.CanUse(out act)
-        || !DreadwyrmTrancePvE.EnoughLevel && HasHostilesInRange && AetherchargePvE.CanUse(out act))
+
+        if (SummonSolarBahamutPvE.EnoughLevel && IsSolarBahamutReady)
         {
-            return true;
+            return SummonSolarBahamutPvE.CanUse(out act);
         }
-        if (SummonPhoenixPvE.CanUse(out act))
+
+        if (SummonPhoenixPvE.EnoughLevel && IsPhoenixReady)
         {
-            return true;
+            return SummonPhoenixPvE.CanUse(out act);
         }
+
+        if (SummonBahamutPvE.EnoughLevel && IsBahamutReady)
+        {
+            return SummonBahamutPvE.CanUse(out act);
+        }
+
+        if (!SummonBahamutPvE.EnoughLevel && DreadwyrmTrancePvE.EnoughLevel)
+        {
+            return DreadwyrmTrancePvE.CanUse(out act);
+        }
+
+        if (!DreadwyrmTrancePvE.EnoughLevel && AetherchargePvE.EnoughLevel)
+        {
+            return AetherchargePvE.CanUse(out act);
+        }
+
         return false;
     }
 
+    private bool SummonFiller(out IAction? act)
+    {
+        act = null;
+        var solarBahamutReadySoon = IsSolarBahamutReady && SummonSolarBahamutPvE.Cooldown.WillHaveOneChargeGCD(1) && SummonSolarBahamutPvE.IsEnabled;
+        var bahamutReadySoon = IsBahamutReady && SummonBahamutPvE.Cooldown.WillHaveOneChargeGCD(1) && SummonBahamutPvE.IsEnabled;
+        var phoenixReadySoon = IsPhoenixReady && SummonPhoenixPvE.Cooldown.WillHaveOneChargeGCD(1) && SummonPhoenixPvE.IsEnabled;
+        var bigSummonReadySoon = solarBahamutReadySoon || bahamutReadySoon || phoenixReadySoon;
+        
+        if ((!InBigSummon && AnyPrimalReady && NoAttunement) || HasAnyFavor || HasAnyAttunement)
+        {
+            return false;
+        }
+
+        if (InBigSummon)
+        {
+            if (InPhoenix)
+            {
+                return BrandOfPurgatoryPvE.CanUse(out act)
+                || FountainOfFirePvE.CanUse(out act);
+            }
+
+            if (InBahamut)
+            {
+                return AstralFlarePvE.CanUse(out act)
+                || AstralImpulsePvE.CanUse(out act);
+            }
+
+            if (InSolarBahamut)
+            {
+                return UmbralFlarePvE.CanUse(out act)
+                || UmbralImpulsePvE.CanUse(out act);
+            }
+        }
+        else
+        {
+            if (IsMoving)
+            {
+                if (HasFurtherRuin)
+                {
+                    return RuinIvPvE.CanUse(out act);
+                }
+
+                if (Ruin3Count < 1)
+                {
+                    return OutburstPvE.CanUse(out act)
+                           || RuinIiiPvE.CanUse(out act)
+                           || RuinIiPvE.CanUse(out act)
+                           || RuinPvE.CanUse(out act);
+                }
+            }
+            else
+            {
+                if (HasFurtherRuin)
+                {
+                    if (!bigSummonReadySoon && Ruin3Count < 1)
+                    {
+                        return OutburstPvE.CanUse(out act)
+                        || RuinIiiPvE.CanUse(out act)
+                        || RuinIiPvE.CanUse(out act)
+                        || RuinPvE.CanUse(out act);
+                    }
+
+                    return RuinIvPvE.CanUse(out act);
+                }
+
+                if (!bigSummonReadySoon || Ruin3Count < 1)
+                {
+                    return OutburstPvE.CanUse(out act)
+                           || RuinIiiPvE.CanUse(out act)
+                           || RuinIiPvE.CanUse(out act)
+                           || RuinPvE.CanUse(out act);
+                }
+            }
+        }
+        return false;
+    }
+    
     private int BigSummonGCDLeft
     {
         get
         {
             if (InBigSummon)
             {
-                var MaxImpulse = Math.Abs((double)SummonTimer / (double)RuinPvE.Cooldown.RecastTime);
+                var maxImpulse = Math.Abs(SummonTimer / (double)RuinPvE.Cooldown.RecastTime);
                 {
-                    if (MaxImpulse > 0)
+                    if (maxImpulse > 0)
                     {
-                        return (int)(MaxImpulse + 1);
+                        return (int)(maxImpulse + 1);
                     }
                 }
             }
             return 0;
         }
     }
+    
     #endregion
 
     #region oGCDs
     private bool TryUseEnergyDrain(out IAction? act)
     {
         act = null;
-        if (HasAetherflowStacks || !InBigSummon)
+        if (HasAetherflowStacks)
         {
             return false;
         }
-        if (BigSummonGCDLeft == 3 && (EnergySiphonPvE.CanUse(out act) || EnergyDrainPvE.CanUse(out act)))
+
+        if (((SummonSolarBahamutPvE.EnoughLevel && InSolarBahamut 
+        || !SummonSolarBahamutPvE.EnoughLevel && (InBahamut|| InPhoenix)) && BigSummonGCDLeft <= 4)
+        || (SummonSolarBahamutPvE.EnoughLevel && (InBahamut || InPhoenix))
+        || (HasSearingLight && !InBigSummon && !NoAttunement))
         {
-            return true;
+            return EnergySiphonPvE.CanUse(out act)
+            || EnergyDrainPvE.CanUse(out act);
         }
         return false;
     }
@@ -717,9 +981,10 @@ public sealed class ChurinSMN : SummonerRotation
         {
             return false;
         }
-        if (BigSummonGCDLeft == 5 && CanLateWeave && SearingLightPvE.CanUse(out act))
+
+        if (InBigSummon && BigSummonGCDLeft <= 5)
         {
-            return true;
+            return SearingLightPvE.CanUse(out act);
         }
 
         return false;
@@ -732,9 +997,11 @@ public sealed class ChurinSMN : SummonerRotation
         {
             return false;
         }
-        if (BigSummonGCDLeft == 2 && (EnkindleSolarBahamutPvE.CanUse(out act) || EnkindleBahamutPvE.CanUse(out act) || EnkindlePhoenixPvE.CanUse(out act)))
+        if (BigSummonGCDLeft <= 3)
         {
-            return true;
+            return EnkindleSolarBahamutPvE.CanUse(out act) 
+            || EnkindleBahamutPvE.CanUse(out act) 
+            || EnkindlePhoenixPvE.CanUse(out act);
         }
         return false;
     }
@@ -746,9 +1013,10 @@ public sealed class ChurinSMN : SummonerRotation
         {
             return false;
         }
-        if (BigSummonGCDLeft == 1 && (SunflarePvE.CanUse(out act) || DeathflarePvE.CanUse(out act)))
+        if (BigSummonGCDLeft <= 3)
         {
-            return true;
+            return SunflarePvE.CanUse(out act) 
+            || DeathflarePvE.CanUse(out act);
         }
         return false;
     }
@@ -760,11 +1028,11 @@ public sealed class ChurinSMN : SummonerRotation
         {
             return false;
         }
-        if (BigSummonGCDLeft < 1 && SearingFlashPvE.CanUse(out act))
+
+        if ((BigSummonGCDLeft <= 2 || !InBigSummon) && SearingFlashPvE.CanUse(out act))
         {
             return true;
         }
-
         return false;
     }
 
@@ -776,16 +1044,52 @@ public sealed class ChurinSMN : SummonerRotation
             return false;
         }
 
-        if ((SummonSolarBahamutPvE.EnoughLevel && InSolar || !SummonSolarBahamutPvE.EnoughLevel && InBahamut) && HasSearingLight || !SearingLightPvE.EnoughLevel)
+        if (HasSearingLight && (InBigSummon && BigSummonGCDLeft <= 4 || !InBigSummon) 
+        || !SearingLightPvE.EnoughLevel)
         {
-            if (PainflarePvE.CanUse(out act) || NecrotizePvE.CanUse(out act) || FesterPvE.CanUse(out act))
-            {
-                return true;
-            }
+            return PainflarePvE.CanUse(out act)
+            || NecrotizePvE.CanUse(out act)
+            || FesterPvE.CanUse(out act);
         }
         return false;
     }
 
+    private bool TryUseSwiftcast(IAction nextGCD, out IAction? act)
+    {
+        if (SwiftcastPvE.CanUse(out act))
+        {
+            if (nextGCD.IsTheSameTo(false, ResurrectionPvE))
+            {
+                return AddSwiftcastOnRaise;
+            }
+
+            if (nextGCD.IsTheSameTo(false, RubyRuinPvE, RubyRuinIiPvE, RubyRuinIiiPvE))
+            {
+                return AddSwiftcastOnLowSt && !RubyRitePvE.EnoughLevel;
+            }
+
+            if (nextGCD.IsTheSameTo(false, RubyOutburstPvE))
+            {
+                return AddSwiftcastOnLowAOE && !RubyRitePvE.EnoughLevel;
+            }
+
+            if (nextGCD.IsTheSameTo(false, RubyRitePvE))
+            {
+                return AddSwiftcastOnRuby && ElementalMasteryTrait.EnoughLevel && !InGaruda;
+            }
+
+            if (nextGCD.IsTheSameTo(false, SlipstreamPvE))
+            {
+                return AddSwiftcastOnGaruda && ElementalMasteryTrait.EnoughLevel && InGaruda;
+            }
+
+            if (nextGCD.IsTheSameTo(false, RubyRitePvE, RubyCatastrophePvE) && IsMoving)
+            {
+                return !HasFurtherRuin && InIfrit && (!Player.HasStatus(true, StatusID.IfritsFavor) || !AddCrimsonCyclone && CrimsonCyclonePvE.Target.Target.DistanceToPlayer() > CrimsonCycloneDistance);
+            }
+        }
+        return false;
+    }
     #endregion
 
     #region Miscellaneous
@@ -793,56 +1097,354 @@ public sealed class ChurinSMN : SummonerRotation
     {
         get
         {
-            int aliveHealerCount = 0;
-            IEnumerable<IBattleChara> healers = PartyMembers.GetJobCategory(JobRole.Healer);
-            foreach (IBattleChara h in healers)
+            var aliveHealerCount = 0;
+            var healers = PartyMembers.GetJobCategory(JobRole.Healer);
+            foreach (var h in healers)
             {
                 if (!h.IsDead)
                     aliveHealerCount++;
             }
 
-            return base.CanHealSingleSpell && (GCDHeal || aliveHealerCount == 0);
+            return base.CanHealSingleSpell && aliveHealerCount == 0;
         }
+    }    
+    
+    #region Potions
+    private void UpdateCustomTimings()
+    {
+        ChurinPotions.CustomTimings = new Potions.CustomTimingsData
+        {
+            Timings = [FirstPotionTiming, SecondPotionTiming, ThirdPotionTiming]
+        };
     }
+    
+    private static readonly ChurinSMNPotions ChurinPotions = new();
+    
+    private float _firstPotionTiming;
+   
+    private float _secondPotionTiming;
+    
+    private float _thirdPotionTiming;
+    
+    /// <summary>
+    /// SMN-specific potion manager that extends base potion logic with job-specific conditions.
+    /// </summary>
+    private class ChurinSMNPotions : Potions
+    {
+        public override bool IsConditionMet()
+        {
+            if (InSolar || InBahamut || InPhoenix)
+            {
+                return CanLateWeave;
+            }
+
+            return false;
+        }
+
+        protected override bool IsTimingValid(float timing)
+        {
+            if (timing > 0 && DataCenter.CombatTimeRaw >= timing && DataCenter.CombatTimeRaw - timing <= TimingWindowSeconds)
+            {
+                return true;
+            }
+
+            // Check opener timing: if it's an opener potion and countdown is within configured time
+            float countDown = Service.CountDownTime;
+            if (IsOpenerPotion(timing) && countDown > 0 && ChurinSMN.OpenerPotionTime > 0)
+            {
+                return countDown <= ChurinSMN.OpenerPotionTime;
+            }
+
+            if (IsOpenerPotion(timing) && ChurinSMN.OpenerPotionTime == 0 && DataCenter.CombatTimeRaw < TimingWindowSeconds)
+            {
+                return IsConditionMet();
+            }
+
+            return false;
+        }
+    
+    }
+    
     #endregion
-#endregion
-
-/// <summary>
-/// SMN-specific potion manager that extends base potion logic with job-specific conditions.
-/// </summary>
-private class ChurinSMNPotions : Potions
-{
-    public override bool IsConditionMet()
+    
+    #region Experimental Methods
+    
+    private bool JustInBigSummon {get; set;}
+    
+    private int Ruin3Count { get; set;}
+    
+    private bool JustUsedRuin3 { get; set;}
+    
+    private bool UseRuin4 { get; set;}
+    
+    private int InBigSummonCount{ get; set;}
+    
+    private bool UseRuin3 { get; set;}
+    
+    private bool CrimsonCycloneTargetTooFar => (CrimsonCyclonePvE.Target.Target.DistanceToPlayer() > CrimsonCycloneDistance) && HasIfritFavor;
+    
+    private bool SkipAttunement { get; set;}
+    
+    public bool UseBothAttunements { get; private set;}
+    
+    public bool UseOneAttunement { get; private set;}
+    
+    public bool UseCycloneFirst { get; private set;}
+    
+    private readonly Dictionary<int, SummonOrderType> _m4SOrderMap = [];
+    
+    private static bool FightPresetCheck(FightPreset preset)
     {
-        if (InSolar || InBahamut || InPhoenix)
+        ushort territory;
+        switch (preset)
         {
-            return CanLateWeave;
+            case FightPreset.CruiserweightM4S: 
+            territory = 1263;
+            break;
+
+            case FightPreset.CruiserweightM3S: 
+            territory = 1261;
+            break;
+
+            case FightPreset.CruiserweightM2S: 
+            territory = 1259;
+            break;
+
+            case FightPreset.CruiserweightM1S: 
+            territory = 1257;
+            break;
+
+            case FightPreset.None:
+            default:
+            return false;
         }
 
-        return false;
+        return IsInTerritory(territory) || CurrentTarget != null && CurrentTarget.IsDummy();
+    }
+    
+    private void SetIfritAttunementFlags(bool both, bool one, bool cycloneFirst, bool addCyclone)
+    {
+        UseBothAttunements = both;
+        UseOneAttunement = one;
+        UseCycloneFirst = cycloneFirst;
+        AddCrimsonCyclone = addCyclone;
+    }
+    
+    private void SetRuin3Flag(bool ruin3Flags)
+    {
+        UseRuin3 = ruin3Flags;
+    }
+    
+    private void SetRuin4Flag(bool ruin4Flags)
+    {
+        UseRuin4 = ruin4Flags;
+    }
+    
+    private void SetSkipAttunementFlag(bool skipAttunementFlag)
+    {
+        SkipAttunement = skipAttunementFlag;
     }
 
-    protected override bool IsTimingValid(float timing)
+    private void ResetCounts()
     {
-        if (timing > 0 && DataCenter.CombatTimeRaw >= timing && DataCenter.CombatTimeRaw - timing <= TimingWindowSeconds)
-        {
-            return true;
-        }
-        
-        // Check opener timing: if it's an opener potion and countdown is within configured time
-        float countDown = Service.CountDownTime;
-        if (IsOpenerPotion(timing) && countDown > 0 && ChurinSMN.OpenerPotionTime > 0)
-        {
-            return countDown <= ChurinSMN.OpenerPotionTime;
-        }
-        
-        if (IsOpenerPotion(timing) && ChurinSMN.OpenerPotionTime == 0 && DataCenter.CombatTimeRaw < TimingWindowSeconds)
-        {
-            return IsConditionMet();
-        }
-
-        return false;
+        InBigSummonCount = 0;
+        JustInBigSummon = false;
+        _m4SOrderMap.Clear();
+        Ruin3Count = 0;
+        UseBothAttunements = true;
+        UseOneAttunement = false;
+        UseCycloneFirst = false;
+        SkipAttunement = false;
+        UseRuin3 = false;
+        UseRuin4 = false; 
     }
-}
 
-}
+    private void UpdateCounts()
+    {
+        // Avoid updating while out of combat
+        if (!InCombat)
+        {   
+            ResetCounts();
+            return;
+        }
+
+        if (InBigSummon && !JustInBigSummon)
+        {
+            InBigSummonCount++;
+            Ruin3Count = 0;
+            var keysToRemove = _m4SOrderMap.Keys.Where(k => k < InBigSummonCount).ToList();
+            foreach (var k in keysToRemove)
+            {
+                _m4SOrderMap.Remove(k);
+            }
+        }
+        
+        if (IsLastGCD(ActionID.RuinIiiPvE) && !JustUsedRuin3)
+        {
+            Ruin3Count++;
+            JustUsedRuin3 = true;
+        }
+        
+        if (!IsLastGCD(ActionID.RuinIiiPvE))
+        {
+            JustUsedRuin3 = false;
+        }
+        // Persist current state for the next check
+        JustInBigSummon = InBigSummon;
+    }
+
+    private void PresetEnabled(FightPreset preset)
+    {
+        if (FightPresetCheck(preset))
+        {
+           switch(preset)
+            {
+                case FightPreset.CruiserweightM4S:
+                    M4SPreset();
+                    break;
+                case FightPreset.CruiserweightM3S:
+                case FightPreset.CruiserweightM2S:
+                case FightPreset.CruiserweightM1S:
+                    break;
+            }
+        }
+        else
+        {
+            DefaultPreset();
+        }
+    }    
+    
+    #region Default Preset Logic
+    
+    private void DefaultPreset()
+    {
+        if (!InCombat)
+        {
+            return;
+        }
+
+        UseBothAttunements = true;
+        UseOneAttunement = false;
+        UseCycloneFirst = false;
+        SkipAttunement = false;
+        UseRuin3 = false;
+        UseRuin4 = false;
+    }
+    
+    #endregion
+    
+    #region M4S Preset Logic
+    
+    private void M4SPreset()
+    {
+        if (!InCombat)
+        {
+            return;
+        }
+
+        if (!AddSwiftcastOnGaruda)
+        {
+            AddSwiftcastOnGaruda = true;
+        }
+
+        if (InBigSummon)
+        {
+            M4SPrimalsOrder();
+        }
+        M4SInPrimals();
+    }
+    
+    private void M4SPrimalsOrder()
+    {
+       if (InBigSummonCount < 0) return;
+
+        for (var c = InBigSummonCount; c <= M4SMaxOrderCount; c++)
+        {
+            var order = GetOrderForCount(c);
+            _m4SOrderMap[c] = order;
+        }
+
+        var currentOrder = GetOrderForCount(InBigSummonCount);
+        if (SummonOrder != currentOrder)
+        {
+            SummonOrder = currentOrder;
+        }
+    }
+
+    private void M4SInPrimals()
+    {
+        var isCastingRubyRite = Player.CastActionId is (uint)ActionID.RubyRitePvE;
+        var castAlmostFinished = Player.IsCasting && isCastingRubyRite && WeaponRemain < 1f;
+        var attunementUsedUp = (HasIfritFavor && !InIfrit) || IsLastGCD(ActionID.RubyRitePvE) && castAlmostFinished && AttunementCount <= 1;
+        var hasOneAttunementLeft = (castAlmostFinished && AttunementCount <= 2) || AttunementCount == 1;
+        var crimsonCycloneTargetInRange = CrimsonCyclonePvE.Target.Target.DistanceToPlayer() <= CrimsonCycloneDistance;
+
+        UseRuin3 = false;
+        UseRuin4 = false;
+        AddCrimsonCyclone = false;
+        SkipAttunement = false;
+        UseCycloneFirst = false;
+    
+        switch (InBigSummonCount)
+        {
+            case <= 1 or 3:
+                SetRuin3Flag(InGaruda && (!HasGarudaFavor || IsLastGCD(ActionID.SlipstreamPvE)) && Ruin3Count < 1);
+                SetIfritAttunementFlags(true, false, false, CrimsonCycloneTargetTooFar && attunementUsedUp);
+                break;
+            case 4:
+                SetIfritAttunementFlags(true, false, false, CrimsonCycloneTargetTooFar && attunementUsedUp);
+                SetRuin3Flag(!IsIfritReady && !InIfrit && IsLastGCD(ActionID.CrimsonStrikePvE) && IsTitanReady && IsGarudaReady && Ruin3Count < 1);
+                SetRuin4Flag(InGaruda && !HasGarudaFavor && HasFurtherRuin);
+                break;
+            case 5:
+                SetIfritAttunementFlags(false, true, false, hasOneAttunementLeft && (CrimsonCycloneTargetTooFar || crimsonCycloneTargetInRange));
+                SetSkipAttunementFlag((InIfrit &&  !HasIfritFavor && !HasCrimsonStrike && AttunementCount == 1 && IsGarudaReady) || (InGaruda && !HasGarudaFavor && AttunementCount < 3 && IsTitanReady));
+                break;
+            case 6:
+                SetRuin3Flag(attunementUsedUp && Ruin3Count < 1);
+                SetIfritAttunementFlags(true, false, false, CrimsonCycloneTargetTooFar && attunementUsedUp && Ruin3Count > 0);
+                break;   
+            case 8:
+                SetRuin3Flag(!InIfrit && !HasCrimsonStrike && !HasIfritFavor && IsLastGCD(ActionID.CrimsonStrikePvE) && !IsIfritReady && IsGarudaReady && IsTitanReady && Ruin3Count < 1);
+                break;
+            case 9:
+                SetIfritAttunementFlags(true, true, false, hasOneAttunementLeft && (CrimsonCycloneTargetTooFar || crimsonCycloneTargetInRange));
+                if (InGaruda)
+                {
+                    if (!HasGarudaFavor && AttunementCount > 3)
+                    {
+                        SetRuin3Flag(Ruin3Count < 1);
+                        SetRuin4Flag(HasFurtherRuin);
+                    }
+                }
+                break;
+            case 10:
+                SetIfritAttunementFlags(true, true, false, hasOneAttunementLeft && (CrimsonCycloneTargetTooFar || crimsonCycloneTargetInRange));
+                SetRuin3Flag(attunementUsedUp && Ruin3Count < 1 && IsTitanReady);
+                SetRuin4Flag(InGaruda && !HasGarudaFavor && AttunementCount > 2 && HasFurtherRuin);
+                break;
+            case 11:
+                SetIfritAttunementFlags(true, false, false, attunementUsedUp && (CrimsonCycloneTargetTooFar || crimsonCycloneTargetInRange) && Ruin3Count > 0);
+                SetRuin3Flag(attunementUsedUp && Ruin3Count < 1);
+                SetRuin4Flag(InGaruda && !HasGarudaFavor && AttunementCount > 3 && HasFurtherRuin);
+                break;
+            case 12:
+                SetRuin3Flag(InGaruda && !HasGarudaFavor && AttunementCount > 3 && Ruin3Count < 1);
+                SetIfritAttunementFlags(true, false, true, CrimsonCycloneTargetTooFar || crimsonCycloneTargetInRange);
+                break;
+            default:
+                SetIfritAttunementFlags(true, false, false, CrimsonCycloneTargetTooFar && attunementUsedUp);
+                break;
+        }
+    }
+    
+    #endregion
+    
+    #endregion
+    
+    #endregion
+    
+    #endregion
+
+}   
+


### PR DESCRIPTION
This pull request includes several updates to the Summoner and Dancer rotation logic, focusing on improving clarity, correctness, and decision-making for ability usage. The main changes involve renaming a key property for attunement handling in Summoner logic and refining the logic for ability usage, thresholds, and cooldown checks in the Dancer rotation.

**Summoner Rotation Improvements:**

* Renamed the static property `Attunement` to `AttunementCount` throughout `SummonerRotation`, and updated all related logic and UI display to use the new property for clarity and accuracy. [[1]](diffhunk://#diff-6d326643eaefd7c169540c6a3e91d7a615fd89417aab1cb1faf44ce9930c2932L28-R30) [[2]](diffhunk://#diff-6d326643eaefd7c169540c6a3e91d7a615fd89417aab1cb1faf44ce9930c2932L191-R193)
* Updated all action checks in Summoner abilities to use `AttunementCount` instead of the old property, ensuring consistency in attunement-based ability gating. [[1]](diffhunk://#diff-6d326643eaefd7c169540c6a3e91d7a615fd89417aab1cb1faf44ce9930c2932L469-R471) [[2]](diffhunk://#diff-6d326643eaefd7c169540c6a3e91d7a615fd89417aab1cb1faf44ce9930c2932L484-R486) [[3]](diffhunk://#diff-6d326643eaefd7c169540c6a3e91d7a615fd89417aab1cb1faf44ce9930c2932L499-R501) [[4]](diffhunk://#diff-6d326643eaefd7c169540c6a3e91d7a615fd89417aab1cb1faf44ce9930c2932L514-R521) [[5]](diffhunk://#diff-6d326643eaefd7c169540c6a3e91d7a615fd89417aab1cb1faf44ce9930c2932L529-R531) [[6]](diffhunk://#diff-6d326643eaefd7c169540c6a3e91d7a615fd89417aab1cb1faf44ce9930c2932L556-R558) [[7]](diffhunk://#diff-6d326643eaefd7c169540c6a3e91d7a615fd89417aab1cb1faf44ce9930c2932L583-R585)
* Improved ability gating for Garuda actions to check both attunement and elemental stance where appropriate.
* Adjusted Slipstream logic to check for swiftcast status and Garuda attunement expiration more accurately.
* Removed redundant `InIfrit` checks from Crimson Cyclone and Crimson Strike actions. [[1]](diffhunk://#diff-6d326643eaefd7c169540c6a3e91d7a615fd89417aab1cb1faf44ce9930c2932L663) [[2]](diffhunk://#diff-6d326643eaefd7c169540c6a3e91d7a615fd89417aab1cb1faf44ce9930c2932L672)

**Dancer (ChurinDNC) Rotation Logic Refinements:**

* Refined the logic for using Technical Step and Standard Step, including more precise cooldown and Esprit threshold checks, and improved handling of ability hold strategies. [[1]](diffhunk://#diff-47a4eb6c618e99b36d8294fb8cab1da42f6e3561e705aa2075ffe4f2a2549957R34) [[2]](diffhunk://#diff-47a4eb6c618e99b36d8294fb8cab1da42f6e3561e705aa2075ffe4f2a2549957L81-R82) [[3]](diffhunk://#diff-47a4eb6c618e99b36d8294fb8cab1da42f6e3561e705aa2075ffe4f2a2549957R154) [[4]](diffhunk://#diff-47a4eb6c618e99b36d8294fb8cab1da42f6e3561e705aa2075ffe4f2a2549957L164-R171) [[5]](diffhunk://#diff-47a4eb6c618e99b36d8294fb8cab1da42f6e3561e705aa2075ffe4f2a2549957L173-R185) [[6]](diffhunk://#diff-47a4eb6c618e99b36d8294fb8cab1da42f6e3561e705aa2075ffe4f2a2549957L205-R224)
* Updated GCD and oGCD logic to better prioritize actions based on current state, cooldowns, and finishing moves.
* Adjusted Starfall Dance usage logic to use more precise timing and Esprit cost checks, ensuring optimal use of the ability. [[1]](diffhunk://#diff-47a4eb6c618e99b36d8294fb8cab1da42f6e3561e705aa2075ffe4f2a2549957L647-R665) [[2]](diffhunk://#diff-47a4eb6c618e99b36d8294fb8cab1da42f6e3561e705aa2075ffe4f2a2549957L662-R690)
* Improved Saber Dance gating to prevent usage when Standard or Technical Step is available, and refined burst phase logic for its use.
* Added and reorganized code regions for clarity, and included additional UI feedback for Technical Step cooldowns. [[1]](diffhunk://#diff-47a4eb6c618e99b36d8294fb8cab1da42f6e3561e705aa2075ffe4f2a2549957R332) [[2]](diffhunk://#diff-47a4eb6c618e99b36d8294fb8cab1da42f6e3561e705aa2075ffe4f2a2549957L345) [[3]](diffhunk://#diff-47a4eb6c618e99b36d8294fb8cab1da42f6e3561e705aa2075ffe4f2a2549957R473) [[4]](diffhunk://#diff-47a4eb6c618e99b36d8294fb8cab1da42f6e3561e705aa2075ffe4f2a2549957R560) [[5]](diffhunk://#diff-47a4eb6c618e99b36d8294fb8cab1da42f6e3561e705aa2075ffe4f2a2549957R712) [[6]](diffhunk://#diff-47a4eb6c618e99b36d8294fb8cab1da42f6e3561e705aa2075ffe4f2a2549957R842) [[7]](diffhunk://#diff-47a4eb6c618e99b36d8294fb8cab1da42f6e3561e705aa2075ffe4f2a2549957R937)