### PR TITLE
Churin MNK!

### DIFF
--- a/RotationSolver/ExtraRotations/Magical/ChurinSMN.cs
+++ b/RotationSolver/ExtraRotations/Magical/ChurinSMN.cs
@@ -174,13 +174,13 @@ public sealed class ChurinSMN : SummonerRotation
                 ImGui.Text($"#{kv.Key}:");
                 ImGui.SameLine();
                 var primals = GetPrimalsFromOrder(kv.Value);
-                const float iconSize = 22f;
+                const float IconSize = 22f;
                 for (var i = 0; i < primals.Length; i++)
                 {
                     var act = primals[i];
                     if (act.GetTexture(out var tex) && tex.Handle != IntPtr.Zero)
                     {
-                        ImGui.Image(tex.Handle, new Vector2(iconSize, iconSize));
+                        ImGui.Image(tex.Handle, new Vector2(IconSize, IconSize));
                         if (ImGui.IsItemHovered()) ImGui.SetTooltip(act?.Name ?? kv.Value.ToString());
                     }
                     else
@@ -262,18 +262,10 @@ public sealed class ChurinSMN : SummonerRotation
             return potionAct;
         }
 
-        if (SummonCarbunclePvE.CanUse(out IAction? act))
-        {
-            return act;
-        }
-
-        if (HasSummon && remainTime <= RuinPvE.Info.CastTime + 0.8f && remainTime > RuinPvE.Info.CastTime && !InCombat
-            && RuinPvE.CanUse(out act))
-        {
-            return act;
-        }
-
-        if (BigSummonTime(out act))
+        if (SummonCarbunclePvE.CanUse(out var act)
+            || HasSummon && remainTime <= RuinPvE.Info.CastTime + 0.8f && remainTime > RuinPvE.Info.CastTime && !InCombat
+            && RuinPvE.CanUse(out act)
+            || BigSummonTime(out act))
         {
             return act;
         }
@@ -286,21 +278,19 @@ public sealed class ChurinSMN : SummonerRotation
     [RotationDesc(ActionID.LuxSolarisPvE)]
     protected override bool HealAreaAbility(IAction nextGCD, out IAction? act)
     {
-        if (LuxSolarisPvE.CanUse(out act))
-        {
-            return true;
-        }
-        return base.HealAreaAbility(nextGCD, out act);
+        return LuxSolarisPvE.CanUse(out act) || base.HealAreaAbility(nextGCD, out act);
     }
 
     [RotationDesc(ActionID.RekindlePvE)]
     protected override bool HealSingleAbility(IAction nextGCD, out IAction? act)
     {
-        if (RekindlePvE.CanUse(out act))
+        if (!HasRadiantAegis)
         {
-            return true;
+            return RadiantAegisPvE.CanUse(out act);
         }
-        return base.HealSingleAbility(nextGCD, out act);
+
+        return RekindlePvE.CanUse(out act)
+               || base.HealSingleAbility(nextGCD, out act);
     }
 
     [RotationDesc(ActionID.LuxSolarisPvE)]
@@ -385,11 +375,7 @@ public sealed class ChurinSMN : SummonerRotation
     [RotationDesc(ActionID.CrimsonCyclonePvE)]
     protected override bool MoveForwardGCD(out IAction? act)
     {
-        if (CrimsonCyclonePvE.CanUse(out act))
-        {
-            return true;
-        }
-        return base.MoveForwardGCD(out act);
+        return CrimsonCyclonePvE.CanUse(out act) || base.MoveForwardGCD(out act);
     }
 
     [RotationDesc(ActionID.PhysickPvE)]
@@ -422,230 +408,151 @@ public sealed class ChurinSMN : SummonerRotation
 
     #region Summon GCD
 
-    private bool PrimalsTime(out IAction? act)
-    {
-        act = null;
+    #region Big Summons
 
-        if (((InBigSummon && !SummonTimeEndAfterGCD()) 
-        || (NoAttunement && (HasGarudaFavor || HasIfritFavor || HasTitanFavor))
-        || (AttunementCount > 0 && !AttunmentTimeEndAfterGCD()) 
-        || NoPrimalReady) && !SkipAttunement)
+    private bool BigSummonTime(out IAction? act)
         {
-            return false;
-        }
-
-        if (UseRuin3 && Ruin3Count < 1)
-        {
-            return RuinIiiPvE.CanUse(out act);
-        }
-
-        if (UseRuin4 && HasFurtherRuin)
-        {
-            return RuinIvPvE.CanUse(out act);
-        }
-
-        return SummonOrder switch
-        {
-            SummonOrderType.TopazRubyEmerald =>
-                TitanTime(out act)
-                || IfritTime(out act)
-                || GarudaTime(out act),
-
-            SummonOrderType.TopazEmeraldRuby =>
-                TitanTime(out act)
-                || GarudaTime(out act)
-                || IfritTime(out act),
-
-            SummonOrderType.EmeraldTopazRuby =>
-                GarudaTime(out act)
-                || TitanTime(out act)
-                || IfritTime(out act),
-
-            SummonOrderType.EmeraldRubyTopaz =>
-                GarudaTime(out act)
-                || IfritTime(out act)
-                || TitanTime(out act),
-
-            SummonOrderType.RubyEmeraldTopaz =>
-                IfritTime(out act)
-                || GarudaTime(out act)
-                || TitanTime(out act),
-
-            SummonOrderType.RubyTopazEmerald =>
-                IfritTime(out act)
-                || TitanTime(out act)
-                || GarudaTime(out act),
-
-            _ => false,
-        };
-    }
-
-    private bool PrimalsFiller(out IAction? act)
-    {
-        act = null;
-
-        if (InBigSummon)
-        {
-            return false;
-        }
-
-        if (SkipAttunement)
-        {
-            return PrimalsTime(out act);
-        }
-        
-        return TitanAttunement(out act)
-        || GarudaAttunement(out act)
-        || IfritAttunement(out act);
-    }
-
-    private bool IfritAttunement(out IAction? act)
-    {
-        act = null;
-            
-        if (InTitan || InGaruda || HasGarudaFavor || HasTitanFavor || (!HasIfritFavor && !HasCrimsonStrike && AttunementCount < 1))
-        {
-            return false;
-        }
-
-        if (EnableFightPresets)
-        {
-            PresetEnabled(FightPresets);
-        }
-
-        if (HasCrimsonStrike)
-        {
-            return CrimsonStrikePvE.CanUse(out act);
-        }
-    
-        return IfritStrategy(IsMoving, out act);
-    }
-    
-    private bool IfritStrategy(bool isMoving, out IAction? act)
-    {
-        act = null;
-        var canUseCrimsonCyclone = AddCrimsonCyclone || CrimsonCyclonePvE.Target.Target.DistanceToPlayer() <= CrimsonCycloneDistance;
-        var cycloneAvailable = canUseCrimsonCyclone && HasIfritFavor;
-        var cycloneMoveAllowed = AddCrimsonCycloneMoving;
-        var cycloneBaseCondition = (UseCycloneFirst && AttunementCount > 1)
-                                    || (UseOneAttunement && AttunementCount == 1)
-                                    || (AttunementCount < 1 && UseBothAttunements && !UseOneAttunement);
-        var cycloneMoveCondition = cycloneAvailable && cycloneMoveAllowed && cycloneBaseCondition;
-    
-        if (isMoving)
-        {
-            if (EnableFightPresets)
+            act = null;
+            if (!SummonBahamutPvE.IsEnabled || !SummonSolarBahamutPvE.IsEnabled || !SummonPhoenixPvE.IsEnabled)
             {
-                if (UseRuin4 && HasFurtherRuin)
-                {
-                    return RuinIvPvE.CanUse(out act);
-                }
-    
-                if (cycloneMoveCondition)
-                {
-                    return CrimsonCyclonePvE.CanUse(out act);
-                }
-            }
-        
-            if (canUseCrimsonCyclone && AddCrimsonCycloneMoving)
-            {
-                return CrimsonCyclonePvE.CanUse(out act);
+                return false;
             }
 
-            if (HasFurtherRuin)
+            if (SummonSolarBahamutPvE.EnoughLevel && IsSolarBahamutReady)
             {
-                return RuinIvPvE.CanUse(out act);
+                return SummonSolarBahamutPvE.CanUse(out act);
             }
-    
-        }
-        else if (!isMoving)
-        {
-            if (EnableFightPresets)
-            {
-                PresetEnabled(FightPresets);
 
-                if (UseRuin3 && Ruin3Count < 1)
+            if (SummonPhoenixPvE.EnoughLevel && IsPhoenixReady)
+            {
+                return SummonPhoenixPvE.CanUse(out act);
+            }
+
+            switch (SummonBahamutPvE.EnoughLevel)
+            {
+                case true when IsBahamutReady:
+                    return SummonBahamutPvE.CanUse(out act);
+
+                case false when DreadwyrmTrancePvE.EnoughLevel:
+                    return DreadwyrmTrancePvE.CanUse(out act);
+            }
+
+            if (!DreadwyrmTrancePvE.EnoughLevel && AetherchargePvE.EnoughLevel)
+            {
+                return AetherchargePvE.CanUse(out act);
+            }
+
+            return false;
+        }
+    private bool SummonFiller(out IAction? act)
+        {
+            act = null;
+            var solarBahamutReadySoon = IsSolarBahamutReady && SummonSolarBahamutPvE.Cooldown.WillHaveOneChargeGCD(1) && SummonSolarBahamutPvE.IsEnabled;
+            var bahamutReadySoon = IsBahamutReady && SummonBahamutPvE.Cooldown.WillHaveOneChargeGCD(1) && SummonBahamutPvE.IsEnabled;
+            var phoenixReadySoon = IsPhoenixReady && SummonPhoenixPvE.Cooldown.WillHaveOneChargeGCD(1) && SummonPhoenixPvE.IsEnabled;
+            var bigSummonReadySoon = solarBahamutReadySoon || bahamutReadySoon || phoenixReadySoon;
+
+            if ((!InBigSummon && AnyPrimalReady && NoAttunement) || HasAnyFavor || HasAnyAttunement)
+            {
+                return false;
+            }
+
+            if (InBigSummon)
+            {
+                if (InPhoenix)
                 {
-                    return RuinIiiPvE.CanUse(out act);
+                    return BrandOfPurgatoryPvE.CanUse(out act)
+                    || FountainOfFirePvE.CanUse(out act);
                 }
-    
-                if (UseRuin4 && HasFurtherRuin)
+
+                if (InBahamut)
                 {
-                    return RuinIvPvE.CanUse(out act);
+                    return AstralFlarePvE.CanUse(out act)
+                    || AstralImpulsePvE.CanUse(out act);
                 }
-    
-                if (HasIfritFavor)
+
+                if (InSolarBahamut)
                 {
-                    if (AttunementCount > 1 && canUseCrimsonCyclone && UseCycloneFirst)
+                    return UmbralFlarePvE.CanUse(out act)
+                    || UmbralImpulsePvE.CanUse(out act);
+                }
+            }
+            else
+            {
+                if (IsMoving)
+                {
+                    if (HasFurtherRuin)
                     {
-                        return CrimsonCyclonePvE.CanUse(out act);
+                        return RuinIvPvE.CanUse(out act);
                     }
-    
-                    if ((UseOneAttunement && AttunementCount == 1 && (UseBothAttunements || !UseBothAttunements))
-                        || (AttunementCount < 1 && UseBothAttunements && !UseOneAttunement))
+
+                    if (Ruin3Count < 1)
                     {
-                        if (canUseCrimsonCyclone)
+                        return OutburstPvE.CanUse(out act)
+                               || RuinIiiPvE.CanUse(out act)
+                               || RuinIiPvE.CanUse(out act)
+                               || RuinPvE.CanUse(out act);
+                    }
+                }
+                else
+                {
+                    if (HasFurtherRuin)
+                    {
+                        if (!bigSummonReadySoon && Ruin3Count < 1)
                         {
-                            return CrimsonCyclonePvE.CanUse(out act);
+                            return OutburstPvE.CanUse(out act)
+                            || RuinIiiPvE.CanUse(out act)
+                            || RuinIiPvE.CanUse(out act)
+                            || RuinPvE.CanUse(out act);
+                        }
+
+                        return RuinIvPvE.CanUse(out act);
+                    }
+
+                    if (!bigSummonReadySoon || Ruin3Count < 1)
+                    {
+                        return OutburstPvE.CanUse(out act)
+                               || RuinIiiPvE.CanUse(out act)
+                               || RuinIiPvE.CanUse(out act)
+                               || RuinPvE.CanUse(out act);
+                    }
+                }
+            }
+            return false;
+        }
+    private int BigSummonGCDLeft
+        {
+            get
+            {
+                if (InBigSummon)
+                {
+                    var maxImpulse = Math.Abs(SummonTimer / (double)RuinPvE.Cooldown.RecastTime);
+                    {
+                        if (maxImpulse > 0)
+                        {
+                            return (int)(maxImpulse + 1);
                         }
                     }
                 }
-    
-                if (UseBothAttunements && AttunementCount > 0)
-                {
-                    return PreciousBrillianceTime(out act) || GemshineTime(out act);
-                }
-    
-                if (UseOneAttunement && AttunementCount == 2)
-                {
-                    return PreciousBrillianceTime(out act) || GemshineTime(out act);
-                }
-    
-                if (UseOneAttunement && UseBothAttunements && !HasIfritFavor && !HasCrimsonStrike && AttunementCount == 1)
-                {
-                    return PreciousBrillianceTime(out act) || GemshineTime(out act);
-                }
-    
-                if (UseOneAttunement && !UseBothAttunements && !HasIfritFavor && !HasCrimsonStrike && AttunementCount == 1)
-                {
-                    return false;
-                }
-            }
-    
-            if (AttunementCount > 0)
-            {
-                return PreciousBrillianceTime(out act) || GemshineTime(out act);
-            }
-    
-            if (HasIfritFavor && canUseCrimsonCyclone)
-            {
-                return CrimsonCyclonePvE.CanUse(out act);
-            }
-
-            if (HasFurtherRuin)
-            {
-                return RuinIvPvE.CanUse(out act);
-            }
-
-            if (Ruin3Count < 1)
-            {
-                return RuinIiiPvE.CanUse(out act);
+                return 0;
             }
         }
-        return false;
-    }
 
-    private bool GarudaAttunement(out IAction? act)
-    {
-        act = null;
-        if (InTitan || InIfrit || HasIfritFavor || HasTitanFavor || (!HasGarudaFavor && AttunementCount < 1))
-        {
-            return false;
-        }
+    #endregion
 
-        if (EnableFightPresets)
+    #region Primals
+
+    private bool PrimalsTime(out IAction? act)
         {
-            PresetEnabled(FightPresets);
+            act = null;
+
+            if (((InBigSummon && !SummonTimeEndAfterGCD())
+            || (NoAttunement && (HasGarudaFavor || HasIfritFavor || HasTitanFavor))
+            || (AttunementCount > 0 && !AttunmentTimeEndAfterGCD())
+            || NoPrimalReady) && !SkipAttunement)
+            {
+                return false;
+            }
 
             if (UseRuin3 && Ruin3Count < 1)
             {
@@ -656,302 +563,379 @@ public sealed class ChurinSMN : SummonerRotation
             {
                 return RuinIvPvE.CanUse(out act);
             }
-        }
-        
-        return GarudaStrategy(IsMoving, out act);
-    }
 
-    private bool GarudaStrategy(bool isMoving, out IAction? act)
-    {
-        act = null;
-        var canSwiftcastSlipstream = AddSwiftcastOnGaruda && (HasSwift || !SwiftcastPvE.Cooldown.IsCoolingDown);
-
-        if (isMoving)
-        {
-            if (HasGarudaFavor)
+            return SummonOrder switch
             {
-                if (canSwiftcastSlipstream)
-                {
-                    return SlipstreamPvE.CanUse(out act, skipCastingCheck: true);
-                }
+                SummonOrderType.TopazRubyEmerald =>
+                    TitanTime(out act)
+                    || IfritTime(out act)
+                    || GarudaTime(out act),
 
-                if (AttunementCount > 0)
-                {
-                    return PreciousBrillianceTime(out act) || GemshineTime(out act);
-                }
+                SummonOrderType.TopazEmeraldRuby =>
+                    TitanTime(out act)
+                    || GarudaTime(out act)
+                    || IfritTime(out act),
 
-                if (HasFurtherRuin)
-                {
-                    return RuinIvPvE.CanUse(out act);
-                }
+                SummonOrderType.EmeraldTopazRuby =>
+                    GarudaTime(out act)
+                    || TitanTime(out act)
+                    || IfritTime(out act),
 
+                SummonOrderType.EmeraldRubyTopaz =>
+                    GarudaTime(out act)
+                    || IfritTime(out act)
+                    || TitanTime(out act),
+
+                SummonOrderType.RubyEmeraldTopaz =>
+                    IfritTime(out act)
+                    || GarudaTime(out act)
+                    || TitanTime(out act),
+
+                SummonOrderType.RubyTopazEmerald =>
+                    IfritTime(out act)
+                    || TitanTime(out act)
+                    || GarudaTime(out act),
+
+                _ => false,
+            };
+        }
+    private bool PrimalsFiller(out IAction? act)
+        {
+            act = null;
+
+            if (InBigSummon)
+            {
+                return false;
             }
 
-            if (AttunementCount > 0)
+            if (SkipAttunement)
             {
-                return PreciousBrillianceTime(out act) || GemshineTime(out act);
+                return PrimalsTime(out act);
+            }
+
+            return TitanAttunement(out act)
+            || GarudaAttunement(out act)
+            || IfritAttunement(out act);
+        }
+    private bool GemshineTime(out IAction? act)
+        {
+            act = null;
+            if (InBigSummon || AttunementCount < 1)
+            {
+                return false;
+            }
+
+            if (InIfrit)
+            {
+                return RubyRitePvE.CanUse(out act)
+                || RubyRuinIiiPvE.CanUse(out act)
+                || RubyRuinIiPvE.CanUse(out act)
+                || RubyRuinPvE.CanUse(out act);
+            }
+
+            if (InGaruda)
+            {
+                return EmeraldRitePvE.CanUse(out act)
+                || EmeraldRuinIiiPvE.CanUse(out act)
+                || EmeraldRuinIiPvE.CanUse(out act)
+                || EmeraldRuinPvE.CanUse(out act);
+            }
+
+            if (InTitan)
+            {
+                return TopazRitePvE.CanUse(out act)
+                || TopazRuinIiiPvE.CanUse(out act)
+                || TopazRuinIiPvE.CanUse(out act)
+                || TopazRuinPvE.CanUse(out act);
             }
 
             return false;
         }
-        else
+    private bool PreciousBrillianceTime(out IAction? act)
         {
-            if (HasGarudaFavor && (canSwiftcastSlipstream || !AddSwiftcastOnGaruda))
+            act = null;
+            if (InBigSummon || AttunementCount < 1)
             {
-                return SlipstreamPvE.CanUse(out act, skipCastingCheck: AddSwiftcastOnGaruda);
+                return false;
             }
-            
-            if (AttunementCount > 0)
+
+            if (InIfrit)
             {
-                return PreciousBrillianceTime(out act) || GemshineTime(out act);
+                return RubyCatastrophePvE.CanUse(out act)
+                || RubyDisasterPvE.CanUse(out act)
+                || RubyOutburstPvE.CanUse(out act);
             }
-        }
-        return false;
-    }
-    
-    private bool TitanAttunement(out IAction? act)
-    {
-        act = null;
-        if (InIfrit || InGaruda || HasGarudaFavor || HasIfritFavor || !HasTitanFavor && AttunementCount < 1)
-        {
+            if (InGaruda)
+            {
+                return EmeraldCatastrophePvE.CanUse(out act)
+                || EmeraldDisasterPvE.CanUse(out act)
+                || EmeraldOutburstPvE.CanUse(out act);
+            }
+            if (InTitan)
+            {
+                return TopazCatastrophePvE.CanUse(out act)
+                || TopazDisasterPvE.CanUse(out act)
+                || TopazOutburstPvE.CanUse(out act);
+            }
             return false;
         }
 
-        return PreciousBrillianceTime(out act)
-        || GemshineTime(out act);
-    }
+    #region Titan
 
     private bool TitanTime(out IAction? act)
-    {
-        act = null;
-        if (!IsTitanReady || HasGarudaFavor || HasIfritFavor)
         {
-            return false;
+            act = null;
+            if (!IsTitanReady || HasGarudaFavor || HasIfritFavor)
+            {
+                return false;
+            }
+            return SummonTitanPvE.CanUse(out act)
+            || SummonTitanIiPvE.CanUse(out act)
+            || SummonTopazPvE.CanUse(out act);
         }
-        return SummonTitanPvE.CanUse(out act) 
-        || SummonTitanIiPvE.CanUse(out act) 
-        || SummonTopazPvE.CanUse(out act);
-    }
+    private bool TitanAttunement(out IAction? act)
+        {
+            act = null;
+            if (InIfrit || InGaruda || HasGarudaFavor || HasIfritFavor || !HasTitanFavor && AttunementCount < 1)
+            {
+                return false;
+            }
+
+            return PreciousBrillianceTime(out act)
+            || GemshineTime(out act);
+        }
+
+    #endregion
+
+    #region Garuda
 
     private bool GarudaTime(out IAction? act)
-    {
-        act = null;
-        if (!IsGarudaReady || HasTitanFavor || HasIfritFavor)
         {
-            return false;
-        }
-        return SummonGarudaPvE.CanUse(out act) 
-        || SummonGarudaIiPvE.CanUse(out act) 
-        || SummonEmeraldPvE.CanUse(out act);
-    }
-
-    private bool IfritTime(out IAction? act)
-    {
-        act = null;
-        if (!IsIfritReady || HasGarudaFavor || HasTitanFavor)
-        {
-            return false;
-        }
-        return SummonIfritPvE.CanUse(out act) 
-        || SummonIfritIiPvE.CanUse(out act) 
-        || SummonRubyPvE.CanUse(out act);
-    }
-
-    private bool GemshineTime(out IAction? act)
-    {
-        act = null;
-        if (InBigSummon || AttunementCount < 1)
-        {
-            return false;
-        }
-
-        if (InIfrit)
-        {
-            return RubyRitePvE.CanUse(out act)
-            || RubyRuinIiiPvE.CanUse(out act)
-            || RubyRuinIiPvE.CanUse(out act)
-            || RubyRuinPvE.CanUse(out act);
-        }
-
-        if (InGaruda)
-        {
-            return EmeraldRitePvE.CanUse(out act)
-            || EmeraldRuinIiiPvE.CanUse(out act)
-            || EmeraldRuinIiPvE.CanUse(out act)
-            || EmeraldRuinPvE.CanUse(out act);
-        }
-
-        if (InTitan)
-        {
-            return TopazRitePvE.CanUse(out act)
-            || TopazRuinIiiPvE.CanUse(out act)
-            || TopazRuinIiPvE.CanUse(out act)
-            || TopazRuinPvE.CanUse(out act);
-        }
-        
-        return false;
-    }
-
-    private bool PreciousBrillianceTime(out IAction? act)
-    {
-        act = null;
-        if (InBigSummon || AttunementCount < 1)
-        {
-            return false;
-        }
-
-        if (InIfrit)
-        {
-            return RubyCatastrophePvE.CanUse(out act)
-            || RubyDisasterPvE.CanUse(out act)
-            || RubyOutburstPvE.CanUse(out act);
-        }
-        if (InGaruda)
-        {
-            return EmeraldCatastrophePvE.CanUse(out act)
-            || EmeraldDisasterPvE.CanUse(out act)
-            || EmeraldOutburstPvE.CanUse(out act);
-        }
-        if (InTitan)
-        {
-            return TopazCatastrophePvE.CanUse(out act)
-            || TopazDisasterPvE.CanUse(out act)
-            || TopazOutburstPvE.CanUse(out act);
-        }
-        return false;
-    }
-
-    private bool BigSummonTime(out IAction? act)
-    {
-        act = null;
-        if (!SummonBahamutPvE.IsEnabled || !SummonSolarBahamutPvE.IsEnabled || !SummonPhoenixPvE.IsEnabled)
-        {
-            return false;
-        }
-
-        if (SummonSolarBahamutPvE.EnoughLevel && IsSolarBahamutReady)
-        {
-            return SummonSolarBahamutPvE.CanUse(out act);
-        }
-
-        if (SummonPhoenixPvE.EnoughLevel && IsPhoenixReady)
-        {
-            return SummonPhoenixPvE.CanUse(out act);
-        }
-
-        if (SummonBahamutPvE.EnoughLevel && IsBahamutReady)
-        {
-            return SummonBahamutPvE.CanUse(out act);
-        }
-
-        if (!SummonBahamutPvE.EnoughLevel && DreadwyrmTrancePvE.EnoughLevel)
-        {
-            return DreadwyrmTrancePvE.CanUse(out act);
-        }
-
-        if (!DreadwyrmTrancePvE.EnoughLevel && AetherchargePvE.EnoughLevel)
-        {
-            return AetherchargePvE.CanUse(out act);
-        }
-
-        return false;
-    }
-
-    private bool SummonFiller(out IAction? act)
-    {
-        act = null;
-        var solarBahamutReadySoon = IsSolarBahamutReady && SummonSolarBahamutPvE.Cooldown.WillHaveOneChargeGCD(1) && SummonSolarBahamutPvE.IsEnabled;
-        var bahamutReadySoon = IsBahamutReady && SummonBahamutPvE.Cooldown.WillHaveOneChargeGCD(1) && SummonBahamutPvE.IsEnabled;
-        var phoenixReadySoon = IsPhoenixReady && SummonPhoenixPvE.Cooldown.WillHaveOneChargeGCD(1) && SummonPhoenixPvE.IsEnabled;
-        var bigSummonReadySoon = solarBahamutReadySoon || bahamutReadySoon || phoenixReadySoon;
-        
-        if ((!InBigSummon && AnyPrimalReady && NoAttunement) || HasAnyFavor || HasAnyAttunement)
-        {
-            return false;
-        }
-
-        if (InBigSummon)
-        {
-            if (InPhoenix)
+            act = null;
+            if (!IsGarudaReady || HasTitanFavor || HasIfritFavor)
             {
-                return BrandOfPurgatoryPvE.CanUse(out act)
-                || FountainOfFirePvE.CanUse(out act);
+                return false;
+            }
+            return SummonGarudaPvE.CanUse(out act)
+            || SummonGarudaIiPvE.CanUse(out act)
+            || SummonEmeraldPvE.CanUse(out act);
+        }
+    private bool GarudaAttunement(out IAction? act)
+        {
+            act = null;
+            if (InTitan || InIfrit || HasIfritFavor || HasTitanFavor || (!HasGarudaFavor && AttunementCount < 1))
+            {
+                return false;
             }
 
-            if (InBahamut)
+            if (EnableFightPresets)
             {
-                return AstralFlarePvE.CanUse(out act)
-                || AstralImpulsePvE.CanUse(out act);
-            }
+                PresetEnabled(FightPresets);
 
-            if (InSolarBahamut)
-            {
-                return UmbralFlarePvE.CanUse(out act)
-                || UmbralImpulsePvE.CanUse(out act);
-            }
-        }
-        else
-        {
-            if (IsMoving)
-            {
-                if (HasFurtherRuin)
+                if (UseRuin3 && Ruin3Count < 1)
+                {
+                    return RuinIiiPvE.CanUse(out act);
+                }
+
+                if (UseRuin4 && HasFurtherRuin)
                 {
                     return RuinIvPvE.CanUse(out act);
                 }
+            }
 
-                if (Ruin3Count < 1)
+            return GarudaStrategy(IsMoving, out act);
+        }
+    private bool GarudaStrategy(bool isMoving, out IAction? act)
+        {
+            act = null;
+            var canSwiftcastSlipstream = AddSwiftcastOnGaruda && (HasSwift || !SwiftcastPvE.Cooldown.IsCoolingDown);
+
+            if (isMoving)
+            {
+                if (HasGarudaFavor)
                 {
-                    return OutburstPvE.CanUse(out act)
-                           || RuinIiiPvE.CanUse(out act)
-                           || RuinIiPvE.CanUse(out act)
-                           || RuinPvE.CanUse(out act);
+                    if (canSwiftcastSlipstream)
+                    {
+                        return SlipstreamPvE.CanUse(out act, skipCastingCheck: true);
+                    }
+
+                    if (AttunementCount > 0)
+                    {
+                        return PreciousBrillianceTime(out act) || GemshineTime(out act);
+                    }
+
+                    if (HasFurtherRuin)
+                    {
+                        return RuinIvPvE.CanUse(out act);
+                    }
+
                 }
             }
             else
             {
-                if (HasFurtherRuin)
+                if (HasGarudaFavor && (canSwiftcastSlipstream || !AddSwiftcastOnGaruda))
                 {
-                    if (!bigSummonReadySoon && Ruin3Count < 1)
-                    {
-                        return OutburstPvE.CanUse(out act)
-                        || RuinIiiPvE.CanUse(out act)
-                        || RuinIiPvE.CanUse(out act)
-                        || RuinPvE.CanUse(out act);
-                    }
-
-                    return RuinIvPvE.CanUse(out act);
-                }
-
-                if (!bigSummonReadySoon || Ruin3Count < 1)
-                {
-                    return OutburstPvE.CanUse(out act)
-                           || RuinIiiPvE.CanUse(out act)
-                           || RuinIiPvE.CanUse(out act)
-                           || RuinPvE.CanUse(out act);
+                    return SlipstreamPvE.CanUse(out act, skipCastingCheck: AddSwiftcastOnGaruda);
                 }
             }
-        }
-        return false;
-    }
-    
-    private int BigSummonGCDLeft
-    {
-        get
-        {
-            if (InBigSummon)
+
+            if (AttunementCount > 0)
             {
-                var maxImpulse = Math.Abs(SummonTimer / (double)RuinPvE.Cooldown.RecastTime);
-                {
-                    if (maxImpulse > 0)
-                    {
-                        return (int)(maxImpulse + 1);
-                    }
-                }
+                return PreciousBrillianceTime(out act) || GemshineTime(out act);
             }
-            return 0;
+
+            return false;
         }
-    }
-    
+
+    #endregion
+
+    #region Ifrit
+
+    private bool IfritTime(out IAction? act)
+        {
+            act = null;
+            if (!IsIfritReady || HasGarudaFavor || HasTitanFavor)
+            {
+                return false;
+            }
+            return SummonIfritPvE.CanUse(out act)
+            || SummonIfritIiPvE.CanUse(out act)
+            || SummonRubyPvE.CanUse(out act);
+        }
+    private bool IfritAttunement(out IAction? act)
+        {
+            act = null;
+
+            if (InTitan || InGaruda || HasGarudaFavor || HasTitanFavor || (!HasIfritFavor && !HasCrimsonStrike && AttunementCount < 1))
+            {
+                return false;
+            }
+
+            if (EnableFightPresets)
+            {
+                PresetEnabled(FightPresets);
+            }
+
+            return HasCrimsonStrike ? CrimsonStrikePvE.CanUse(out act) : IfritStrategy(IsMoving, out act);
+        }
+    private bool IfritStrategy(bool isMoving, out IAction? act)
+       {
+           act = null;
+           var canUseCrimsonCyclone = AddCrimsonCyclone || CrimsonCyclonePvE.Target.Target.DistanceToPlayer() <= CrimsonCycloneDistance;
+           var cycloneAvailable = canUseCrimsonCyclone && HasIfritFavor;
+           var cycloneMoveAllowed = AddCrimsonCycloneMoving;
+           var cycloneBaseCondition = (UseCycloneFirst && AttunementCount > 1)
+                                       || (UseOneAttunement && AttunementCount == 1)
+                                       || (AttunementCount < 1 && UseBothAttunements && !UseOneAttunement);
+           var cycloneMoveCondition = cycloneAvailable && cycloneMoveAllowed && cycloneBaseCondition;
+           var usedOneAttunement = Player.IsCasting && Player.CastActionId == (uint)ActionID.RubyRitePvE && !IsLastGCD(ActionID.RubyRitePvE) && AttunementCount >= 1;
+
+           switch (isMoving)
+           {
+               case true:
+               {
+                   if (EnableFightPresets)
+                   {
+                       if (UseRuin4 && HasFurtherRuin)
+                       {
+                           return RuinIvPvE.CanUse(out act);
+                       }
+
+                       if (cycloneMoveCondition)
+                       {
+                           return CrimsonCyclonePvE.CanUse(out act);
+                       }
+                   }
+
+                   if (canUseCrimsonCyclone && AddCrimsonCycloneMoving)
+                   {
+                       return CrimsonCyclonePvE.CanUse(out act);
+                   }
+
+                   if (HasFurtherRuin)
+                   {
+                       return RuinIvPvE.CanUse(out act);
+                   }
+
+                   break;
+               }
+
+               case false:
+               {
+                   if (EnableFightPresets)
+                   {
+                       PresetEnabled(FightPresets);
+
+                       if (UseRuin3 && Ruin3Count < 1)
+                       {
+                           return RuinIiiPvE.CanUse(out act);
+                       }
+
+                       if (UseRuin4 && HasFurtherRuin)
+                       {
+                           return RuinIvPvE.CanUse(out act);
+                       }
+
+                       if (HasIfritFavor)
+                       {
+                           if (canUseCrimsonCyclone && UseCycloneFirst)
+                           {
+                               return CrimsonCyclonePvE.CanUse(out act);
+                           }
+
+                           if ((UseOneAttunement && usedOneAttunement && (UseBothAttunements || !UseBothAttunements))
+                               || (AttunementCount < 1 && UseBothAttunements && !UseOneAttunement))
+                           {
+                               if (canUseCrimsonCyclone)
+                               {
+                                   return CrimsonCyclonePvE.CanUse(out act);
+                               }
+                           }
+                       }
+
+                       if (UseBothAttunements && AttunementCount > 0
+                           || UseOneAttunement && (AttunementCount == 2 || !UseBothAttunements && AttunementCount is <= 2 and >=1 && !Player.IsCasting)
+                           || UseOneAttunement && UseBothAttunements && !HasIfritFavor && !HasCrimsonStrike && AttunementCount == 1)
+                       {
+                           return PreciousBrillianceTime(out act) || GemshineTime(out act);
+                       }
+
+                       if (UseOneAttunement && !UseBothAttunements && !HasIfritFavor && !HasCrimsonStrike && AttunementCount == 1)
+                       {
+                           return false;
+                       }
+                   }
+
+                   if (AttunementCount > 0)
+                   {
+                       return PreciousBrillianceTime(out act) || GemshineTime(out act);
+                   }
+
+                   if (HasIfritFavor && canUseCrimsonCyclone)
+                   {
+                       return CrimsonCyclonePvE.CanUse(out act);
+                   }
+
+                   if (HasFurtherRuin)
+                   {
+                       return RuinIvPvE.CanUse(out act);
+                   }
+
+                   if (Ruin3Count < 1)
+                   {
+                       return RuinIiiPvE.CanUse(out act);
+                   }
+
+                   break;
+               }
+           }
+           return false;
+       }
+
+    #endregion
+
+    #endregion
+
     #endregion
 
     #region oGCDs
@@ -1184,12 +1168,12 @@ public sealed class ChurinSMN : SummonerRotation
     private bool CrimsonCycloneTargetTooFar => (CrimsonCyclonePvE.Target.Target.DistanceToPlayer() > CrimsonCycloneDistance) && HasIfritFavor;
     
     private bool SkipAttunement { get; set;}
-    
-    public bool UseBothAttunements { get; private set;}
-    
-    public bool UseOneAttunement { get; private set;}
-    
-    public bool UseCycloneFirst { get; private set;}
+
+    private bool UseBothAttunements { get; set;}
+
+    private bool UseOneAttunement { get; set;}
+
+    private bool UseCycloneFirst { get; set;}
     
     private readonly Dictionary<int, SummonOrderType> _m4SOrderMap = [];
     
@@ -1376,8 +1360,9 @@ public sealed class ChurinSMN : SummonerRotation
         var isCastingRubyRite = Player.CastActionId is (uint)ActionID.RubyRitePvE;
         var castAlmostFinished = Player.IsCasting && isCastingRubyRite && WeaponRemain < 1f;
         var attunementUsedUp = (HasIfritFavor && !InIfrit) || IsLastGCD(ActionID.RubyRitePvE) && castAlmostFinished && AttunementCount <= 1;
-        var hasOneAttunementLeft = (castAlmostFinished && AttunementCount <= 2) || AttunementCount == 1;
+        var hasOneAttunementLeft = (castAlmostFinished && AttunementCount <= 2) || (IsLastGCD(ActionID.RubyRitePvE) && AttunementCount == 1);
         var crimsonCycloneTargetInRange = CrimsonCyclonePvE.Target.Target.DistanceToPlayer() <= CrimsonCycloneDistance;
+        var defaultCycloneCondition = (CrimsonCycloneTargetTooFar|| crimsonCycloneTargetInRange) && attunementUsedUp;
 
         UseRuin3 = false;
         UseRuin4 = false;
@@ -1389,20 +1374,20 @@ public sealed class ChurinSMN : SummonerRotation
         {
             case <= 1 or 3:
                 SetRuin3Flag(InGaruda && (!HasGarudaFavor || IsLastGCD(ActionID.SlipstreamPvE)) && Ruin3Count < 1);
-                SetIfritAttunementFlags(true, false, false, CrimsonCycloneTargetTooFar && attunementUsedUp);
+                SetIfritAttunementFlags(true, false, false, defaultCycloneCondition);
                 break;
             case 4:
-                SetIfritAttunementFlags(true, false, false, CrimsonCycloneTargetTooFar && attunementUsedUp);
+                SetIfritAttunementFlags(true, false, false, defaultCycloneCondition);
                 SetRuin3Flag(!IsIfritReady && !InIfrit && IsLastGCD(ActionID.CrimsonStrikePvE) && IsTitanReady && IsGarudaReady && Ruin3Count < 1);
                 SetRuin4Flag(InGaruda && !HasGarudaFavor && HasFurtherRuin);
                 break;
             case 5:
                 SetIfritAttunementFlags(false, true, false, hasOneAttunementLeft && (CrimsonCycloneTargetTooFar || crimsonCycloneTargetInRange));
-                SetSkipAttunementFlag((InIfrit &&  !HasIfritFavor && !HasCrimsonStrike && AttunementCount == 1 && IsGarudaReady) || (InGaruda && !HasGarudaFavor && AttunementCount < 3 && IsTitanReady));
+                SetSkipAttunementFlag((InIfrit &&  !HasIfritFavor && !HasCrimsonStrike && AttunementCount == 1 && IsGarudaReady && IsLastGCD(ActionID.CrimsonStrikePvE)) || (InGaruda && !HasGarudaFavor && AttunementCount < 3 && IsTitanReady));
                 break;
             case 6:
                 SetRuin3Flag(attunementUsedUp && Ruin3Count < 1);
-                SetIfritAttunementFlags(true, false, false, CrimsonCycloneTargetTooFar && attunementUsedUp && Ruin3Count > 0);
+                SetIfritAttunementFlags(true, false, false, defaultCycloneCondition && Ruin3Count == 1);
                 break;   
             case 8:
                 SetRuin3Flag(!InIfrit && !HasCrimsonStrike && !HasIfritFavor && IsLastGCD(ActionID.CrimsonStrikePvE) && !IsIfritReady && IsGarudaReady && IsTitanReady && Ruin3Count < 1);
@@ -1424,7 +1409,7 @@ public sealed class ChurinSMN : SummonerRotation
                 SetRuin4Flag(InGaruda && !HasGarudaFavor && AttunementCount > 2 && HasFurtherRuin);
                 break;
             case 11:
-                SetIfritAttunementFlags(true, false, false, attunementUsedUp && (CrimsonCycloneTargetTooFar || crimsonCycloneTargetInRange) && Ruin3Count > 0);
+                SetIfritAttunementFlags(true, false, false, defaultCycloneCondition && Ruin3Count == 1);
                 SetRuin3Flag(attunementUsedUp && Ruin3Count < 1);
                 SetRuin4Flag(InGaruda && !HasGarudaFavor && AttunementCount > 3 && HasFurtherRuin);
                 break;
@@ -1433,7 +1418,7 @@ public sealed class ChurinSMN : SummonerRotation
                 SetIfritAttunementFlags(true, false, true, CrimsonCycloneTargetTooFar || crimsonCycloneTargetInRange);
                 break;
             default:
-                SetIfritAttunementFlags(true, false, false, CrimsonCycloneTargetTooFar && attunementUsedUp);
+                SetIfritAttunementFlags(true, false, false, defaultCycloneCondition);
                 break;
         }
     }
@@ -1443,7 +1428,7 @@ public sealed class ChurinSMN : SummonerRotation
     #endregion
     
     #endregion
-    
+
     #endregion
 
 }   

--- a/RotationSolver/ExtraRotations/Melee/ChurinMNK.cs
+++ b/RotationSolver/ExtraRotations/Melee/ChurinMNK.cs
@@ -1,0 +1,893 @@
+﻿using System.ComponentModel;
+using RotationSolver.Updaters;
+
+namespace RotationSolver.ExtraRotations.Melee;
+
+[Rotation("Churin MNK", CombatType.PvE, GameVersion = "7.35", Description = "An eye for an eye. A tooth for a tooth. An eye and a tooth for a loaf of bread. Eyes and teeth are the new currency.")]
+[SourceCode(Path = "main/ExtraRotations/Melee/ChurinMNK.cs")]
+public sealed class ChurinMNK : MonkRotation
+{
+    #region Properties
+
+    #region Enums
+    private enum OpenerType : byte
+    {
+        [Description("Double Lunar")] DoubleLunar,
+        [Description("Solar Lunar")] SolarLunar,
+        [Description("Triple Lunar")] TripleLunar
+    }
+
+    private enum OpenerVariation : byte
+    {
+        [Description("Dragon Kick - 5s")] DragonKick5,
+        [Description("Dragon Kick - 7s")] DragonKick7,
+        [Description("Demolish - 7s")] Demolish7
+    }
+
+    private enum Nadi : byte
+{
+    [Description("None")] None,
+    [Description("Lunar")] Lunar,
+    [Description("Solar")] Solar,
+}
+
+    private enum Blitz : byte
+    {
+        [Description("None")] None,
+        [Description("Elixir Burst")] ElixirBurst,         // Grants Lunar
+        [Description("Rising Phoenix")] RisingPhoenix,     // Grants Solar
+        [Description("Phantom Rush")] PhantomRush,         // Consumes Both
+    }
+
+    #endregion
+
+    #region States
+
+    private Nadi NextNadiGoal { get; set; } = Nadi.Lunar;
+    private Blitz NextBlitz { get; set; }
+    private bool PhantomRushed { get; set; }
+    private bool LunarOddWindow => NextNadiGoal == Nadi.Lunar
+                                   && BrotherhoodPvE.Cooldown.RecastTimeElapsedRaw is >30f and < 90f;
+    private bool SolarOddWindow => NextNadiGoal == Nadi.Solar
+                                   && BrotherhoodPvE.Cooldown.RecastTimeElapsedRaw is >30f and < 90f;
+    private static bool HasBlitzReady => !BeastChakrasContains(BeastChakra.None);
+    private static bool IsReadySoon(IBaseAction action, int maxGCD)
+    {
+        var gcdTotal = WeaponTotal;
+        const float Buffer = 0.6f;
+
+        for (var i = 0; i <= maxGCD; i++)
+        {
+            var deadLine = gcdTotal * i + (gcdTotal - Math.Abs(WeaponRemain - Buffer));
+            if (action.Cooldown.WillHaveOneCharge(deadLine)) return true;
+        }
+        return false;
+    }
+    private static int IsReadyIndex(IBaseAction action, int maxGCDs)
+    {
+        var gcdTotal = WeaponTotal;
+        const float Buffer = 0.6f;
+
+        for (var i = 0; i <= maxGCDs; i++)
+        {
+            var deadline = gcdTotal * i + (gcdTotal - Buffer + WeaponRemain);
+            if (action.Cooldown.RecastTimeRemain <= deadline) return i;
+        }
+        return -1;
+    }
+    private bool IsCooldownAligned(int range)
+    {
+        var bhIndex = IsReadyIndex(BrotherhoodPvE, range);
+        var rofIndex = IsReadyIndex(RiddleOfFirePvE, range);
+
+        if (bhIndex == -1 || rofIndex == -1) return false;
+
+        var difference = Math.Abs(rofIndex - bhIndex);
+        return difference <= 0.6f;
+    }
+    private bool CanBurst => MergedStatus.HasFlag(AutoStatus.Burst) && BrotherhoodPvE.IsEnabled;
+    private static bool InBurst => HasBrotherhood && HasRiddleOfFire;
+    private bool MustUseOpo => HasFormlessFist || IsLastGCD(true, FiresReplyPvE, MasterfulBlitzPvE, ElixirBurstPvE,
+        RisingPhoenixPvE, PhantomRushPvE);
+    private static bool IsNextGCDOpo => ActionUpdater.NextGCDAction != null &&
+                                        ActionUpdater.NextGCDAction.IsTheSameTo(true, ActionID.DragonKickPvE,
+                                            ActionID.LeapingOpoPvE, ActionID.BootshinePvE,
+                                            ActionID.ShadowOfTheDestroyerPvE, ActionID.ArmOfTheDestroyerPvE);
+    private bool IsLastGCDMasterfulBlitz => IsLastGCD(true, ElixirBurstPvE, PhantomRushPvE, RisingPhoenixPvE);
+    private bool IsLastGCDOpo => IsLastGCD( true, DragonKickPvE, LeapingOpoPvE, BootshinePvE, ShadowOfTheDestroyerPvE, ArmOfTheDestroyerPvE);
+    private static bool PerfectBalanceStacks(int stacks) => Player.StatusStack(true, StatusID.PerfectBalance) == stacks;
+    private static bool CanLateWeave => WeaponRemain <= LateWeaveWindow;
+    private static bool CanEarlyWeave => WeaponRemain >= LateWeaveWindow;
+    private const float LateWeaveWindow = 1.15f;
+    private static bool EnoughWeaveTime => WeaponRemain > 0.75f;
+    private static bool IsOpenerStart => InCombat && CombatTime < 5.0f;
+    private static bool HasBothNadi => HasLunar && HasSolar;
+    private static bool HasNoNadi => !HasLunar && !HasSolar;
+    private int BlitzCount { get; set; }
+    private bool _canIncrement;
+    private const float BossHealthThreshold = 0.1f;
+
+    #endregion
+
+    #region Updaters
+
+    private void RotationUpdater()
+    {
+        if (!InCombat && HasNoNadi && OpoOpoFury == 0 && RaptorFury == 0 && CoeurlFury == 0)
+        {
+            ResetState();
+            return;
+        }
+
+        if (IsLastGCD(true, PhantomRushPvE))
+        {
+            BlitzCount = 0; // Reset loop
+            PhantomRushed = true;
+        }
+
+        var incrementTrigger = IsLastGCD(true, ElixirBurstPvE, RisingPhoenixPvE);
+
+        if (!_canIncrement && incrementTrigger)
+        {
+                        BlitzCount++;
+        }
+
+        _canIncrement = incrementTrigger;
+
+
+        // Determine the next Blitz based on the Opener or Standard Rotation
+        NextBlitz = GetNextBlitz();
+
+        // Determine the Nadi Goal based on the Blitz we want to execute
+        NextNadiGoal = NextBlitz switch
+        {
+            Blitz.ElixirBurst => Nadi.Lunar,
+            Blitz.RisingPhoenix => Nadi.Solar,
+            Blitz.PhantomRush => Nadi.Lunar,
+            _ => Nadi.None
+        };
+    }
+    private Blitz GetNextBlitz()
+    {
+    // 1. Handle Openers (Fixed Sequences)
+        if (!PhantomRushed)
+        {
+            return (ChosenOpener, BlitzCount) switch
+            {
+                // Solar Lunar: Solar -> Lunar -> Phantom Rush
+                (OpenerType.SolarLunar, 0) => Blitz.RisingPhoenix,
+                (OpenerType.SolarLunar, 1) => Blitz.ElixirBurst,
+                (OpenerType.SolarLunar, 2) => Blitz.PhantomRush,
+
+                // Double Lunar: Lunar -> Lunar -> Solar -> Phantom Rush
+                (OpenerType.DoubleLunar, 0) => Blitz.ElixirBurst,
+                (OpenerType.DoubleLunar, 1) => Blitz.ElixirBurst,
+                (OpenerType.DoubleLunar, 2) => Blitz.RisingPhoenix,
+                (OpenerType.DoubleLunar, 3) => Blitz.PhantomRush,
+
+                // Triple Lunar (Theoretical/Niche): Lunar x3 -> Solar -> PR
+                (OpenerType.TripleLunar, 0) => Blitz.ElixirBurst,
+                (OpenerType.TripleLunar, 1) => Blitz.ElixirBurst,
+                (OpenerType.TripleLunar, 2) => Blitz.ElixirBurst,
+                (OpenerType.TripleLunar, 3) => Blitz.RisingPhoenix,
+                (OpenerType.TripleLunar, 4) => Blitz.PhantomRush,
+
+                // Default fallback if counts go out of bounds before PR
+                _ => Blitz.None
+        };
+    }
+
+        // 2. Handle Standard Loop (Post-Opener)
+        // Logic: Fill missing Nadi -> Phantom Rush -> Repeat
+        return (HasLunar, HasSolar) switch
+        {
+            (true, true) => Blitz.PhantomRush,      // Have both? Rush.
+            (false, false) => Blitz.ElixirBurst,    // Have neither? Default to Lunar (Standard Loop start).
+            (true, false) => Blitz.RisingPhoenix,   // Have Lunar? Get Solar.
+            (false, true) => Blitz.ElixirBurst,     // Have Solar? Get Lunar.
+        };
+    }
+    private void ResetState()
+{
+    BlitzCount = 0;
+    PhantomRushed = false;
+    _canIncrement = false;
+
+    // Pre-combat prep: Set initial Blitz based on opener preference
+    NextBlitz = ChosenOpener switch
+    {
+        OpenerType.SolarLunar => Blitz.RisingPhoenix,
+        _ => Blitz.ElixirBurst // Double and Triple Lunar start with Elixir Burst
+    };
+
+    NextNadiGoal = NextBlitz == Blitz.RisingPhoenix ? Nadi.Solar : Nadi.Lunar;
+}
+    private static string CheckFuryGaugeState()
+    {
+
+        if (OpoOpoFury > 0)
+        {
+            return "Coeurl, Raptor, Opo";
+        }
+
+        if (RaptorFury > 0 || (OpoOpoFury == 0 && CoeurlFury == 0 && RaptorFury == 0))
+        {
+            return "Opo, Coeurl, Raptor";
+        }
+
+        return CoeurlFury > 0 ? "Opo, Raptor, Coeurl" : "Coeurl, Raptor, Opo";
+    }
+    #endregion
+
+    #endregion
+
+    #region Tracking Properties
+    /// <summary>
+    /// Displays the current rotation status in the UI.
+    /// </summary>
+    // csharp
+    public override void DisplayRotationStatus()
+    {
+        // Colors
+        var green = new Vector4(0.22f, 0.85f, 0.32f, 1f);
+        var red = new Vector4(0.95f, 0.28f, 0.28f, 1f);
+        var yellow = new Vector4(0.98f, 0.78f, 0.18f, 1f);
+        var blue = new Vector4(0.33f, 0.66f, 0.95f, 1f);
+        var gray = new Vector4(0.75f, 0.75f, 0.75f, 1f);
+
+        if (!ImGui.BeginTable("Rotation Status", 2, ImGuiTableFlags.BordersInnerV | ImGuiTableFlags.RowBg))
+        {
+            ImGui.EndTable();
+            return;
+        }
+
+        ImGui.TableSetupColumn("Property");
+        ImGui.TableSetupColumn("Value");
+        ImGui.TableHeadersRow();
+
+        // Header / meta
+        ImGui.TableNextRow();
+        ImGui.TableSetColumnIndex(0);
+        ImGui.TextUnformatted("Rotation Snapshot");
+        ImGui.TableSetColumnIndex(1);
+        ImGui.TextDisabled($"Updated: {DateTime.Now:T}");
+
+        ImGui.TableNextRow();
+        ImGui.TableSetColumnIndex(0);
+        ImGui.TextUnformatted("— Performance");
+        ImGui.TableSetColumnIndex(1);
+        ImGui.TextUnformatted(string.Empty);
+
+        AddTableRowColored("Weapon Total", $"{WeaponTotal:F2}s", blue);
+        AddTableRowColored("Animation Lock", $"{AnimationLock:F2}s", gray);
+        AddTableRowColored("Late Weave Window", $"{LateWeaveWindow:F2}s", gray);
+
+        // Weave hints
+        AddTableRowColored("Can Early Weave", CanEarlyWeave ? "Yes" : "No", CanEarlyWeave ? green : red);
+        AddTableRowColored("Enough Weave Time", EnoughWeaveTime ? "Yes" : "No", EnoughWeaveTime ? green : red);
+
+        // Nadi / Blitz
+        ImGui.TableNextRow();
+        ImGui.TableSetColumnIndex(0);
+        ImGui.TextUnformatted("— Nadi & Blitz");
+        ImGui.TableSetColumnIndex(1);
+        ImGui.TextUnformatted(string.Empty);
+
+        var oddWindow = LunarOddWindow ? "Lunar Odd Window" : SolarOddWindow ? "Solar Odd Window" : "Normal Window";
+        var oddWindowColor = LunarOddWindow ? blue : SolarOddWindow ? yellow : red;
+        AddTableRowColored("Odd Window", oddWindow, oddWindowColor);
+
+        var nadiLabel = HasNoNadi ? "No Nadi" : HasBothNadi ? "Both" : HasLunar ? "Lunar" : "Solar";
+        var nadiColor = HasNoNadi ? gray : HasBothNadi ? yellow : HasLunar ? blue : new Vector4(1f, 0.55f, 0.12f, 1f);
+        AddTableRowColored("Nadi State", nadiLabel, nadiColor);
+
+        var blitzReadyLabel = ElixirBurstPvEReady ? "Elixir Burst" : RisingPhoenixPvEReady ? "Rising Phoenix" : PhantomRushPvEReady ? "Phantom Rush" : "None";
+        var blitzReadyColor = ElixirBurstPvEReady || RisingPhoenixPvEReady || PhantomRushPvEReady ? green : gray;
+        AddTableRowColored("Next Blitz", $"{NextBlitz} (Count: {BlitzCount})", blitzReadyColor);
+        AddTableRowColored("Blitz Ready", blitzReadyLabel, blitzReadyColor);
+
+        AddTableRowColored("Next Nadi Goal", $"{NextNadiGoal}", nadiColor);
+        AddTableRowColored("Has Used Phantom Rush?", PhantomRushed ? "Yes ✓" : "No ✗", PhantomRushed ? gray : green);
+
+        // Forms & Fury
+        ImGui.TableNextRow();
+        ImGui.TableSetColumnIndex(0);
+        ImGui.TextUnformatted("— Forms & Fury");
+        ImGui.TableSetColumnIndex(1);
+        ImGui.TextUnformatted(string.Empty);
+
+        var formLabel = InOpoopoForm ? "Opo-Opo" : InRaptorForm ? "Raptor" : InCoeurlForm ? "Coeurl" : "None";
+        AddTableRowColored("Current Form", formLabel, InOpoopoForm || InRaptorForm || InCoeurlForm ? yellow : gray);
+
+        AddTableRowColored("Beast Chakras", $"{BeastChakras[0]}, {BeastChakras[1]}, {BeastChakras[2]}", gray);
+        AddTableRowColored("Fury Gauge State", CheckFuryGaugeState(), gray);
+
+        // GCD / Opo checks
+        ImGui.TableNextRow();
+        ImGui.TableSetColumnIndex(0);
+        ImGui.TextUnformatted("— GCD / Opener Hints");
+        ImGui.TableSetColumnIndex(1);
+        ImGui.TextUnformatted(string.Empty);
+
+        AddTableRowColored("Is Last GCD Opo?", IsLastGCDOpo ? "Yes ✓" : "No ✗", IsLastGCDOpo ? yellow : gray);
+        AddTableRowColored("Is Next GCD Opo", IsNextGCDOpo ? "Yes ✓" : "No ✗", IsNextGCDOpo ? yellow : gray);
+
+        // Small helper badge row for important cooldowns
+        ImGui.TableNextRow();
+        ImGui.TableSetColumnIndex(0);
+        ImGui.TextUnformatted("Key Cooldowns");
+        ImGui.TableSetColumnIndex(1);
+        ImGui.BeginGroup();
+        AddBadge("Brotherhood", BrotherhoodPvE.IsEnabled && BrotherhoodPvE.Cooldown.HasOneCharge, green, gray);
+        ImGui.SameLine();
+        AddBadge("Riddle of Fire", RiddleOfFirePvE.IsEnabled && RiddleOfFirePvE.Cooldown.HasOneCharge, green, gray);
+        ImGui.SameLine();
+        // Ensure we pass both active and inactive colors (fourth param) to match AddBadge signature
+        AddBadge("Perfect Balance", PerfectBalancePvE.IsEnabled && PerfectBalancePvE.Cooldown.HasOneCharge, BrotherhoodPvE.IsEnabled ? yellow : gray, gray);
+        ImGui.EndGroup();
+
+        ImGui.EndTable();
+    }
+
+    // Helper: colored table row
+    private static void AddTableRowColored(string label, string value, Vector4 color)
+    {
+        ImGui.TableNextRow();
+        ImGui.TableSetColumnIndex(0);
+        ImGui.TextUnformatted(label);
+        ImGui.TableSetColumnIndex(1);
+        ImGui.PushStyleColor(ImGuiCol.Text, color);
+        ImGui.TextUnformatted(value);
+        ImGui.PopStyleColor();
+    }
+
+    // Helper: small badge (simple rectangular label)
+    private static void AddBadge(string text, bool active, Vector4 activeColor, Vector4 inactiveColor)
+    {
+        var color = active ? activeColor : inactiveColor;
+        ImGui.PushStyleColor(ImGuiCol.Text, color);
+        ImGui.TextUnformatted(active ? $"[{text} ✓]" : $"[{text} ✗]");
+        ImGui.PopStyleColor();
+    }
+
+    #endregion
+
+    #region Config Options
+
+    [RotationConfig(CombatType.PvE, Name = "Choose Opener.")]
+    private OpenerType ChosenOpener { get; set; } = OpenerType.DoubleLunar;
+
+    [RotationConfig(CombatType.PvE, Name = "Choose Opener Variation")]
+    private OpenerVariation ChosenVariation { get; set; } = OpenerVariation.DragonKick5;
+
+
+    #endregion
+
+    #region Countdown Logic
+    protected override IAction? CountDownAction(float remainTime)
+    {
+        if  (remainTime <= 0.8f && ThunderclapPvE.CanUse(out var act)
+            || remainTime <= 2 && TrueNorthPvE.CanUse(out act)
+            || remainTime <= 5 && Chakra < 5 && TryUseMeditations(out act))
+        {
+            return act;
+        }
+
+        return remainTime < 15 && FormShiftPvE.CanUse(out act) ? act : base.CountDownAction(remainTime);
+    }
+    #endregion
+
+    #region oGCD Logic
+    protected override bool EmergencyAbility(IAction nextGCD, out IAction? act)
+    {
+        return TryUseBuffs(out act)
+               || TryUsePerfectBalance(out act)
+               || base.EmergencyAbility(nextGCD, out act);
+    }
+
+    [RotationDesc(ActionID.ThunderclapPvE)]
+    protected override bool MoveForwardAbility(IAction nextGCD, out IAction? act)
+    {
+        return ThunderclapPvE.CanUse(out act) || base.MoveForwardAbility(nextGCD, out act);
+    }
+
+    [RotationDesc(ActionID.FeintPvE)]
+    protected override bool DefenseAreaAbility(IAction nextGCD, out IAction? act)
+    {
+        act = null;
+        if (!EnoughWeaveTime) return false;
+        return FeintPvE.CanUse(out act) || base.DefenseAreaAbility(nextGCD, out act);
+    }
+
+    [RotationDesc(ActionID.MantraPvE)]
+    protected override bool HealAreaAbility(IAction nextGCD, out IAction? act)
+    {
+        act = null;
+        if (!EnoughWeaveTime) return false;
+        if (EarthsReplyPvE.CanUse(out act))
+        {
+            return true;
+        }
+
+        return MantraPvE.CanUse(out act) || base.HealAreaAbility(nextGCD, out act);
+    }
+
+    [RotationDesc(ActionID.RiddleOfEarthPvE)]
+    protected override bool DefenseSingleAbility(IAction nextGCD, out IAction? act)
+    {
+        act = null;
+        if (!EnoughWeaveTime) return false;
+        return RiddleOfEarthPvE.CanUse(out act, usedUp: true) || base.DefenseSingleAbility(nextGCD, out act);
+    }
+
+    protected override bool AttackAbility(IAction nextGCD, out IAction? act)
+    {
+        act = null;
+        return TryUseRiddleOfWind(out act)
+               || TryUseForbiddenChakra(out act)
+               || base.AttackAbility(nextGCD, out act);
+    }
+    #endregion
+
+    #region GCD Logic
+    protected override bool GeneralGCD(out IAction? act)
+    {
+        RotationUpdater();
+
+        if (MustUseOpo)
+        {
+            return CombatElapsedLessGCD(1) ? TryUseOpenerVariation(out act) : TryUseOpoOpo(out act);
+        }
+
+        if (TryUseWindsReply(out act)) return true;
+        if (TryUseFiresReply(out act)) return true;
+
+        return  TryGenerateNadi(out act)
+            || TryUseMasterfulBlitz(out act)
+            || TryUseFiller(out act)
+            || TryUseMeditations(out act)
+            || base.GeneralGCD(out act);
+    }
+
+    #endregion
+
+    #region  Extra Methods
+
+    #region Form Execution
+    private bool TryUseMeditations(out IAction? act)
+    {
+        act = null;
+        if (InCombat && HasHostilesInRange) return false;
+
+        if ((!HasHostilesInRange || !InCombat) && Chakra < 5)
+        {
+            return EnlightenedMeditationPvE.CanUse(out act)
+                   || ForbiddenMeditationPvE.CanUse(out act)
+                   || InspiritedMeditationPvE.CanUse(out act)
+                   || !ForbiddenMeditationPvE.Info.EnoughLevelAndQuest() && SteeledMeditationPvE.CanUse(out act);
+        }
+
+        return false;
+    }
+    private bool TryUseOpoOpo(out IAction? act)
+    {
+        act = null;
+        if (InOpoopoForm || HasFormlessFist || HasPerfectBalance)
+        {
+            if (ArmOfTheDestroyerPvE.CanUse(out act, skipComboCheck: true))
+            {
+                return true;
+            }
+
+            switch (OpoOpoFury)
+            {
+                case > 0 when LeapingOpoPvE.EnoughLevel:
+                    return LeapingOpoPvE.CanUse(out act, skipComboCheck: true);
+                case > 0:
+                    return BootshinePvE.CanUse(out act, skipComboCheck: true);
+                case 0:
+                    return DragonKickPvE.CanUse(out act, skipComboCheck: true);
+            }
+        }
+        return false;
+    }
+    private bool TryUseRaptor(out IAction? act)
+    {
+        act = null;
+        if (InRaptorForm || HasFormlessFist ||HasPerfectBalance)
+        {
+            if (FourpointFuryPvE.CanUse(out act, skipComboCheck: true))
+            {
+                return true;
+            }
+
+            switch (RaptorFury)
+            {
+                case > 0 when RisingRaptorPvE.EnoughLevel:
+                    return RisingRaptorPvE.CanUse(out act, skipComboCheck: true);
+                case > 0:
+                    return TrueStrikePvE.CanUse(out act, skipComboCheck: true);
+                case 0:
+                    return TwinSnakesPvE.CanUse(out act, skipComboCheck: true);
+
+            }
+        }
+        return false;
+    }
+    private bool TryUseCoeurl(out IAction? act)
+    {
+        act = null;
+        if (InCoeurlForm || HasFormlessFist ||HasPerfectBalance)
+        {
+            if (RockbreakerPvE.CanUse(out act, skipComboCheck: true))
+            {
+                return true;
+            }
+
+            switch (CoeurlFury)
+            {
+                case > 0 when PouncingCoeurlPvE.EnoughLevel:
+                    return PouncingCoeurlPvE.CanUse(out act, skipComboCheck: true);
+                case > 0:
+                    return SnapPunchPvE.CanUse(out act, skipComboCheck: true);
+                case 0:
+                    return DemolishPvE.CanUse(out act, skipComboCheck: true);
+            }
+
+        }
+
+        return false;
+    }
+    private bool TryUseFiller(out IAction? act)
+    {
+
+        return TryUseOpoOpo(out act)
+               || TryUseRaptor(out act)
+               || TryUseCoeurl(out act)
+               || TryUseFormShift(out act);
+
+    }
+    private bool TryUseOpenerVariation(out IAction? act)
+    {
+        act = null;
+        if (!CombatElapsedLessGCD(1)) return false;
+
+        return ChosenVariation switch
+        {
+            OpenerVariation.Demolish7 => TryUseCoeurl(out act),
+            OpenerVariation.DragonKick5 => TryUseOpoOpo(out act),
+            OpenerVariation.DragonKick7 => TryUseOpoOpo(out act),
+            _ => false
+        };
+    }
+
+    #endregion
+
+    #region Perfect Balance / Nadi Generation
+
+    private bool TryGenerateNadi(out IAction? act)
+    {
+        act = null;
+                if (!HasPerfectBalance || !BeastChakrasContains(BeastChakra.None)) return false;
+
+        return NextNadiGoal switch
+        {
+            Nadi.None => false,
+            Nadi.Lunar when BeastChakrasContains(BeastChakra.None) => TryGenerateLunarNadi(out act),
+            Nadi.Solar when BeastChakrasContains(BeastChakra.None) => TryGenerateSolarNadi(out act),
+            _ => false
+        };
+    }
+
+    private bool TryGenerateLunarNadi(out IAction? act)
+    {
+        act = null;
+        if (!BeastChakrasContains(BeastChakra.None) || NextNadiGoal != Nadi.Lunar) return false;
+
+        return TryUseOpoOpo(out act);
+    }
+
+    private bool TryGenerateSolarNadi(out IAction? act)
+    {
+        act = null;
+        if (!BeastChakrasContains(BeastChakra.None) || NextNadiGoal != Nadi.Solar) return false;
+
+        var furyState = CheckFuryGaugeState();
+
+        return furyState switch
+        {
+            "Coeurl, Raptor, Opo" => !BeastChakrasContains(BeastChakra.Coeurl) && TryUseCoeurl(out act)
+                                || !BeastChakrasContains(BeastChakra.Raptor) && TryUseRaptor(out act)
+                                || !BeastChakrasContains(BeastChakra.OpoOpo) && TryUseOpoOpo(out act),
+
+            "Opo, Coeurl, Raptor" => !BeastChakrasContains(BeastChakra.OpoOpo) && TryUseOpoOpo(out act)
+                                || !BeastChakrasContains(BeastChakra.Coeurl) && TryUseCoeurl(out act)
+                                || !BeastChakrasContains(BeastChakra.Raptor) && TryUseRaptor(out act),
+
+            "Opo, Raptor, Coeurl" => !BeastChakrasContains(BeastChakra.OpoOpo) && TryUseOpoOpo(out act)
+                                || !BeastChakrasContains(BeastChakra.Raptor) && TryUseRaptor(out act)
+                                || !BeastChakrasContains(BeastChakra.Coeurl) && TryUseCoeurl(out act),
+
+            _ => false,
+        };
+    }
+
+    #endregion
+
+    #region Masterful Blitz Execution
+
+    private bool TryUseMasterfulBlitz(out IAction? act)
+    {
+        act = null;
+        if (BeastChakrasContains(BeastChakra.None)) return false;
+
+        if (HasBothNadi && PhantomRushPvEReady)
+        {
+            return PhantomRushPvE.CanUse(out act);
+        }
+
+        if (BeastChakrasAllSame() && ElixirBurstPvEReady)
+        {
+            return ElixirBurstPvE.CanUse(out act);
+        }
+
+        if (BeastChakrasAllDifferent() && RisingPhoenixPvEReady)
+        {
+            return RisingPhoenixPvE.CanUse(out act);
+        }
+
+        return false;
+    }
+
+    #endregion
+
+    #region  Other GCDs
+
+    private bool TryUseFiresReply(out IAction? act)
+    {
+        act = null;
+        if (!HasRiddleOfFire && !HasFiresRumination || HasPerfectBalance) return false;
+
+        if (IsBurst && !HasBlitzReady)
+        {
+            if (FiresReplyPvE.CanUse(out act))
+            {
+                if (IsLastGCD(true, WindsReplyPvE))
+                {
+                    return true;
+                }
+
+                if (IsLastGCDOpo)
+                {
+                    return true;
+                }
+            }
+        }
+
+        if (!IsBurst && !HasBlitzReady)
+        {
+            if (FiresReplyPvE.CanUse(out act))
+            {
+                if (LunarOddWindow && ((PhantomRushed && BlitzCount == 2) || !PhantomRushed && BlitzCount == 3))
+                {
+                    return IsLastGCDOpo;
+                }
+
+                if (SolarOddWindow && IsLastGCDOpo && !HasBlitzReady)
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+    private bool TryUseWindsReply(out IAction? act)
+    {
+        act = null;
+        if (!HasWindsRumination || HasPerfectBalance) return false;
+
+        if (WindsReplyPvE.CanUse(out act))
+        {
+            if (IsBurst && !HasBlitzReady && IsLastGCDOpo)
+            {
+                return true;
+            }
+
+            if (!IsBurst && HasRiddleOfFire && IsLastGCDOpo)
+            {
+                return true;
+            }
+
+            if (!IsBurst && !HasRiddleOfFire && IsLastGCDOpo)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+    private bool TryUseSixSidedStar(out IAction? act)
+    {
+        act = null;
+        if (!IsInHighEndDuty || (CurrentTarget != null && CurrentTarget.GetHealthRatio() > BossHealthThreshold)) return false;
+
+        if (CurrentTarget != null && (CurrentTarget.IsBossFromIcon() || CurrentTarget.IsBossFromTTK()))
+        {
+            if (CurrentTarget.GetHealthRatio() <= BossHealthThreshold && (!HasPerfectBalance && !HasFormlessFist))
+            {
+                return SixsidedStarPvE.CanUse(out act);
+            }
+        }
+
+        return false;
+    }
+    private bool TryUseFormShift(out IAction? act)
+    {
+        act = null;
+        if (HasFormlessFist || InOpoopoForm || InCoeurlForm || InRaptorForm ||
+            HasPerfectBalance || InCombat && HasHostilesInRange) return false;
+
+        return FormShiftPvE.CanUse(out act);
+    }
+
+    #endregion
+
+    #region oGCD Methods
+
+    private bool TryUseBuffs(out IAction? act)
+    {
+        act = null;
+            return TryUseBrotherhood(out act)
+                   || TryUseRiddleOfFire(out act);
+    }
+    private bool TryUsePerfectBalance(out IAction? act)
+    {
+        act = null;
+        if (HasPerfectBalance) return false;
+
+        if (CombatElapsedLessGCD(1))
+        {
+            if (BrotherhoodPvE.Cooldown.HasOneCharge &&
+                RiddleOfFirePvE.Cooldown.HasOneCharge)
+            {
+                return PerfectBalancePvE.CanUse(out act, usedUp: false);
+            }
+        }
+
+        if (InBurst && !HasFiresRumination)
+        {
+            return IsLastGCDOpo && PerfectBalancePvE.CanUse(out act, usedUp: true);
+        }
+
+        if (SolarOddWindow && IsLastGCDOpo && IsReadySoon(RiddleOfFirePvE, 2))
+        {
+            return PerfectBalancePvE.CanUse(out act, usedUp: true);
+        }
+
+        if (LunarOddWindow && (HasRiddleOfFire || IsReadySoon(RiddleOfFirePvE, 0)) && !HasBothNadi)
+        {
+            return  IsLastGCDOpo && PerfectBalancePvE.Cooldown.WillHaveOneCharge(10) && PerfectBalancePvE.CanUse(out act, usedUp: true);
+        }
+
+        if (IsReadySoon(BrotherhoodPvE, 2) && IsReadySoon(RiddleOfFirePvE,2))
+        {
+                return IsLastGCDOpo && PerfectBalancePvE.CanUse(out act, usedUp: true);
+        }
+
+
+        return false;
+    }
+    private bool TryUseBrotherhood(out IAction? act)
+    {
+        act = null;
+        if (!CanBurst || !CanEarlyWeave || !RiddleOfFirePvE.Cooldown.WillHaveOneCharge(0.5f)) return false;
+
+        var timeRequirement = ChosenVariation switch
+        {
+            OpenerVariation.DragonKick5 => PerfectBalanceStacks(1) && CombatElapsedLessGCD(10),
+            OpenerVariation.DragonKick7 => HasBlitzReady && CombatElapsedLessGCD(10),
+            OpenerVariation.Demolish7 => HasBlitzReady && CombatElapsedLessGCD(10),
+            _ => PerfectBalanceStacks(1) && CombatElapsedLessGCD(10)
+        };
+
+        if (timeRequirement) return BrotherhoodPvE.CanUse(out act);
+
+        if (!CombatElapsedLessGCD(10))
+        {
+            if (IsCooldownAligned(3))
+            {
+                return BrotherhoodPvE.CanUse(out act);
+            }
+        }
+        return false;
+    }
+    private bool TryUseRiddleOfFire(out IAction? act)
+    {
+        act = null;
+        if (!RiddleOfFirePvE.IsEnabled || CanEarlyWeave || !CanLateWeave) return false;
+
+        if (RiddleOfFirePvE.CanUse(out act))
+        {
+            if (IsLastAbility(ActionID.BrotherhoodPvE) || HasBrotherhood)
+            {
+                return true;
+            }
+
+
+
+            if (LunarOddWindow)
+            {
+                if (IsLastAbility(ActionID.PerfectBalancePvE) && IsLastGCDOpo || !IsLastGCDOpo)
+                {
+                    return true;
+                }
+            }
+
+            if (SolarOddWindow)
+            {
+                if (IsLastGCDOpo || IsLastAbility(ActionID.PerfectBalancePvE) || IsLastGCDMasterfulBlitz ||
+                    HasBlitzReady)
+                {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+    private bool TryUseRiddleOfWind(out IAction? act)
+    {
+        act = null;
+        if (!RiddleOfWindPvE.IsEnabled || !EnoughWeaveTime || !RiddleOfWindPvE.Cooldown.WillHaveOneCharge(WeaponRemain) && WeaponRemain <= 1.2f ) return false;
+
+        if (RiddleOfWindPvE.CanUse(out act))
+        {
+            if (InBurst)
+            {
+                if (IsLastGCDOpo || IsLastGCDMasterfulBlitz)
+                {
+                    return true;
+                }
+            }
+
+            if (HasRiddleOfFire)
+            {
+                if (IsLastGCDOpo || IsLastGCDMasterfulBlitz)
+                {
+                    return true;
+                }
+            }
+
+            if (IsLastGCDOpo && BrotherhoodPvE.Cooldown.IsCoolingDown && RiddleOfFirePvE.Cooldown.IsCoolingDown)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+    private bool TryUseForbiddenChakra(out IAction? act)
+    {
+        act = null;
+
+                if (Chakra < 5 || !EnoughWeaveTime || ((IsReadySoon(BrotherhoodPvE, 1) || IsReadySoon(RiddleOfFirePvE, 1)) && !IsOpenerStart)) return false;
+
+        // AoE Check
+        if (EnlightenmentPvE.CanUse(out act)) return true;
+
+        if (IsOpenerStart && BlitzCount == 0)
+        {
+            if (ChosenVariation == OpenerVariation.Demolish7 && !InBurst) return false;
+            return Chakra >= 5 && TheForbiddenChakraPvE.CanUse(out act);
+        }
+
+        if (Chakra >= 5 && TheForbiddenChakraPvE.CanUse(out act)) return true;
+
+        // Low level fallback
+        return !TheForbiddenChakraPvE.EnoughLevel && Chakra >= 5 && SteelPeakPvE.CanUse(out act);
+    }
+
+    #endregion
+
+    #endregion
+}


### PR DESCRIPTION
Introduces a new Monk rotation implementation ChurinMNK at RotationSolver/ExtraRotations/Melee/ChurinMNK.cs. Implements opener sequences and post-opener looping for Nadi/Blitz management, plus a compact ImGui rotation status panel.
What this PR adds:
New rotation class ChurinMNK with full opener support:
OpenerType (DoubleLunar, SolarLunar, TripleLunar)
OpenerVariation (DragonKick5/7, Demolish7)
Blitz enum and tracking (ElixirBurst, RisingPhoenix, PhantomRush)
Opener sequencing and BlitzCount progression
State machine and decision logic:
RotationUpdater, GetNextBlitz, ResetState
NextNadiGoal mapping from chosen Blitz
Phantom Rush handling and loop reset on use
Nadi generation and Masterful Blitz execution:
TryGenerateNadi, TryGenerateLunarNadi, TryGenerateSolarNadi
TryUseMasterfulBlitz to select appropriate Blitz action based on chakras
GCD / oGCD and weaving helpers:
Readiness checks (IsReadySoon, IsReadyIndex, IsCooldownAligned)
Weave timing utilities and opener detection
Integration with Perfect Balance / Brotherhood / Riddle-of-Fire decision logic
oGCD and other behavior:
TryUsePerfectBalance, TryUseBrotherhood, TryUseRiddleOfFire, TryUseForbiddenChakra, etc.
Pre-combat reset and meditation logic
UI: DisplayRotationStatus() ImGui table showing weapon timing, nadi/blitz state, forms/fury, and badges for key cooldowns
Config options exposed:
ChosenOpener and ChosenVariation