### PR TITLE
Fix for NIN AutoUnhide setting being active outside of RSR enable state

### DIFF
--- a/RotationSolver.Basic/RotationSolver.Basic.csproj
+++ b/RotationSolver.Basic/RotationSolver.Basic.csproj
@@ -79,7 +79,7 @@
         <Using Include="Dalamud.Bindings.ImGui" />
         <Using Include="Newtonsoft.Json" />
 
-        <PackageReference Include="ECommons" Version="3.1.0.13" />
+        <PackageReference Include="ECommons" Version="3.1.0.15" />
 
         <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.0.0" />
 

--- a/RotationSolver.Basic/Rotations/CustomRotation_OtherInfo.cs
+++ b/RotationSolver.Basic/Rotations/CustomRotation_OtherInfo.cs
@@ -22,7 +22,13 @@ public partial class CustomRotation
 	public static bool IsCasting => Player?.IsCasting ?? false;
 
 	/// <summary>
-	/// Does player have swift cast, dual cast or triple cast.
+	/// 
+	/// </summary>
+	[Description("Is RSR active")]
+	public static bool StateEnabled => DataCenter.State;
+
+	/// <summary>
+	/// Does player have swift cast, dual cast or triple cast. State
 	/// </summary>
 	[Description("Has Swift")]
     public static bool HasSwift => StatusHelper.PlayerHasStatus(true, StatusHelper.SwiftcastStatus);

--- a/RotationSolver.Basic/packages.lock.json
+++ b/RotationSolver.Basic/packages.lock.json
@@ -4,9 +4,9 @@
     "net10.0-windows10.0.26100": {
       "ECommons": {
         "type": "Direct",
-        "requested": "[3.1.0.13, )",
-        "resolved": "3.1.0.13",
-        "contentHash": "h7IvgmSOniX1hXorHogX43hDg7aoneyzWKrPEY9qbN3/By4oc1Z5MgQCeoSp1vloSbbf1MQg1h+/DyNtlpYv2A=="
+        "requested": "[3.1.0.15, )",
+        "resolved": "3.1.0.15",
+        "contentHash": "abmpVgmG8xBIG/+/IMsMEgj9p1T38ztQA9+QYL1c7HoIf47Fvlm33P1jt9V+o4NDwFg6eZigTkE5lc7EcLlyAQ=="
       },
       "Microsoft.CodeAnalysis.CSharp": {
         "type": "Direct",

--- a/RotationSolver/RebornRotations/Melee/NIN_Reborn.cs
+++ b/RotationSolver/RebornRotations/Melee/NIN_Reborn.cs
@@ -1069,7 +1069,7 @@ public sealed class NIN_Reborn : NinjaRotation
             }
         }
 
-        if (AutoUnhide && IsHidden)
+        if (StateEnabled && AutoUnhide && IsHidden)
         {
             StatusHelper.StatusOff(StatusID.Hidden);
         }

--- a/RotationSolver/RotationSolver.csproj
+++ b/RotationSolver/RotationSolver.csproj
@@ -22,7 +22,7 @@
 
 	<ItemGroup>
 		<!-- Keep ECommons runtime so its DLL is included -->
-		<PackageReference Include="ECommons" Version="3.1.0.13" />
+		<PackageReference Include="ECommons" Version="3.1.0.15" />
 		<!-- Do not copy Roslyn runtime to output -->
 		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.0.0" PrivateAssets="all" ExcludeAssets="runtime" />
 	</ItemGroup>

--- a/RotationSolver/packages.lock.json
+++ b/RotationSolver/packages.lock.json
@@ -16,9 +16,9 @@
       },
       "ECommons": {
         "type": "Direct",
-        "requested": "[3.1.0.13, )",
-        "resolved": "3.1.0.13",
-        "contentHash": "h7IvgmSOniX1hXorHogX43hDg7aoneyzWKrPEY9qbN3/By4oc1Z5MgQCeoSp1vloSbbf1MQg1h+/DyNtlpYv2A=="
+        "requested": "[3.1.0.15, )",
+        "resolved": "3.1.0.15",
+        "contentHash": "abmpVgmG8xBIG/+/IMsMEgj9p1T38ztQA9+QYL1c7HoIf47Fvlm33P1jt9V+o4NDwFg6eZigTkE5lc7EcLlyAQ=="
       },
       "Microsoft.CodeAnalysis.CSharp": {
         "type": "Direct",
@@ -79,7 +79,7 @@
       "RotationSolverReborn.Basic": {
         "type": "Project",
         "dependencies": {
-          "ECommons": "[3.1.0.13, )",
+          "ECommons": "[3.1.0.15, )",
           "Microsoft.CodeAnalysis.CSharp": "[5.0.0, )",
           "RotationSolver.SourceGenerators": "[1.0.0, )",
           "Svg": "[3.4.7, )",


### PR DESCRIPTION
- Added a check in CustomRotation to reflective if RSR is active
- Used new active check to control NIN AutoUnhide logic
- Updated Ecommons