### PR TITLE
Improve RDM/SGE action checks

### DIFF
--- a/RotationSolver.Basic/RotationSolver.Basic.csproj
+++ b/RotationSolver.Basic/RotationSolver.Basic.csproj
@@ -79,7 +79,7 @@
         <Using Include="Dalamud.Bindings.ImGui" />
         <Using Include="Newtonsoft.Json" />
 
-        <PackageReference Include="ECommons" Version="3.1.0.22" />
+        <PackageReference Include="ECommons" Version="3.1.0.26" />
 
         <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.0.0" />
 

--- a/RotationSolver.Basic/Rotations/Basic/RedMageRotation.cs
+++ b/RotationSolver.Basic/Rotations/Basic/RedMageRotation.cs
@@ -329,7 +329,8 @@ public partial class RedMageRotation
     static partial void ModifyJoltPvE(ref ActionSetting setting)
     {
         setting.StatusProvide = [StatusID.Dualcast];
-    }
+		setting.ActionCheck = () => !IsLastAction(ActionID.JoltPvE);
+	}
 
     static partial void ModifyVerthunderPvE(ref ActionSetting setting)
     {
@@ -451,8 +452,8 @@ public partial class RedMageRotation
 
     static partial void ModifyJoltIiPvE(ref ActionSetting setting)
     {
-        
-    }
+		setting.ActionCheck = () => !IsLastAction(ActionID.JoltIiPvE);
+	}
 
     static partial void ModifyVerraisePvE(ref ActionSetting setting)
     {
@@ -505,8 +506,8 @@ public partial class RedMageRotation
 
     static partial void ModifyJoltIiiPvE(ref ActionSetting setting)
     {
-
-    }
+		setting.ActionCheck = () => !IsLastAction(ActionID.JoltIiiPvE);
+	}
 
     static partial void ModifyMagickBarrierPvE(ref ActionSetting setting)
     {

--- a/RotationSolver.Basic/Rotations/Basic/SageRotation.cs
+++ b/RotationSolver.Basic/Rotations/Basic/SageRotation.cs
@@ -139,7 +139,7 @@ public partial class SageRotation
 
     static partial void ModifyEukrasiaPvE(ref ActionSetting setting)
     {
-        setting.ActionCheck = () => !HasEukrasia;
+        setting.ActionCheck = () => !IsLastAction(ActionID.EukrasiaPvE);
         setting.StatusProvide = [StatusID.Eukrasia];
         setting.IsFriendly = true;
         setting.CreateConfig = () => new ActionConfig()

--- a/RotationSolver.Basic/packages.lock.json
+++ b/RotationSolver.Basic/packages.lock.json
@@ -4,9 +4,9 @@
     "net10.0-windows10.0.26100": {
       "ECommons": {
         "type": "Direct",
-        "requested": "[3.1.0.22, )",
-        "resolved": "3.1.0.22",
-        "contentHash": "Ca11yUT35iPCTnlhSePNublOxLQJIt1dU8c1xwMwNFipDt2Bkl5geyl+ScQoJQAGv8C3rvdjGVfhtFXACQWpsQ=="
+        "requested": "[3.1.0.26, )",
+        "resolved": "3.1.0.26",
+        "contentHash": "U/8GcdAmMp7ARLie3U5LoEqWbSnWf16nziljwd78kHPqNgZdrUKUv6GMRgbIXzBUWPA4Ivy2K0rR9y/Y05tkiQ=="
       },
       "Microsoft.CodeAnalysis.CSharp": {
         "type": "Direct",

--- a/RotationSolver/RebornRotations/Healer/SGE_Reborn.cs
+++ b/RotationSolver/RebornRotations/Healer/SGE_Reborn.cs
@@ -460,7 +460,7 @@ public sealed class SGE_Reborn : SageRotation
         {
             _lastEukrasiaActionAim = _EukrasiaActionAim;
             _EukrasiaActionAim = null;
-            if (HasEukrasia && !InCombat)
+            if (HasEukrasia && !InCombat && !HasHostilesInMaxRange)
             {
                 StatusHelper.StatusOff(StatusID.Eukrasia);
             }

--- a/RotationSolver/RebornRotations/Magical/RDM_Reborn.cs
+++ b/RotationSolver/RebornRotations/Magical/RDM_Reborn.cs
@@ -45,7 +45,7 @@ public sealed class RDM_Reborn : RedMageRotation
         }
 
         //Remove Swift
-        if (HasDualcast && remainTime < 0f)
+        if (HasDualcast && remainTime < 0f && !InCombat)
         {
             StatusHelper.StatusOff(StatusID.Dualcast);
         }

--- a/RotationSolver/RotationSolver.csproj
+++ b/RotationSolver/RotationSolver.csproj
@@ -22,7 +22,7 @@
 
 	<ItemGroup>
 		<!-- Keep ECommons runtime so its DLL is included -->
-		<PackageReference Include="ECommons" Version="3.1.0.22" />
+		<PackageReference Include="ECommons" Version="3.1.0.26" />
 		<!-- Do not copy Roslyn runtime to output -->
 		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.0.0" PrivateAssets="all" ExcludeAssets="runtime" />
 	</ItemGroup>

--- a/RotationSolver/packages.lock.json
+++ b/RotationSolver/packages.lock.json
@@ -16,9 +16,9 @@
       },
       "ECommons": {
         "type": "Direct",
-        "requested": "[3.1.0.22, )",
-        "resolved": "3.1.0.22",
-        "contentHash": "Ca11yUT35iPCTnlhSePNublOxLQJIt1dU8c1xwMwNFipDt2Bkl5geyl+ScQoJQAGv8C3rvdjGVfhtFXACQWpsQ=="
+        "requested": "[3.1.0.26, )",
+        "resolved": "3.1.0.26",
+        "contentHash": "U/8GcdAmMp7ARLie3U5LoEqWbSnWf16nziljwd78kHPqNgZdrUKUv6GMRgbIXzBUWPA4Ivy2K0rR9y/Y05tkiQ=="
       },
       "Microsoft.CodeAnalysis.CSharp": {
         "type": "Direct",
@@ -79,7 +79,7 @@
       "RotationSolverReborn.Basic": {
         "type": "Project",
         "dependencies": {
-          "ECommons": "[3.1.0.22, )",
+          "ECommons": "[3.1.0.26, )",
           "Microsoft.CodeAnalysis.CSharp": "[5.0.0, )",
           "RotationSolver.SourceGenerators": "[1.0.0, )",
           "Svg": "[3.4.7, )",


### PR DESCRIPTION
Updated ECommons to 3.1.0.26 in project and lock files. Refined ActionCheck logic for RDM Jolt/Jolt II/Jolt III and SGE Eukrasia to prevent repeat suggestions. Improved status removal logic for Eukrasia and Dualcast to only occur out of combat and when appropriate. These changes enhance rotation robustness and context awareness.