### PR TITLE
Improve VFX detection, updates to RDM, NIN, MCH, and GNB

### DIFF
--- a/RotationSolver.Basic/Configuration/Configs.cs
+++ b/RotationSolver.Basic/Configuration/Configs.cs
@@ -410,7 +410,7 @@ internal partial class Configs : IPluginConfiguration
     [ConditionBool, UI("Show Cooldown Window", Filter = UiWindows)]
     private static readonly bool _showCooldownWindow = false;
 
-    [ConditionBool, UI("Show Action Timeline Window (currently bugged)", Filter = UiWindows)]
+    [ConditionBool, UI("Show Action Timeline Window", Filter = UiWindows)]
     private static readonly bool _showActionTimelineWindow = false;
 
     [ConditionBool, UI("Only show timeline in combat", Parent = nameof(ShowActionTimelineWindow))]

--- a/RotationSolver.Basic/RotationSolver.Basic.csproj
+++ b/RotationSolver.Basic/RotationSolver.Basic.csproj
@@ -83,7 +83,7 @@
 
         <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.0.0" />
 
-        <PackageReference Include="System.Drawing.Common" Version="10.0.1" />
+        <PackageReference Include="System.Drawing.Common" Version="10.0.2" />
         <ProjectReference Include="..\RotationSolver.SourceGenerators\RotationSolver.SourceGenerators.csproj" OutputItemType="Analyzer" ExcludeAssets="All" />
 
         <None Include="..\COPYING.LESSER">

--- a/RotationSolver.Basic/packages.lock.json
+++ b/RotationSolver.Basic/packages.lock.json
@@ -30,11 +30,11 @@
       },
       "System.Drawing.Common": {
         "type": "Direct",
-        "requested": "[10.0.1, )",
-        "resolved": "10.0.1",
-        "contentHash": "cmkIduwyVPfuO8kNehu3xNcjo26nMgUoJyfso9S/zTO85YovvPPG0/AFLjanx1iVgQ80OpJVnLb1jU3aIKNLdg==",
+        "requested": "[10.0.2, )",
+        "resolved": "10.0.2",
+        "contentHash": "nCq8jeGD4vWaUjX3nGaDMKYqfFPposw2f4KCFnuY5Rt3NhK6zMZ/c0a52a3TZK/nnkCJfyQMwb+POKwAnZexZw==",
         "dependencies": {
-          "Microsoft.Win32.SystemEvents": "10.0.1"
+          "Microsoft.Win32.SystemEvents": "10.0.2"
         }
       },
       "ExCSS": {
@@ -57,8 +57,8 @@
       },
       "Microsoft.Win32.SystemEvents": {
         "type": "Transitive",
-        "resolved": "10.0.1",
-        "contentHash": "trU4LN2C04nj5qnl8HqoX0NJGPCFg9h2f5o+jjp3Xm8c8fQtu6Ga1/fNFMf3AapoHyLP1WlP21XnL2ij/TLKlg=="
+        "resolved": "10.0.2",
+        "contentHash": "1G4BdeFwc8E95MpwtR7pO4rEh2YCG/o5gqcOszdQRGrWX1ayHTZtho3xPuYZTbBxKb/3kQHjL3b4nQeNGvbM9g=="
       },
       "rotationsolver.sourcegenerators": {
         "type": "Project",

--- a/RotationSolver/RebornRotations/Magical/RDM_Reborn.cs
+++ b/RotationSolver/RebornRotations/Magical/RDM_Reborn.cs
@@ -295,39 +295,38 @@ public sealed class RDM_Reborn : RedMageRotation
 
     protected override bool GeneralGCD(out IAction? act)
     {
-        if (ManaStacks == 3)
-        {
-            // Prefer Verholy if BlackMana > WhiteMana and can't use VerStone
-            if (BlackMana > WhiteMana && !CanVerStone && VerholyPvE.CanUse(out act))
-                return true;
+		if (ManaStacks == 3)
+		{
+			int diff = BlackMana - WhiteMana;
+			int gap = Math.Abs(diff);
 
-            // Prefer Verflare if WhiteMana > BlackMana and can't use VerFire
-            if (WhiteMana > BlackMana && !CanVerFire && VerflarePvE.CanUse(out act))
-                return true;
+			bool forceBalance = HasEmbolden || gap >= 19;
 
-            // Fallbacks: try Verflare, then Verholy
-            if (!CanVerFire && VerflarePvE.CanUse(out act))
-                return true;
+			if (forceBalance)
+			{
+				// Balance first
+				if (diff > 0 && VerholyPvE.CanUse(out act)) return true;  // Black leads -> add White
+				if (diff < 0 && VerflarePvE.CanUse(out act)) return true; // White leads -> add Black
+			}
+			else
+			{
+				// Slight imbalance: proc-aware preference to avoid overwriting existing procs
+				if (CanVerFire && VerholyPvE.CanUse(out act)) return true;
+				if (CanVerStone && VerflarePvE.CanUse(out act)) return true;
+			}
 
-            if (!CanVerStone && VerholyPvE.CanUse(out act))
-                return true;
+			// Fallbacks
+			if (diff > 0 && VerholyPvE.CanUse(out act)) return true;
+			if (diff < 0 && VerflarePvE.CanUse(out act)) return true;
 
-            // Prefer Verholy if BlackMana > WhiteMana
-            if (BlackMana > WhiteMana && VerholyPvE.CanUse(out act))
-                return true;
+			if (CanVerFire && !CanVerStone && VerholyPvE.CanUse(out act)) return true;
+			if (CanVerStone && !CanVerFire && VerflarePvE.CanUse(out act)) return true;
 
-            // Prefer Verflare if WhiteMana > BlackMana
-            if (WhiteMana > BlackMana && VerflarePvE.CanUse(out act))
-                return true;
+			if (VerholyPvE.CanUse(out act)) return true;
+			if (VerflarePvE.CanUse(out act)) return true;
+		}
 
-            if (VerflarePvE.CanUse(out act))
-                return true;
-
-            if (VerholyPvE.CanUse(out act))
-                return true;
-        }
-
-        if (CanInstantCast && !CanVerEither)
+		if (CanInstantCast && !CanVerEither)
         {
             if (ScatterPvE.CanUse(out act))
             {
@@ -398,7 +397,7 @@ public sealed class RDM_Reborn : RedMageRotation
 		//Check if you can start melee combo
 		if (EnoughMana)
 		{
-			if (!IsLastGCD(true, EnchantedRipostePvE_45960) && ((HasEmbolden && CanMagickedSwordplay) || StatusHelper.PlayerWillStatusEndGCD(4, 0, true, StatusID.MagickedSwordplay)) && EnchantedRipostePvE_45960.CanUse(out act))
+			if (EnchantedRipostePvE.Config.IsEnabled && !IsLastGCD(true, EnchantedRipostePvE_45960) && ((HasEmbolden && CanMagickedSwordplay) || StatusHelper.PlayerWillStatusEndGCD(4, 0, true, StatusID.MagickedSwordplay)) && EnchantedRipostePvE_45960.CanUse(out act))
 			{
 				return true;
 			}

--- a/RotationSolver/RebornRotations/Melee/NIN_Reborn.cs
+++ b/RotationSolver/RebornRotations/Melee/NIN_Reborn.cs
@@ -17,17 +17,17 @@ public sealed class NIN_Reborn : NinjaRotation
     [RotationConfig(CombatType.PvE, Name = "Use Mudras outside of combat when enemies are near")]
     public bool CombatMudra { get; set; } = true;
 
-    [RotationConfig(CombatType.PvE, Name = "Use both stacks of Mudras")]
+	[RotationConfig(CombatType.PvE, Name = "Use both stacks of Mudras")]
     public bool BurnMudraStacks { get; set; } = false;
 
     [RotationConfig(CombatType.PvE, Name = "Use Forked Raiju instead of Fleeting Raiju if you are outside of range (Dangerous)")]
     public bool ForkedUse { get; set; } = false;
-    #endregion
+	#endregion
 
-    #region Tracking Properties
-    // Properties to track RabbitMediumPvE failures and related information.
-    //private int _rabbitMediumFailures = GetActionUsageCount((uint)ActionID.RabbitMediumPvE);
-    private IBaseAction? _lastNinActionAim = null;
+	#region Tracking Properties
+	// Properties to track RabbitMediumPvE failures and related information.
+	//private int _rabbitMediumFailures = GetActionUsageCount((uint)ActionID.RabbitMediumPvE);
+	private IBaseAction? _lastNinActionAim = null;
     // Holds the next ninjutsu action to perform.
     private IBaseAction? _ninActionAim = null;
     private readonly ActionID NinjutsuPvEid = AdjustId(ActionID.NinjutsuPvE);
@@ -123,7 +123,7 @@ public sealed class NIN_Reborn : NinjaRotation
         }
 
         // Side-effect: decide/refresh ninjutsu aim; do not consume the oGCD slot here.
-        if (InCombat || (CombatMudra && HasHostilesInMaxRange && TenPvE.Cooldown.CurrentCharges == TenPvE.Cooldown.MaxCharges))
+        if ((InCombat && HasHostilesInMaxRange) || (CombatMudra && HasHostilesInMaxRange && TenPvE.Cooldown.CurrentCharges == TenPvE.Cooldown.MaxCharges))
         {
             _ = ChoiceNinjutsu(out _);
         }

--- a/RotationSolver/RebornRotations/Ranged/MCH_Reborn.cs
+++ b/RotationSolver/RebornRotations/Ranged/MCH_Reborn.cs
@@ -30,12 +30,17 @@ public sealed class MCH_Reborn : MachinistRotation
 			return act;
 		}
 
-		if (remainTime < 4.8f && ReassemblePvE.CanUse(out act))
+		if (remainTime < 4.75f && ReassemblePvE.CanUse(out act))
         {
             return act;
         }
 
-		if (IsBurst && OpenerBurstMeds && remainTime <= 1f && UseBurstMedicine(out act))
+		if (AirAnchorCountdown && IsBurst && OpenerBurstMeds && remainTime <= 1.5f && UseBurstMedicine(out act))
+		{
+			return act;
+		}
+
+		if (!AirAnchorCountdown && IsBurst && OpenerBurstMeds && remainTime <= 1f && UseBurstMedicine(out act))
         {
             return act;
         }

--- a/RotationSolver/RebornRotations/Tank/GNB_Reborn.cs
+++ b/RotationSolver/RebornRotations/Tank/GNB_Reborn.cs
@@ -29,8 +29,12 @@ public sealed class GNB_Reborn : GunbreakerRotation
     #region oGCD Logic
     protected override bool EmergencyAbility(IAction nextGCD, out IAction? act)
     {
-       
-        if (AbdomenTearPvE.CanUse(out act))
+		if (JugularRipPvE.CanUse(out act))
+		{
+			return true;
+		}
+
+		if (AbdomenTearPvE.CanUse(out act))
         {
             return true;
         }
@@ -40,12 +44,12 @@ public sealed class GNB_Reborn : GunbreakerRotation
             return true;
         }
 
-        if (FatedBrandPvE.CanUse(out act))
-        {
-            return true;
-        }
+		if (HypervelocityPvE.CanUse(out act))
+		{
+			return true;
+		}
 
-        if (HypervelocityPvE.CanUse(out act))
+		if (FatedBrandPvE.CanUse(out act))
         {
             return true;
         }
@@ -198,11 +202,6 @@ public sealed class GNB_Reborn : GunbreakerRotation
 		if (nextGCD.IsTheSameTo(false, (ActionID)GnashingFangPvE.ID) && !NoMercyPvE.Cooldown.IsCoolingDown)
         {
             return base.AttackAbility(nextGCD, out act);
-        }
-
-        if (JugularRipPvE.CanUse(out act))
-        {
-            return true;
         }
 
         if (DangerZonePvE.CanUse(out act) && !DoubleDownPvE.EnoughLevel)

--- a/RotationSolver/UI/RotationConfigWindow.cs
+++ b/RotationSolver/UI/RotationConfigWindow.cs
@@ -417,7 +417,8 @@ public partial class RotationConfigWindow : Window
             _ = diagInfo.AppendLine($"Update Frequency: {Service.Config.MinUpdatingTime}");
             _ = diagInfo.AppendLine($"Intercept: {Service.Config.InterceptAction2}");
             _ = diagInfo.AppendLine($"Player Level: {DataCenter.PlayerSyncedLevel()}");
-            _ = diagInfo.AppendLine($"Player Job: {Player.Job}");
+			_ = diagInfo.AppendLine($"Rotation Name: {_curRotationAttribute?.Name ?? string.Empty}");
+			_ = diagInfo.AppendLine($"Player Job: {Player.Job}");
             _ = diagInfo.AppendLine($"AutoFaceTargetOnActionSetting: {DataCenter.AutoFaceTargetOnActionSetting()}");
             var moveModeValue = DataCenter.MoveModeSetting();
             string moveModeText = moveModeValue switch

--- a/RotationSolver/packages.lock.json
+++ b/RotationSolver/packages.lock.json
@@ -50,8 +50,8 @@
       },
       "Microsoft.Win32.SystemEvents": {
         "type": "Transitive",
-        "resolved": "10.0.1",
-        "contentHash": "trU4LN2C04nj5qnl8HqoX0NJGPCFg9h2f5o+jjp3Xm8c8fQtu6Ga1/fNFMf3AapoHyLP1WlP21XnL2ij/TLKlg=="
+        "resolved": "10.0.2",
+        "contentHash": "1G4BdeFwc8E95MpwtR7pO4rEh2YCG/o5gqcOszdQRGrWX1ayHTZtho3xPuYZTbBxKb/3kQHjL3b4nQeNGvbM9g=="
       },
       "Svg": {
         "type": "Transitive",
@@ -64,10 +64,10 @@
       },
       "System.Drawing.Common": {
         "type": "Transitive",
-        "resolved": "10.0.1",
-        "contentHash": "cmkIduwyVPfuO8kNehu3xNcjo26nMgUoJyfso9S/zTO85YovvPPG0/AFLjanx1iVgQ80OpJVnLb1jU3aIKNLdg==",
+        "resolved": "10.0.2",
+        "contentHash": "nCq8jeGD4vWaUjX3nGaDMKYqfFPposw2f4KCFnuY5Rt3NhK6zMZ/c0a52a3TZK/nnkCJfyQMwb+POKwAnZexZw==",
         "dependencies": {
-          "Microsoft.Win32.SystemEvents": "10.0.1"
+          "Microsoft.Win32.SystemEvents": "10.0.2"
         }
       },
       "rotationsolver.sourcegenerators": {
@@ -83,7 +83,7 @@
           "Microsoft.CodeAnalysis.CSharp": "[5.0.0, )",
           "RotationSolver.SourceGenerators": "[1.0.0, )",
           "Svg": "[3.4.7, )",
-          "System.Drawing.Common": "[10.0.1, )"
+          "System.Drawing.Common": "[10.0.2, )"
         }
       }
     }


### PR DESCRIPTION
- Refactored VFX detection for tankbusters, multi-hit, and shared AOEs using cached, case-insensitive sets for accuracy and performance.
- Overhauled RDM Mana Stack (3) finisher logic for better mana balancing and proc usage.
- Adjusted GNB oGCD priorities and removed redundant checks.
- Fixed NIN mudra usage logic combat check.
- Tweaked MCH burst logic and Reassemble timing.
- UI: Show rotation name in diagnostics; updated timeline window label.