### PR TITLE
Updated Phantom rotaiton and slight adjustment to MCH opener

### DIFF
--- a/RotationSolver/RebornRotations/Duty/PhantomDefault.cs
+++ b/RotationSolver/RebornRotations/Duty/PhantomDefault.cs
@@ -313,7 +313,7 @@ public sealed class PhantomDefault : PhantomRotation
             return base.DefenseSingleAbility(nextGCD, out act);
         }
 
-		if (DefendPvE.CanUse(out act))
+		if (InCombat && StatusHelper.PlayerHasStatus(true, StatusHelper.TankStanceStatus) && DefendPvE.CanUse(out act))
 		{
 			return true;
 		}

--- a/RotationSolver/RebornRotations/Ranged/MCH_Reborn.cs
+++ b/RotationSolver/RebornRotations/Ranged/MCH_Reborn.cs
@@ -30,6 +30,11 @@ public sealed class MCH_Reborn : MachinistRotation
 			return act;
 		}
 
+		if (!AirAnchorCountdown && remainTime < 0.1f && AirAnchorPvE.EnoughLevel && AirAnchorPvE.CanUse(out act))
+		{
+			return act;
+		}
+
 		if (remainTime < 4.75f && ReassemblePvE.CanUse(out act))
         {
             return act;


### PR DESCRIPTION
Updated DefendPvE logic in PhantomDefault to require both combat status and active tank stance. Added a new AirAnchorPvE usage condition in MCH_Reborn for when AirAnchorCountdown is false and remaining time is under 0.1s.