### PR TITLE
Fix typo: mechancis → mechanics

### DIFF
--- a/RotationSolver/Data/UiString.cs
+++ b/RotationSolver/Data/UiString.cs
@@ -55,7 +55,7 @@ namespace RotationSolver.Data
         [Description("This includes almost all information available in one combat frame, including the status of all party members, hostile target statuses, skill cooldowns, MP and HP of characters, character locations, hostile target casting status, combo state, combat duration, player level, etc.\n\nIt will then highlight the best action on the hotbar, or help you click it.")]
         ConfigWindow_About_Description,
 
-        [Description("This is designed for GENERAL COMBAT, not for Savage or Ultimate content. \n\nUse it carefully! While not designed specifically for Savage or Ultimate content RSR works fine in them, but it will not solve mechancis for you. Pay attention and use macros.")]
+        [Description("This is designed for GENERAL COMBAT, not for Savage or Ultimate content. \n\nUse it carefully! While not designed specifically for Savage or Ultimate content RSR works fine in them, but it will not solve mechanics for you. Pay attention and use macros.")]
         ConfigWindow_About_Warning,
 
         [Description("RSR has helped you by clicking actions {0:N0} times.")]


### PR DESCRIPTION
Small error in the warning on the main page. "Mechancis" to "Mechanics" See screenshot below. PR fixes the typo :) 

<img width="605" height="150" alt="Screenshot 2025-12-25 122343" src="https://github.com/user-attachments/assets/9fd0b0b3-b3ed-4041-aae2-aee10369b00d" />

