### PR TITLE
Change ActionCheck condition for SamuraiRotation

### DIFF
--- a/RotationSolver.Basic/Rotations/Basic/SamuraiRotation.cs
+++ b/RotationSolver.Basic/Rotations/Basic/SamuraiRotation.cs
@@ -386,7 +386,7 @@ public partial class SamuraiRotation
 static partial void ModifyIkishotenPvE(ref ActionSetting setting)
     {
         setting.StatusProvide = [StatusID.OgiNamikiriReady, StatusID.ZanshinReady];
-        setting.ActionCheck = () => InCombat && Kenki >= 50;
+        setting.ActionCheck = () => InCombat && Kenki <= 50;
         setting.IsFriendly = true;
     }
 


### PR DESCRIPTION
Kenki is not required to use IkishotenPvE.
It only increases Kenki by +50.
This was the reason why IkishotenPvE was not used as much as it should have been.