### PR TITLE
refactor: Churin Rotations

### DIFF
--- a/RotationSolver/ExtraRotations/Melee/ChurinMNK.cs
+++ b/RotationSolver/ExtraRotations/Melee/ChurinMNK.cs
@@ -749,13 +749,13 @@ public sealed class ChurinMNK : MonkRotation
             if (BrotherhoodPvE.Cooldown.HasOneCharge &&
                 RiddleOfFirePvE.Cooldown.HasOneCharge)
             {
-                return PerfectBalancePvE.CanUse(out act, usedUp: false);
+                return PerfectBalancePvE.CanUse(out act, usedUp: false, skipTTKCheck:true);
             }
         }
 
         if (InBurst && !HasFiresRumination)
         {
-            return IsLastGCDOpo && PerfectBalancePvE.CanUse(out act, usedUp: true);
+            return IsLastGCDOpo && PerfectBalancePvE.CanUse(out act, usedUp: true, skipTTKCheck:true);
         }
 
         if (SolarOddWindow && IsLastGCDOpo && IsReadySoon(RiddleOfFirePvE, 2))
@@ -765,12 +765,12 @@ public sealed class ChurinMNK : MonkRotation
 
         if (LunarOddWindow && (HasRiddleOfFire || IsReadySoon(RiddleOfFirePvE, 0)) && !HasBothNadi)
         {
-            return  IsLastGCDOpo && PerfectBalancePvE.Cooldown.WillHaveOneCharge(10) && PerfectBalancePvE.CanUse(out act, usedUp: true);
+            return  IsLastGCDOpo && PerfectBalancePvE.Cooldown.WillHaveOneCharge(10) && PerfectBalancePvE.CanUse(out act, usedUp: true, skipTTKCheck:true);
         }
 
         if (IsReadySoon(BrotherhoodPvE, 2) && IsReadySoon(RiddleOfFirePvE,2))
         {
-                return IsLastGCDOpo && PerfectBalancePvE.CanUse(out act, usedUp: true);
+                return IsLastGCDOpo && PerfectBalancePvE.CanUse(out act, usedUp: true, skipTTKCheck:true);
         }
 
 


### PR DESCRIPTION
**ChurinDNC**
Refactors: AreDanceTargetsInRange simplified with LINQ; PartyMembers null check replaced; CanUseStandardBasedOnEsprit converted from method → property; new DisableStandardInBurstCheck property extracted; CanUseStepHoldCheck unified into a single switch expression.
Level-gating: EnoughLevel guards added to ShouldUseTechStep, ShouldUseStandardStep, ShouldUseFinishingMove, and TryUseFlourish.
Burst/GCD logic: IsSaberDancePrimed fully reworked with early returns, proper HasLastDance handling, Starfall status check, and medicated path. TryUseTillana now uses a GCD-count loop instead of a single charge check. TryUseSaberDance restructured with cleaner control flow. TryUseBasicGCD gains a high-esprit gate. Misplaced TryUseDevilment call removed from GeneralGCD. TryUseDevilment itself rewritten with correct guards.

**ChurinBRD**
CanEarlyWeave now prevents double-weaving via !HasWeaved(). Late weave window tightened to 45%. EnoughWeaveTime moved before its dependents. Debug status display improved.

**ChurinMNK**
All PerfectBalancePvE.CanUse(...) calls now pass skipTTKCheck: true to prevent burst windows from being skipped on low-HP targets.