### PR TITLE
Add duty-specific config section and encounter logic, and more

### DIFF
--- a/RotationSolver.Basic/Actions/ActionTargetInfo.cs
+++ b/RotationSolver.Basic/Actions/ActionTargetInfo.cs
@@ -918,7 +918,7 @@ public struct ActionTargetInfo(IBaseAction action)
         }
 
         // Cleave mode
-        if (aoeCount > 1 && Service.Config.AoEType == AoEType.Cleave)
+        if (aoeCount > 1 && (Service.Config.AoEType == AoEType.Cleave || (DataCenter.IsInM9S && Service.Config.M9SCleaveOnly)))
         {
             yield break;
         }

--- a/RotationSolver.Basic/Configuration/Configs.cs
+++ b/RotationSolver.Basic/Configuration/Configs.cs
@@ -13,7 +13,17 @@ internal partial class Configs : IPluginConfiguration
     public const string
         BasicTimer = "BasicTimer",
         BasicAutoSwitch = "BasicAutoSwitch",
-        BasicParams = "BasicParams",
+		DutySpecifcPvP = "DutySpecifcPvP",
+		DutySpecifcFieldOps = "DutySpecifcFieldOps",
+		DutySpecifcAlliance = "DutySpecifcAlliance",
+		DutySpecifcDeepDungeon = "DutySpecifcDeepDungeon",
+		DutySpecifcVariantDungeon = "DutySpecifcVariantDungeon",
+		DutySpecifcChaoticAlliance = "DutySpecifcChaoticAlliance",
+		DutySpecifcDungeon = "DutySpecifcDungeon",
+		DutySpecifcUltimate = "DutySpecifcUltimate",
+		DutySpecifcExtreme = "DutySpecifcExtreme",
+		DutySpecifcSavage = "DutySpecifcSavage",
+		BasicParams = "BasicParams",
         UiInformation = "UiInformation",
         UiWindows = "UiWindows",
         PvPSpecificControls = "PvPSpecificControls",
@@ -43,7 +53,165 @@ internal partial class Configs : IPluginConfiguration
     public MacroInfo DutyStart { get; set; } = new MacroInfo();
     public MacroInfo DutyEnd { get; set; } = new MacroInfo();
 
-    [ConditionBool, UI("Intercept player input and queue it for RSR to execute the action. (PvE only)",
+	#region Duty Specific
+	[ConditionBool, UI("O12S - Packet Filter logic.",
+	Description = "Treat OmegaM/OmegaF as immune if you have their corresponding Packet Filter status (also applies to Normal).",
+	Filter = DutySpecifcSavage)]
+	private static readonly bool _o12sOmegaMF = true;
+
+	[ConditionBool, UI("M8S - Wolf Pack/Stone Pack logic.",
+	Description = "Treat Wolf of Wind/Wolf of Stone as immune if you don't have the corresponding status for it.",
+	Filter = DutySpecifcSavage)]
+	private static readonly bool _m8sWindStone = true;
+
+	[ConditionBool, UI("M9S - Only use cleave logic.",
+	Description = "This should clear up any targeting issues when a nail, the boss, and a flail are near each other at the same time.",
+	Filter = DutySpecifcSavage)]
+	private static readonly bool _m9sCleaveOnly = true;
+
+	[ConditionBool, UI("M9S - Cell Targeting logic.",
+	Description = "Treat Cells as immune if you don't have the corresponding status for it.",
+	Filter = DutySpecifcSavage)]
+	private static readonly bool _m9sCellTargeting = true;
+
+	[ConditionBool, UI("M9S - Ads Targeting logic.",
+	Description = "Prioritize Doornail or Flail based on role and distance to target.",
+	Filter = DutySpecifcSavage)]
+	private static readonly bool _m9sAdsTargeting = true;
+
+	[ConditionBool, UI("M10S - Firesnaking/Watersnaking targeting logic.",
+	Description = "Priotize Red Hot if you have firesnaking buff, and Deep Blue if you have watersnaking buff (also applies to Normal).",
+	Filter = DutySpecifcSavage)]
+	private static readonly bool _m10sBroTargeting = true;
+
+	[ConditionBool, UI("Limitless Blue Extreme - Whaleback logic.",
+	Description = "Treat Bismark Shell/Bismark Corona as immune if you don't have the Whaleback status",
+	Filter = DutySpecifcExtreme)]
+	private static readonly bool _limitlessBlueTargeting = true;
+
+	[ConditionBool, UI("Cinder Drift Extreme - Pall Targeting logic.",
+	Description = "Treat Pall of Rage/Pall of Grief as immune if you don't have the corresponding status for it.",
+	Filter = DutySpecifcExtreme)]
+	private static readonly bool _cinderDriftPallTargeting = true;
+
+	[ConditionBool, UI("The Epic of Alexander (Ultimate) - Jagd Doll logic.",
+	Description = "Treat Jagd Doll ads as immune when HP is less than 25%.",
+	Filter = DutySpecifcUltimate)]
+	private static readonly bool _teaJagdDoll = true;
+
+	[ConditionBool, UI("The Epic of Alexander (Ultimate) - True Heart logic.",
+	Description = "Treat True Heart ad as immune.",
+	Filter = DutySpecifcUltimate)]
+	private static readonly bool _teaTrueHeart = true;
+
+	[ConditionBool, UI("The Omega Protocol (Ultimate) - Packet Filter logic.",
+	Description = "Treat OmegaM/OmegaF as immune if you have their corresponding Packet Filter status.",
+	Filter = DutySpecifcUltimate)]
+	private static readonly bool _topOmegaMF = true;
+
+	[ConditionBool, UI("Futures Rewritten (Ultimate) - Crystal Of Darkness logic.",
+	Description = "Treat Crystal Of Darkness ad as immune.",
+	Filter = DutySpecifcUltimate)]
+	private static readonly bool _fruCrystalOfDarkness = true;
+
+	[ConditionBool, UI("The Ghimlyt Dark - Colossus Rubricatus ad.",
+	Description = "Treat Colossus Rubricatus as immune while its casting scripted action which leads to its death.",
+	Filter = DutySpecifcDungeon)]
+	private static readonly bool _colossusRubricatusImmune = true;
+
+	[ConditionBool, UI("Dohn Mheg - Liars Lyre mechancic.",
+	Description = "Treat Liars Lyre as immune if you don't have the Unfooled status.",
+	Filter = DutySpecifcDungeon)]
+	private static readonly bool _dohnMhegLyre = true;
+
+	[ConditionBool, UI("The Meso Terminal - Thanatos logic.",
+	Description = "Treat Jailers in second boss fight as immune if you don't have corresponding buff.",
+	Filter = DutySpecifcDungeon)]
+	private static readonly bool _jailerImmune = true;
+
+	[ConditionBool, UI("Forked Tower - Dead Star logic.",
+	Description = "Treat Triton/Nereid/Phobos as immune if you don't have the corresponding status for it.",
+	Filter = DutySpecifcFieldOps)]
+	private static readonly bool _forkedtowerDeadStar = true;
+
+	[ConditionBool, UI("Pilgrim's Traverse - Eminent Grief logic.",
+	Description = "Treat Eminent Grief as immune if you don't have Light Vengeance buff, and treat Devoured Eater as immune if you don't have Dark Vengeance buff.",
+	Filter = DutySpecifcDeepDungeon)]
+	private static readonly bool _eminent = true;
+
+	[ConditionBool, UI("The Labyrinth of the Ancients - Thanatos logic.",
+	Description = "Treat Thanatos as immune if you don't have Astral Realignment buff.",
+	Filter = DutySpecifcAlliance)]
+	private static readonly bool _thanatosImmune = true;
+
+	[ConditionBool, UI("The Void Ark - Irminsul and Sawtooth logic.",
+	Description = "Treat Irminsul and Sawtooth as immune if you don't have corresponding buff.",
+	Filter = DutySpecifcAlliance)]
+	private static readonly bool _irminsulSawtoothImmune = true;
+
+	[ConditionBool, UI("The Puppets' Bunker - Superior Flight Unit logic.",
+	Description = "Treat each Superior Flight Unit as immune if you don't have corresponding buff.",
+	Filter = DutySpecifcAlliance)]
+	private static readonly bool _superiorFlightUnitImmune = true;
+
+	[ConditionBool, UI("The Tower at Paradigm's Breach - Hansel and Gretel logic.",
+	Description = "Treat each Hansel/Gretel as immune if you are at an angle that would cause you to take rebound damage from the shield mechanic.",
+	Filter = DutySpecifcAlliance)]
+	private static readonly bool _hanselorGretelShieldedImmune = true;
+
+	[ConditionBool, UI("Jeuno: The First Walk - The Ark Angels logic.",
+	Description = "Treat each Ark Angel as immune if you don't have corresponding buff.",
+	Filter = DutySpecifcAlliance)]
+	private static readonly bool _jeunoBossImmune = true;
+
+	[ConditionBool, UI("Cloud of Darkness - Ads phase logic.",
+	Description = "Treat Cloud of Darkness/Stygian as immune if you don't have corresponding buff.",
+	Filter = DutySpecifcChaoticAlliance)]
+	private static readonly bool _codImmune = true;
+
+	[ConditionBool, UI("The Sil'dihn Subterrane - Drakefamily ads logic.",
+	Description = "Custom logic to treat certain drakes as immune to kill them in a specific order for the purposes Variant path 12.",
+	Filter = DutySpecifcVariantDungeon)]
+	private static readonly bool _drakeImmune = true;
+	#endregion
+
+	#region PvP
+	[JobConfig, UI("The HP for using Guard.",
+		Filter = DutySpecifcPvP)]
+	[Range(0, 1, ConfigUnitType.Percent, 0.02f)]
+	public float HealthForGuard { get; set; } = 0.15f;
+
+	[ConditionBool, UI("Ignore TTK for PvP purposes.", Filter = DutySpecifcPvP)]
+	private static readonly bool _ignorePvPTTK = true;
+
+	[ConditionBool, UI("Prioritize A tier tomeliths in Shatter.", Filter = DutySpecifcPvP)]
+	private static readonly bool _prioAtomelith = false;
+
+	[ConditionBool, UI("Prioritize B tier tomeliths in Shatter.", Filter = DutySpecifcPvP)]
+	private static readonly bool _prioBtomelith = false;
+
+	[JobConfig, UI("Ignore Invincibility for PvP purposes.", Filter = DutySpecifcPvP)]
+	private static readonly bool _ignorePvPInvincibility = false;
+
+	[ConditionBool, UI("Auto turn off when dead in PvP.",
+		 Filter = DutySpecifcPvP)]
+	private static readonly bool _autoOffWhenDeadPvP = true;
+
+	[ConditionBool, UI("Auto turn off when PvP match ends.",
+		 Filter = DutySpecifcPvP)]
+	private static readonly bool _autoOffPvPMatchEnd = true;
+
+	[ConditionBool, UI("Auto turn on when PvP match starts.",
+		 Filter = DutySpecifcPvP)]
+	private static readonly bool _autoOnPvPMatchStart = true;
+
+	[ConditionBool, UI("Set RSR to PvP specific state when enabled in PvP zone.",
+		 Filter = DutySpecifcPvP)]
+	private static readonly bool _pvpStateControl = false;
+
+	#endregion
+
+	[ConditionBool, UI("Intercept player input and queue it for RSR to execute the action. (PvE only)",
     Filter = AutoActionUsage, Section = 5)]
     private static readonly bool _interceptAction2 = false;
 
@@ -751,11 +919,6 @@ internal partial class Configs : IPluginConfiguration
     Filter = Extra)]
     private static readonly bool _showCactbotToasts = false;
 
-    [JobConfig, UI("The HP for using Guard.",
-        Filter = PvPSpecificControls)]
-    [Range(0, 1, ConfigUnitType.Percent, 0.02f)]
-    public float HealthForGuard { get; set; } = 0.15f;
-
     [UI("Highlight color.", Parent = nameof(TeachingMode))]
     public Vector4 TeachingModeColor { get; set; } = new(0f, 1f, 0f, 1f);
 
@@ -914,37 +1077,6 @@ internal partial class Configs : IPluginConfiguration
         PvEFilter = JobFilterType.Tank)]
     [Range(1, 8, ConfigUnitType.None, 0.05f)]
     public int AutoDefenseNumber { get; set; } = 2;
-
-    #endregion
-
-    #region PvP
-    [ConditionBool, UI("Ignore TTK for PvP purposes.", Filter = PvPSpecificControls)]
-    private static readonly bool _ignorePvPTTK = true;
-
-    [ConditionBool, UI("Prioritize A tier tomeliths in Shatter.", Filter = PvPSpecificControls)]
-    private static readonly bool _prioAtomelith = false;
-
-    [ConditionBool, UI("Prioritize B tier tomeliths in Shatter.", Filter = PvPSpecificControls)]
-    private static readonly bool _prioBtomelith = false;
-
-    [JobConfig, UI("Ignore Invincibility for PvP purposes.", Filter = PvPSpecificControls)]
-    private static readonly bool _ignorePvPInvincibility = false;
-
-    [ConditionBool, UI("Auto turn off when dead in PvP.",
-         Filter = PvPSpecificControls)]
-    private static readonly bool _autoOffWhenDeadPvP = true;
-
-    [ConditionBool, UI("Auto turn off when PvP match ends.",
-         Filter = PvPSpecificControls)]
-    private static readonly bool _autoOffPvPMatchEnd = true;
-
-    [ConditionBool, UI("Auto turn on when PvP match starts.",
-         Filter = PvPSpecificControls)]
-    private static readonly bool _autoOnPvPMatchStart = true;
-
-    [ConditionBool, UI("Set RSR to PvP specific state when enabled in PvP zone.",
-         Filter = PvPSpecificControls)]
-    private static readonly bool _pvpStateControl = false;
 
     #endregion
 

--- a/RotationSolver.Basic/Helpers/ObjectHelper.cs
+++ b/RotationSolver.Basic/Helpers/ObjectHelper.cs
@@ -975,7 +975,7 @@ public static class ObjectHelper
 			return false;
 		}
 
-		if (DataCenter.IsInM9S)
+		if (Service.Config.M9SAdsTargeting && DataCenter.IsInM9S)
 		{
 			var DeadlyDoornail = battleChara.NameId == 14303;
 			var FatalFlail = battleChara.NameId == 14302;
@@ -1127,7 +1127,7 @@ public static class ObjectHelper
 			return false;
 		}
 
-		if (DataCenter.IsInM10S)
+		if (Service.Config.M10SBroTargeting && DataCenter.IsInM10S)
 		{
 			var RedHot = battleChara.NameId == 14370;
 			var DeepBlue = battleChara.NameId == 14369;
@@ -1193,7 +1193,7 @@ public static class ObjectHelper
 			return false;
 		}
 
-		if (DataCenter.TerritoryID == 1322)
+		if (Service.Config.M10SBroTargeting && DataCenter.TerritoryID == 1322)
 		{
 			var RedHot = battleChara.NameId == 14370;
 			var DeepBlue = battleChara.NameId == 14369;
@@ -1622,7 +1622,7 @@ public static class ObjectHelper
 			return false;
 		}
 
-		if (DataCenter.IsInM9S)
+		if (Service.Config.M9SCellTargeting && DataCenter.IsInM9S)
 		{
 			var CharnelCell = battleChara.NameId == 14304;
 
@@ -1684,32 +1684,9 @@ public static class ObjectHelper
 	/// <summary>
 	/// 
 	/// </summary>
-	public static bool IsCrystalOfDarknessImmune(this IBattleChara battleChara)
-	{
-		if (DataCenter.TerritoryID == 1238)
-		{
-			var CrystalOfDarkness = battleChara.NameId == 13556;
-
-			if (CrystalOfDarkness)
-			{
-				if (Service.Config.InDebug)
-				{
-					PluginLog.Information("IsCrystalOfDarknessImmune action found, ignoring mob");
-				}
-				return true;
-			}
-
-		}
-
-		return false;
-	}
-
-	/// <summary>
-	/// 
-	/// </summary>
 	public static bool IsColossusRubricatusImmune(this IBattleChara battleChara)
     {
-        if (DataCenter.TerritoryID == 1174)
+        if (Service.Config.ColossusRubricatusImmune && DataCenter.TerritoryID == 1174)
         {
             var ColossusRubricatus = battleChara.NameId == 9511;
 
@@ -1733,32 +1710,9 @@ public static class ObjectHelper
     /// <summary>
     /// 
     /// </summary>
-    public static bool IsTrueHeartImmune(this IBattleChara battleChara)
-    {
-        if (DataCenter.TerritoryID == 887)
-        {
-            var TrueHeart = battleChara.NameId == 9223;
-
-            if (TrueHeart)
-            {
-                if (Service.Config.InDebug)
-                {
-                    PluginLog.Information("IsTrueHeartImmune status found");
-                }
-                return true;
-            }
-
-        }
-
-        return false;
-    }
-
-    /// <summary>
-    /// 
-    /// </summary>
     public static bool IsEminentGriefImmune(this IBattleChara battleChara)
     {
-        if (DataCenter.TerritoryID == 1311 || DataCenter.TerritoryID == 1333 || DataCenter.TerritoryID == 1290)
+        if (Service.Config.Eminent && (DataCenter.TerritoryID == 1311 || DataCenter.TerritoryID == 1333 || DataCenter.TerritoryID == 1290))
         {
             var EminentGrief = battleChara.NameId == 14037;
             var DevouredEater = battleChara.NameId == 14038;
@@ -1793,7 +1747,7 @@ public static class ObjectHelper
     /// </summary>
     public static bool IsLOTAImmune(this IBattleChara battleChara)
     {
-        if (DataCenter.TerritoryID == 174)
+        if (Service.Config.ThanatosImmune && DataCenter.TerritoryID == 174)
         {
             var Thanatos = battleChara.NameId == 710;
             var AstralRealignment = StatusHelper.PlayerHasStatus(false, StatusID.AstralRealignment);
@@ -1816,7 +1770,7 @@ public static class ObjectHelper
     /// </summary>
     public static bool IsMesoImmune(this IBattleChara battleChara)
     {
-        if (DataCenter.TerritoryID == 1292)
+        if (Service.Config.JailerImmune && DataCenter.TerritoryID == 1292)
         {
             StatusID CellJailerA = (StatusID)4546;
             StatusID CellJailerB = (StatusID)4547;
@@ -1883,12 +1837,12 @@ public static class ObjectHelper
     /// </summary>
     public static bool IsJagdDollImmune(this IBattleChara battleChara)
     {
-        if (DataCenter.TerritoryID == 887)
+        if (Service.Config.TeaJagdDoll && DataCenter.TerritoryID == 887)
         {
             var JagdDoll = battleChara.NameId == 9214;
             var HealthThreshold = battleChara.GetEffectiveHpPercent();
 
-            if (JagdDoll && HealthThreshold < 25)
+            if (JagdDoll && HealthThreshold < 25f)
             {
                 return true;
             }
@@ -1897,12 +1851,57 @@ public static class ObjectHelper
         return false;
     }
 
-    /// <summary>
-    /// 
-    /// </summary>
-    public static bool IsLyreImmune(this IBattleChara battleChara)
+	/// <summary>
+	/// 
+	/// </summary>
+	public static bool IsTrueHeartImmune(this IBattleChara battleChara)
+	{
+		if (Service.Config.TeaTrueHeart && DataCenter.TerritoryID == 887) // In TEA
+		{
+			var TrueHeart = battleChara.NameId == 9223;
+
+			if (TrueHeart)
+			{
+				if (Service.Config.InDebug)
+				{
+					PluginLog.Information("IsTrueHeartImmune mob found, ignoring mob");
+				}
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/// <summary>
+	/// 
+	/// </summary>
+	public static bool IsCrystalOfDarknessImmune(this IBattleChara battleChara)
+	{
+		if (Service.Config.FruCrystalOfDarkness && DataCenter.TerritoryID == 1238)
+		{
+			var CrystalOfDarkness = battleChara.NameId == 13556;
+
+			if (CrystalOfDarkness)
+			{
+				if (Service.Config.InDebug)
+				{
+					PluginLog.Information("IsCrystalOfDarknessImmune mob found, ignoring mob");
+				}
+				return true;
+			}
+
+		}
+
+		return false;
+	}
+
+	/// <summary>
+	/// 
+	/// </summary>
+	public static bool IsLyreImmune(this IBattleChara battleChara)
     {
-        if (DataCenter.TerritoryID == 821)
+        if (Service.Config.DohnMhegLyre && DataCenter.TerritoryID == 821)
         {
             var LiarsLyre = battleChara.NameId == 8958;
             var Unfooled = StatusHelper.PlayerHasStatus(false, StatusID.Unfooled);
@@ -1921,7 +1920,7 @@ public static class ObjectHelper
     /// </summary>
     public static bool IsDrakeImmune(this IBattleChara battleChara)
     {
-        if (DataCenter.TerritoryID == 1069)
+        if (Service.Config.DrakeImmune && DataCenter.TerritoryID == 1069)
         {
             // NameIds for each drake
             const uint DrakefatherId = 11463;
@@ -1985,7 +1984,7 @@ public static class ObjectHelper
     /// <returns></returns>
     public static bool IsWolfImmune(this IBattleChara battleChara)
     {
-        if (DataCenter.TerritoryID == 1263)
+        if (Service.Config.M8SWindStone && DataCenter.TerritoryID == 1263)
         {
             // Numeric values used instead of name as Lumina does not provide name yet, and may update to change name
             StatusID WindPack = (StatusID)4389; // Numeric value for "Rsv43891100S74Cfc3B0E74Cfc3B0", unable to hit Wolf of Wind
@@ -2026,7 +2025,7 @@ public static class ObjectHelper
     /// <returns></returns>
     public static bool IsIrminsulSawtoothImmune(this IBattleChara battleChara)
     {
-        if (DataCenter.TerritoryID == 508)
+        if (Service.Config.IrminsulSawtoothImmune && DataCenter.TerritoryID == 508)
         {
             var RangedPhysicalRole = Player.Job.IsPhysicalRangedDps();
             var RangedMagicalRole = Player.Job.IsMagicalRangedDps();
@@ -2064,7 +2063,7 @@ public static class ObjectHelper
     /// <returns></returns>
     public static bool IsSuperiorFlightUnitImmune(this IBattleChara battleChara)
     {
-        if (DataCenter.TerritoryID == 917)
+        if (Service.Config.SuperiorFlightUnitImmune && DataCenter.TerritoryID == 917)
         {
             var ShieldProtocolAPlayer = StatusHelper.PlayerHasStatus(false, StatusID.ShieldProtocolA);
             var ShieldProtocolBPlayer = StatusHelper.PlayerHasStatus(false, StatusID.ShieldProtocolB);
@@ -2105,14 +2104,40 @@ public static class ObjectHelper
         return false;
     }
 
-    /// <summary>
-    /// Is target Jeuno Boss immune.
-    /// </summary>
-    /// <param name="battleChara">the object.</param>
-    /// <returns></returns>
-    public static bool IsJeunoBossImmune(this IBattleChara battleChara)
+	/// <summary>
+	/// Is target Hansel or Gretel and has the Strong of Shield status.
+	/// </summary>
+	/// <param name="battleChara">the object.</param>
+	/// <returns></returns>
+	public static bool IsHanselorGretelShielded(this IBattleChara battleChara)
+	{
+		if (Service.Config.HanselorGretelShieldedImmune && DataCenter.TerritoryID == 966)
+		{
+			EnemyPositional strongOfShieldPositional = EnemyPositional.Front;
+			StatusID strongOfShieldStatus = StatusID.StrongOfShield;
+
+			if (battleChara.HasStatus(false, strongOfShieldStatus) &&
+					strongOfShieldPositional != battleChara.FindEnemyPositional())
+			{
+				if (Service.Config.InDebug)
+				{
+					PluginLog.Information("IsHanselorGretelShielded: StrongOfShield status found, ignoring status haver if player is out of position");
+				}
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/// <summary>
+	/// Is target Jeuno Boss immune.
+	/// </summary>
+	/// <param name="battleChara">the object.</param>
+	/// <returns></returns>
+	public static bool IsJeunoBossImmune(this IBattleChara battleChara)
     {
-        if (DataCenter.TerritoryID == 1248)
+        if (Service.Config.JeunoBossImmune && DataCenter.TerritoryID == 1248)
         {
             var FatedVillain = battleChara.HasStatus(false, StatusID.FatedVillain);
             var VauntedVillain = battleChara.HasStatus(false, StatusID.VauntedVillain);
@@ -2160,7 +2185,7 @@ public static class ObjectHelper
     /// <returns></returns>
     public static bool IsDeadStarImmune(this IBattleChara battleChara)
     {
-        if (DataCenter.IsInForkedTower)
+        if (Service.Config.ForkedtowerDeadStar && DataCenter.IsInForkedTower)
         {
             var Triton = battleChara.NameId == 13730;
             var Nereid = battleChara.NameId == 13731;
@@ -2208,7 +2233,7 @@ public static class ObjectHelper
     /// <returns></returns>
     public static bool IsCODBossImmune(this IBattleChara battleChara)
     {
-        if (DataCenter.TerritoryID == 1241)
+        if (Service.Config.CodImmune && DataCenter.TerritoryID == 1241)
         {
             var CloudOfDarknessStatus = battleChara.HasStatus(false, StatusID.VeilOfDarkness);
             var StygianStatus = battleChara.HasStatus(false, StatusID.UnnamedStatus_4388);
@@ -2238,14 +2263,66 @@ public static class ObjectHelper
         return false;
     }
 
-    /// <summary>
-    /// Is target Cinder Drift Boss immune.
-    /// </summary>
-    /// <param name="battleChara">the object.</param>
-    /// <returns></returns>
-    public static bool IsCinderDriftImmune(this IBattleChara battleChara)
+	/// <summary>
+	/// Is target Limitless Blue immune.
+	/// </summary>
+	/// <param name="battleChara">the object.</param>
+	/// <returns></returns>
+	public static bool IsLimitlessBlue(this IBattleChara battleChara)
+	{
+		if (Service.Config.LimitlessBlueTargeting && (DataCenter.TerritoryID == 436 || DataCenter.TerritoryID == 447))
+		{
+			StatusID WillOfTheWater = StatusID.WillOfTheWater;
+			StatusID WillOfTheWind = StatusID.WillOfTheWind;
+			StatusID WhaleBack = StatusID.Whaleback;
+
+			bool Green = battleChara.NameId == 3654;
+			bool Blue = battleChara.NameId == 3655;
+			bool BismarkShell = battleChara.NameId == 3656;
+			bool BismarkCorona = battleChara.NameId == 3657;
+
+			if ((BismarkShell || BismarkCorona) &&
+					!StatusHelper.PlayerHasStatus(false, WhaleBack))
+			{
+				if (Service.Config.InDebug)
+				{
+					PluginLog.Information("IsLimitlessBlue: Bismark found, WhaleBack status not found");
+				}
+				return true;
+			}
+
+			if (Blue &&
+				StatusHelper.PlayerHasStatus(false, WillOfTheWater))
+			{
+				if (Service.Config.InDebug)
+				{
+					PluginLog.Information("IsLimitlessBlue: WillOfTheWater status found");
+				}
+				return true;
+			}
+
+			if (Green &&
+				StatusHelper.PlayerHasStatus(false, WillOfTheWind))
+			{
+				if (Service.Config.InDebug)
+				{
+					PluginLog.Information("IsLimitlessBlue: WillOfTheWind status found");
+				}
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/// <summary>
+	/// Is target Cinder Drift Boss immune.
+	/// </summary>
+	/// <param name="battleChara">the object.</param>
+	/// <returns></returns>
+	public static bool IsCinderDriftImmune(this IBattleChara battleChara)
     { 
-        if (DataCenter.TerritoryID == 912)
+        if (Service.Config.CinderDriftPallTargeting && DataCenter.TerritoryID == 912)
         {
             var GriefAdd = battleChara.HasStatus(false, StatusID.BlindToGrief);
             var RageAdd = battleChara.HasStatus(false, StatusID.BlindToRage);
@@ -2314,14 +2391,54 @@ public static class ObjectHelper
         return false;
     }
 
-    /// <summary>
-    /// Is target Omega Boss immune.
-    /// </summary>
-    /// <param name="battleChara">the object.</param>
-    /// <returns></returns>
-    public static bool IsOmegaImmune(this IBattleChara battleChara)
+	/// <summary>
+	/// Is target Omega Boss immune.
+	/// </summary>
+	/// <param name="battleChara">the object.</param>
+	/// <returns></returns>
+	public static bool IsTOPImmune(this IBattleChara battleChara)
+	{
+		if (Service.Config.TopOmegaMf && DataCenter.TerritoryID == 1122)
+		{
+			StatusID AntiOmegaF_Ultimate = StatusID.PacketFilterF_3500;
+			StatusID AntiOmegaM_Ultimate = StatusID.PacketFilterM_3499;
+
+			StatusID OmegaF = StatusID.OmegaF;
+			StatusID OmegaM = StatusID.Omega;
+			StatusID OmegaM2 = StatusID.OmegaM_3454;
+
+			if (battleChara.HasStatus(false, OmegaF) &&
+					StatusHelper.PlayerHasStatus(false, AntiOmegaF_Ultimate))
+			{
+				if (Service.Config.InDebug)
+				{
+					PluginLog.Information("IsTOPImmune: PacketFilterF status found");
+				}
+				return true;
+			}
+
+			if (battleChara.HasStatus(false, OmegaM, OmegaM2) &&
+				StatusHelper.PlayerHasStatus(false, AntiOmegaM_Ultimate))
+			{
+				if (Service.Config.InDebug)
+				{
+					PluginLog.Information("IsTOPImmune: PacketFilterM status found");
+				}
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/// <summary>
+	/// Is target Omega Boss immune.
+	/// </summary>
+	/// <param name="battleChara">the object.</param>
+	/// <returns></returns>
+	public static bool IsOmegaImmune(this IBattleChara battleChara)
     {
-        if (DataCenter.TerritoryID == 801 || DataCenter.TerritoryID == 805)
+        if (Service.Config.O12SOmegaMf && (DataCenter.TerritoryID == 801 || DataCenter.TerritoryID == 805))
         {
             StatusID AntiOmegaF = StatusID.PacketFilterF;
             StatusID AntiOmegaF_Extreme = StatusID.PacketFilterF_3500;
@@ -2348,84 +2465,6 @@ public static class ObjectHelper
                 if (Service.Config.InDebug)
                 {
                     PluginLog.Information("IsOmegaImmune: PacketFilterM status found");
-                }
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    /// <summary>
-    /// Is target Limitless Blue immune.
-    /// </summary>
-    /// <param name="battleChara">the object.</param>
-    /// <returns></returns>
-    public static bool IsLimitlessBlue(this IBattleChara battleChara)
-    {
-        if (DataCenter.TerritoryID == 436 || DataCenter.TerritoryID == 447)
-        {
-            StatusID WillOfTheWater = StatusID.WillOfTheWater;
-            StatusID WillOfTheWind = StatusID.WillOfTheWind;
-            StatusID WhaleBack = StatusID.Whaleback;
-
-            bool Green = battleChara.NameId == 3654;
-            bool Blue = battleChara.NameId == 3655;
-            bool BismarkShell = battleChara.NameId == 3656;
-            bool BismarkCorona = battleChara.NameId == 3657;
-
-            if ((BismarkShell || BismarkCorona) &&
-                    !StatusHelper.PlayerHasStatus(false, WhaleBack))
-            {
-                if (Service.Config.InDebug)
-                {
-                    PluginLog.Information("IsLimitlessBlue: Bismark found, WhaleBack status not found");
-                }
-                return true;
-            }
-
-            if (Blue &&
-                StatusHelper.PlayerHasStatus(false, WillOfTheWater))
-            {
-                if (Service.Config.InDebug)
-                {
-                    PluginLog.Information("IsLimitlessBlue: WillOfTheWater status found");
-                }
-                return true;
-            }
-
-            if (Green &&
-                StatusHelper.PlayerHasStatus(false, WillOfTheWind))
-            {
-                if (Service.Config.InDebug)
-                {
-                    PluginLog.Information("IsLimitlessBlue: WillOfTheWind status found");
-                }
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    /// <summary>
-    /// Is target Hansel or Gretel and has the Strong of Shield status.
-    /// </summary>
-    /// <param name="battleChara">the object.</param>
-    /// <returns></returns>
-    public static bool IsHanselorGretelShielded(this IBattleChara battleChara)
-    {
-        if (DataCenter.TerritoryID == 966)
-        {
-            EnemyPositional strongOfShieldPositional = EnemyPositional.Front;
-            StatusID strongOfShieldStatus = StatusID.StrongOfShield;
-
-            if (battleChara.HasStatus(false, strongOfShieldStatus) &&
-                    strongOfShieldPositional != battleChara.FindEnemyPositional())
-            {
-                if (Service.Config.InDebug)
-                {
-                    PluginLog.Information("IsHanselorGretelShielded: StrongOfShield status found, ignoring status haver if player is out of position");
                 }
                 return true;
             }

--- a/RotationSolver.Basic/RotationSolver.Basic.csproj
+++ b/RotationSolver.Basic/RotationSolver.Basic.csproj
@@ -79,7 +79,7 @@
         <Using Include="Dalamud.Bindings.ImGui" />
         <Using Include="Newtonsoft.Json" />
 
-        <PackageReference Include="ECommons" Version="3.1.0.15" />
+        <PackageReference Include="ECommons" Version="3.1.0.16" />
 
         <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.0.0" />
 

--- a/RotationSolver.Basic/Rotations/Basic/BlueMageRotation.cs
+++ b/RotationSolver.Basic/Rotations/Basic/BlueMageRotation.cs
@@ -155,7 +155,7 @@ public partial class BlueMageRotation
         //_ = SetBlueMageActions(); disabled for now while i figure out what is causing it to crash to desktop
     }
 
-    private uint[] _lastAppliedBluActions = Array.Empty<uint>();
+    private uint[] _lastAppliedBluActions = [];
 
     /// <summary>
     /// Attempts to set the actions for the Blue Mage character.

--- a/RotationSolver.Basic/Rotations/Basic/SageRotation.cs
+++ b/RotationSolver.Basic/Rotations/Basic/SageRotation.cs
@@ -184,14 +184,22 @@ public partial class SageRotation
         };
     }
 
-    static partial void ModifySoteriaPvE(ref ActionSetting setting)
-    {
-        setting.StatusProvide = [StatusID.Soteria];
-        setting.TargetType = TargetType.Self;
-        setting.ActionCheck = () => DataCenter.PartyMembers.Any(m => m.HasStatus(true, StatusID.Kardion));
-    }
+	static partial void ModifySoteriaPvE(ref ActionSetting setting)
+	{
+		setting.StatusProvide = [StatusID.Soteria];
+		setting.TargetType = TargetType.Self;
+		setting.ActionCheck = () =>
+		{
+			foreach (var m in DataCenter.PartyMembers)
+			{
+				if (m.HasStatus(true, StatusID.Kardion))
+					return true;
+			}
+			return false;
+		};
+	}
 
-    static partial void ModifyIcarusPvE(ref ActionSetting setting)
+	static partial void ModifyIcarusPvE(ref ActionSetting setting)
     {
         setting.SpecialType = SpecialActionType.HostileFriendlyMovingForward;
     }

--- a/RotationSolver.Basic/Rotations/CustomRotation_Actions.cs
+++ b/RotationSolver.Basic/Rotations/CustomRotation_Actions.cs
@@ -115,8 +115,8 @@ public partial class CustomRotation
     #region PvP
     static partial void ModifyStandardissueElixirPvP(ref ActionSetting setting)
     {
-        setting.ActionCheck = () => !HasHostilesInMaxRange
-            && (Player?.CurrentMp <= Player?.MaxMp / 3 || Player?.CurrentHp <= Player?.MaxHp / 3)
+        setting.ActionCheck = () => (!HasHostilesInMaxRange || StatusHelper.PlayerHasStatus(false, StatusID.Covered_1301))
+			&& (Player?.CurrentMp <= Player?.MaxMp / 3 || Player?.CurrentHp <= Player?.MaxHp / 3)
             && !IsLastAction(ActionID.StandardissueElixirPvP) && Player.TimeAlive() > 5;
         setting.IsFriendly = true;
     }

--- a/RotationSolver.Basic/Rotations/CustomRotation_GCD.cs
+++ b/RotationSolver.Basic/Rotations/CustomRotation_GCD.cs
@@ -617,7 +617,7 @@ public partial class CustomRotation
             return true;
         }
 
-        if (StandardissueElixirPvP.CanUse(out act))
+		if (StandardissueElixirPvP.CanUse(out act))
         {
             return true;
         }

--- a/RotationSolver.Basic/packages.lock.json
+++ b/RotationSolver.Basic/packages.lock.json
@@ -4,9 +4,9 @@
     "net10.0-windows10.0.26100": {
       "ECommons": {
         "type": "Direct",
-        "requested": "[3.1.0.15, )",
-        "resolved": "3.1.0.15",
-        "contentHash": "abmpVgmG8xBIG/+/IMsMEgj9p1T38ztQA9+QYL1c7HoIf47Fvlm33P1jt9V+o4NDwFg6eZigTkE5lc7EcLlyAQ=="
+        "requested": "[3.1.0.16, )",
+        "resolved": "3.1.0.16",
+        "contentHash": "wC2uvYyDLH77Wt1nmSAc4AyGVOKlPidN1qo+HslqA+HU69fiUX1JDIX2aRlDqd9thz1ALAnb+ojPBhbQSMbdCw=="
       },
       "Microsoft.CodeAnalysis.CSharp": {
         "type": "Direct",

--- a/RotationSolver/Data/UiString.cs
+++ b/RotationSolver/Data/UiString.cs
@@ -460,7 +460,37 @@ namespace RotationSolver.Data
         [Description("Rotation is null. Please log in or switch jobs!")]
         ConfigWindow_Condition_RotationNullWarning,
 
-        [Description("Delay its transition to true")]
+		[Description("Ultimate")]
+		ConfigWindow_Duty_Ultimate,
+
+		[Description("Savage")]
+		ConfigWindow_Duty_Savage,
+
+		[Description("Chaotic Alliance Raid")]
+		ConfigWindow_Duty_ChaoticAlliance,
+
+		[Description("Extreme")]
+		ConfigWindow_Duty_Extreme,
+
+		[Description("Dungeon")]
+		ConfigWindow_Duty_Dungeon,
+
+		[Description("Deep Dungeon")]
+		ConfigWindow_Duty_DeepDungeon,
+
+		[Description("Variant Dungeon")]
+		ConfigWindow_Duty_VariantDungeon,
+
+		[Description("Alliance Raid")]
+		ConfigWindow_Duty_Alliance,
+
+		[Description("Field Ops")]
+		ConfigWindow_Duty_FieldOps,
+
+		[Description("PvP")]
+		ConfigWindow_Duty_PvP,
+
+		[Description("Delay its transition to true")]
         ActionSequencer_Delay_Description,
 
         [Description("Delay its transition")]
@@ -639,9 +669,6 @@ namespace RotationSolver.Data
 
         [Description("Recent Changes:")]
         WelcomeWindow_Changelog,
-
-        [Description("PvP-Specific Controls")]
-        ConfigWindow_Auto_PvPSpecific,
     }
 
     public static class EnumExtensions

--- a/RotationSolver/RotationSolver.csproj
+++ b/RotationSolver/RotationSolver.csproj
@@ -22,7 +22,7 @@
 
 	<ItemGroup>
 		<!-- Keep ECommons runtime so its DLL is included -->
-		<PackageReference Include="ECommons" Version="3.1.0.15" />
+		<PackageReference Include="ECommons" Version="3.1.0.16" />
 		<!-- Do not copy Roslyn runtime to output -->
 		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.0.0" PrivateAssets="all" ExcludeAssets="runtime" />
 	</ItemGroup>

--- a/RotationSolver/UI/RotationConfigWindow.cs
+++ b/RotationSolver/UI/RotationConfigWindow.cs
@@ -543,7 +543,7 @@ public partial class RotationConfigWindow : Window
                 {
                     displayName = Player.Job.ToString(); // Use the current player's job name
                 }
-                else if (item == RotationConfigWindowTab.Duty && Player.Object != null)
+                else if (item == RotationConfigWindowTab.DutyRotation && Player.Object != null)
                 {
                     if (!DataCenter.IsInDuty || DataCenter.CurrentDutyRotation == null)
                     {
@@ -608,7 +608,7 @@ public partial class RotationConfigWindow : Window
                 }
 
                 // Add a separator after the "Duty" tab
-                if (item == RotationConfigWindowTab.Duty)
+                if (item == RotationConfigWindowTab.DutyRotation)
                 {
                     ImGui.Separator();
                 }
@@ -618,7 +618,7 @@ public partial class RotationConfigWindow : Window
                 {
                     ImGui.Separator();
                 }
-            }
+			}
             DrawDiagnosticInfoCube();
             ImGui.Spacing();
         }
@@ -1104,7 +1104,7 @@ public partial class RotationConfigWindow : Window
                         DrawAbout();
                         break;
 
-                    case RotationConfigWindowTab.Duty:
+                    case RotationConfigWindowTab.DutyRotation:
                         DrawDutyRotationBody();
                         break;
 
@@ -1148,7 +1148,11 @@ public partial class RotationConfigWindow : Window
                         DrawTarget();
                         break;
 
-                    case RotationConfigWindowTab.Extra:
+					case RotationConfigWindowTab.Duty:
+						DrawDutySpecific();
+						break;
+
+					case RotationConfigWindowTab.Extra:
                         DrawExtra();
                         break;
 
@@ -1179,9 +1183,15 @@ public partial class RotationConfigWindow : Window
             Configs.BasicAutoSwitch => $"Auto > {UiString.ConfigWindow_Basic_AutoSwitch.GetDescription()}",
             Configs.AutoActionUsage => $"Auto > {UiString.ConfigWindow_Auto_ActionUsage.GetDescription()}",
             Configs.HealingActionCondition => $"Auto > {UiString.ConfigWindow_Auto_HealingCondition.GetDescription()}",
-            Configs.PvPSpecificControls => $"Auto > {UiString.ConfigWindow_Auto_PvPSpecific.GetDescription()}",
+            Configs.DutySpecifcUltimate => $"Auto > {UiString.ConfigWindow_Duty_Ultimate.GetDescription()}",
+			Configs.DutySpecifcSavage => $"Auto > {UiString.ConfigWindow_Duty_Savage.GetDescription()}",
+			Configs.DutySpecifcExtreme => $"Auto > {UiString.ConfigWindow_Duty_Extreme.GetDescription()}",
+			Configs.DutySpecifcAlliance => $"Auto > {UiString.ConfigWindow_Duty_Alliance.GetDescription()}",
+			Configs.DutySpecifcDungeon => $"Auto > {UiString.ConfigWindow_Duty_Dungeon.GetDescription()}",
+			Configs.DutySpecifcFieldOps => $"Auto > {UiString.ConfigWindow_Duty_FieldOps.GetDescription()}",
+			Configs.DutySpecifcPvP => $"Auto > {UiString.ConfigWindow_Duty_PvP.GetDescription()}",
 
-            Configs.TargetConfig => $"Target > {UiString.ConfigWindow_Target_Config.GetDescription()}",
+			Configs.TargetConfig => $"Target > {UiString.ConfigWindow_Target_Config.GetDescription()}",
 
             Configs.Extra => $"Extra > {UiString.ConfigWindow_Extra_Others.GetDescription()}",
 
@@ -1229,12 +1239,36 @@ public partial class RotationConfigWindow : Window
                 _activeTab = RotationConfigWindowTab.Auto;
                 _autoHeader.OpenHeaderByTitle(UiString.ConfigWindow_Auto_HealingCondition.GetDescription());
                 break;
-            case Configs.PvPSpecificControls:
-                _activeTab = RotationConfigWindowTab.Auto;
-                _autoHeader.OpenHeaderByTitle(UiString.ConfigWindow_Auto_PvPSpecific.GetDescription());
+            case Configs.DutySpecifcUltimate:
+                _activeTab = RotationConfigWindowTab.Duty;
+                _autoHeader.OpenHeaderByTitle(UiString.ConfigWindow_Duty_Ultimate.GetDescription());
                 break;
+			case Configs.DutySpecifcSavage:
+				_activeTab = RotationConfigWindowTab.Duty;
+				_autoHeader.OpenHeaderByTitle(UiString.ConfigWindow_Duty_Savage.GetDescription());
+				break;
+			case Configs.DutySpecifcExtreme:
+				_activeTab = RotationConfigWindowTab.Duty;
+				_autoHeader.OpenHeaderByTitle(UiString.ConfigWindow_Duty_Extreme.GetDescription());
+				break;
+			case Configs.DutySpecifcAlliance:
+				_activeTab = RotationConfigWindowTab.Duty;
+				_autoHeader.OpenHeaderByTitle(UiString.ConfigWindow_Duty_Alliance.GetDescription());
+				break;
+			case Configs.DutySpecifcDungeon:
+				_activeTab = RotationConfigWindowTab.Duty;
+				_autoHeader.OpenHeaderByTitle(UiString.ConfigWindow_Duty_Dungeon.GetDescription());
+				break;
+			case Configs.DutySpecifcFieldOps:
+				_activeTab = RotationConfigWindowTab.Duty;
+				_autoHeader.OpenHeaderByTitle(UiString.ConfigWindow_Duty_FieldOps.GetDescription());
+				break;
+			case Configs.DutySpecifcPvP:
+				_activeTab = RotationConfigWindowTab.Duty;
+				_autoHeader.OpenHeaderByTitle(UiString.ConfigWindow_Duty_PvP.GetDescription());
+				break;
 
-            case Configs.TargetConfig:
+			case Configs.TargetConfig:
                 _activeTab = RotationConfigWindowTab.Target;
                 _targetHeader.OpenHeaderByTitle(UiString.ConfigWindow_Target_Config.GetDescription());
                 break;
@@ -1414,10 +1448,75 @@ public partial class RotationConfigWindow : Window
             ImGuiHelper.ReactPopup(key, command, Reset, false);
         }
     }
-    #endregion
+	#endregion
 
-    #region About
-    private static void DrawAbout()
+	#region DutySpecifc
+	private static void DrawDutySpecific()
+	{
+		_dutySpecificHeader?.Draw();
+	}
+
+	private static readonly CollapsingHeaderGroup _dutySpecificHeader = new(new Dictionary<Func<string>, Action>
+	{
+		{ UiString.ConfigWindow_Duty_Ultimate.GetDescription, DrawDutySpecificUltimate },
+		{ UiString.ConfigWindow_Duty_Savage.GetDescription, DrawDutySpecificSavage },
+		{ UiString.ConfigWindow_Duty_Extreme.GetDescription, DrawDutySpecifcExtreme },
+		{ UiString.ConfigWindow_Duty_ChaoticAlliance.GetDescription, DrawDutySpecifcChaoticAlliance },
+		{ UiString.ConfigWindow_Duty_Alliance.GetDescription, DrawDutySpecifcAlliance },
+		{ UiString.ConfigWindow_Duty_Dungeon.GetDescription, DrawDutySpecifcDungeon },
+		{ UiString.ConfigWindow_Duty_DeepDungeon.GetDescription, DrawDutySpecifcDeepDungeon },
+		{ UiString.ConfigWindow_Duty_VariantDungeon.GetDescription, DrawDutySpecifcVariantDungeon },
+		{ UiString.ConfigWindow_Duty_FieldOps.GetDescription, DrawDutySpecifcFieldOps },
+		{ UiString.ConfigWindow_Duty_PvP.GetDescription, DrawDutySpecifcPvP },
+	})
+	{
+		HeaderSize = HeaderSize,
+	};
+
+	private static void DrawDutySpecificUltimate()
+	{
+		_allSearchable.DrawItems(Configs.DutySpecifcUltimate);
+	}
+	private static void DrawDutySpecificSavage()
+	{
+		_allSearchable.DrawItems(Configs.DutySpecifcSavage);
+	}
+	private static void DrawDutySpecifcExtreme()
+	{
+		_allSearchable.DrawItems(Configs.DutySpecifcExtreme);
+	}
+	private static void DrawDutySpecifcChaoticAlliance()
+	{
+		_allSearchable.DrawItems(Configs.DutySpecifcChaoticAlliance);
+	}
+	private static void DrawDutySpecifcAlliance()
+	{
+		_allSearchable.DrawItems(Configs.DutySpecifcAlliance);
+	}
+	private static void DrawDutySpecifcDungeon()
+	{
+		_allSearchable.DrawItems(Configs.DutySpecifcDungeon);
+	}
+	private static void DrawDutySpecifcDeepDungeon()
+	{
+		_allSearchable.DrawItems(Configs.DutySpecifcDeepDungeon);
+	}
+	private static void DrawDutySpecifcVariantDungeon()
+	{
+		_allSearchable.DrawItems(Configs.DutySpecifcVariantDungeon);
+	}
+	private static void DrawDutySpecifcFieldOps()
+	{
+		_allSearchable.DrawItems(Configs.DutySpecifcFieldOps);
+	}
+	private static void DrawDutySpecifcPvP()
+	{
+		_allSearchable.DrawItems(Configs.DutySpecifcPvP);
+	}
+
+	#endregion
+	#region About
+	private static void DrawAbout()
     {
         // Draw the punchline with a specific font and color
         using (ImRaii.Font font = ImRaii.PushFont(FontManager.GetFont(18)))
@@ -1441,7 +1540,7 @@ public partial class RotationConfigWindow : Window
 
         ImGui.Spacing();
         float width2 = ImGui.GetWindowWidth();
-        if (IconSet.GetTexture("https://storage.ko-fi.com/cdn/brandasset/kofi_button_red.png", out Dalamud.Interface.Textures.TextureWraps.IDalamudTextureWrap? icon2) && ImGuiHelper.TextureButton(icon2, width2, 250 * Scale, "Ko-fi link"))
+        if (IconSet.GetTexture("https://storage.ko-fi.com/cdn/brandasset/kofi_button_red.png", out IDalamudTextureWrap? icon2) && ImGuiHelper.TextureButton(icon2, width2, 250 * Scale, "Ko-fi link"))
         {
             Util.OpenLink("https://ko-fi.com/ltscombatreborn");
         }

--- a/RotationSolver/UI/RotationConfigWindowTab.cs
+++ b/RotationSolver/UI/RotationConfigWindowTab.cs
@@ -35,7 +35,7 @@ internal enum RotationConfigWindowTab : byte
     [TabIcon(Icon = 4)] Job,
 
     [Description("Configure Duty Rotation.")]
-    [TabIcon(Icon = 4)] Duty,
+    [TabIcon(Icon = 4)] DutyRotation,
 
     [Description("Configure abilities and custom conditions for your current job.")]
     [TabIcon(Icon = 4)] Actions,
@@ -55,7 +55,10 @@ internal enum RotationConfigWindowTab : byte
     [Description("Configure targeting settings.")]
     [TabIcon(Icon = 16)] Target,
 
-    [Description("Configure optional helpful features.")]
+	[Description("Duty specific settings.")]
+	[TabIcon(Icon = 16)] Duty,
+
+	[Description("Configure optional helpful features.")]
     [TabIcon(Icon = 51)] Extra,
 
     [Description("Debug options for developers and rotation writers (disable when not in use).")]

--- a/RotationSolver/UI/RotationConfigWindow_Config.cs
+++ b/RotationSolver/UI/RotationConfigWindow_Config.cs
@@ -89,7 +89,6 @@ public partial class RotationConfigWindow
         { UiString.ConfigWindow_Basic_AutoSwitch.GetDescription, DrawBasicAutoSwitch },
         { UiString.ConfigWindow_Auto_ActionUsage.GetDescription, DrawActionUsageControl },
         { UiString.ConfigWindow_Auto_HealingCondition.GetDescription, DrawHealingActionCondition },
-        { UiString.ConfigWindow_Auto_PvPSpecific.GetDescription, DrawPvPSpecificControls },
     })
     {
         HeaderSize = HeaderSize,
@@ -98,13 +97,6 @@ public partial class RotationConfigWindow
     private static void DrawBasicAutoSwitch()
     {
         _allSearchable.DrawItems(Configs.BasicAutoSwitch);
-    }
-
-    private static void DrawPvPSpecificControls()
-    {
-        ImGui.TextWrapped(UiString.ConfigWindow_Auto_PvPSpecific.GetDescription());
-        ImGui.Separator();
-        _allSearchable.DrawItems(Configs.PvPSpecificControls);
     }
 
     /// <summary>

--- a/RotationSolver/Updaters/MajorUpdater.cs
+++ b/RotationSolver/Updaters/MajorUpdater.cs
@@ -137,7 +137,7 @@ internal static class MajorUpdater
         if (!_shouldRunThisCycle)
             return;
 
-        var autoOnEnabled = (Service.Config.StartOnAllianceIsInCombat2 
+        var autoOnEnabled = Service.Config.AutoOnYes && (Service.Config.StartOnAllianceIsInCombat2 
             || Service.Config.StartOnAttackedBySomeone2 
             || Service.Config.StartOnFieldOpInCombat2 
             || Service.Config.StartOnPartyIsInCombat2) && !DataCenter.IsInDutyReplay();

--- a/RotationSolver/packages.lock.json
+++ b/RotationSolver/packages.lock.json
@@ -16,9 +16,9 @@
       },
       "ECommons": {
         "type": "Direct",
-        "requested": "[3.1.0.15, )",
-        "resolved": "3.1.0.15",
-        "contentHash": "abmpVgmG8xBIG/+/IMsMEgj9p1T38ztQA9+QYL1c7HoIf47Fvlm33P1jt9V+o4NDwFg6eZigTkE5lc7EcLlyAQ=="
+        "requested": "[3.1.0.16, )",
+        "resolved": "3.1.0.16",
+        "contentHash": "wC2uvYyDLH77Wt1nmSAc4AyGVOKlPidN1qo+HslqA+HU69fiUX1JDIX2aRlDqd9thz1ALAnb+ojPBhbQSMbdCw=="
       },
       "Microsoft.CodeAnalysis.CSharp": {
         "type": "Direct",
@@ -79,7 +79,7 @@
       "RotationSolverReborn.Basic": {
         "type": "Project",
         "dependencies": {
-          "ECommons": "[3.1.0.15, )",
+          "ECommons": "[3.1.0.16, )",
           "Microsoft.CodeAnalysis.CSharp": "[5.0.0, )",
           "RotationSolver.SourceGenerators": "[1.0.0, )",
           "Svg": "[3.4.7, )",


### PR DESCRIPTION
Introduced a new "Duty Specific" section in the configuration UI, with filters and collapsible headers for various duty types (Ultimate, Savage, Extreme, Alliance, Dungeon, Field Ops, PvP, etc.). Added new config keys and options for encounter-specific logic (e.g., O12S Packet Filter, M8S Wolf Pack, M9S Cleave Only, M10S Firesnaking). Moved PvP options into this new section and removed the old PvPSpecificControls group.

Refactored ObjectHelper methods to respect new config options for encounter immunities and targeting, and added new helpers for additional mechanics. Updated UI strings for new duty types. Upgraded ECommons to 3.1.0.16. Performed minor code cleanups, fixed a BlueMageRotation array initialization, improved Soteria PvE logic, and adjusted StandardissueElixirPvP and auto-on logic.