### PR TITLE
Add teaching mode auto-target and target hint options

### DIFF
--- a/RotationSolver.Basic/Configuration/Configs.cs
+++ b/RotationSolver.Basic/Configuration/Configs.cs
@@ -419,6 +419,16 @@ internal partial class Configs : IPluginConfiguration
 	[ConditionBool, UI("Teaching mode", Filter = UiInformation)]
 	private static readonly bool _teachingMode = false;
 
+	[ConditionBool, UI("Auto-target in teaching mode while in combat",
+		Description = "When teaching mode is active, automatically switch your target to match the rotation's suggested action target. Useful for tanks and healers where the optimal target may differ from your current selection.",
+		Parent = nameof(TeachingMode))]
+	private static readonly bool _teachingModeAutoTarget = false;
+
+	[ConditionBool, UI("Show target hint in Next Action window",
+		Description = "When teaching mode is active, display the rotation's suggested target name below the Next Action icon. Shown in orange if you don't have that target selected, green if you do.",
+		Parent = nameof(TeachingMode))]
+	private static readonly bool _teachingModeShowTargetHint = false;
+
 	[ConditionBool, UI("Simulate the effect of pressing abilities",
 		Filter = UiInformation)]
 	private static readonly bool _keyboardNoise = true;

--- a/RotationSolver/UI/NextActionWindow.cs
+++ b/RotationSolver/UI/NextActionWindow.cs
@@ -1,5 +1,6 @@
 ﻿using Dalamud.Interface.Colors;
 using Dalamud.Interface.Windowing;
+using ECommons.DalamudServices;
 using ECommons.GameHelpers;
 using FFXIVClientStructs.FFXIV.Client.Game;
 using RotationSolver.Updaters;
@@ -79,9 +80,63 @@ internal class NextActionWindow : Window
 		}
 
 		_ = ControlWindow.DrawIAction(ActionUpdater.NextAction, width, percent);
+
+		// Teaching Mode: show a target hint if the rotation wants a different target
+		if (Service.Config.TeachingMode && Service.Config.TeachingModeShowTargetHint)
+		{
+			DrawTeachingModeTargetHint(width);
+		}
 	}
 
-	public static unsafe void DrawGcdCooldown(float width, bool drawTitle)
+	private static void DrawTeachingModeTargetHint(float width)
+	{
+		IBattleChara? suggestedTarget = null;
+		if (ActionUpdater.NextAction is BaseAction baseAct)
+		{
+			suggestedTarget = baseAct.Target.Target;
+		}
+
+		if (suggestedTarget == null)
+		{
+			return;
+		}
+
+		string name = suggestedTarget.Name.TextValue;
+		if (string.IsNullOrEmpty(name))
+		{
+			return;
+		}
+
+		bool isCurrentTarget = Svc.Targets.Target?.GameObjectId == suggestedTarget.GameObjectId;
+		bool isSelf = suggestedTarget.GameObjectId == (Player.Object?.GameObjectId ?? 0);
+
+		string label = $"Target: {name}";
+		Vector4 color = isSelf
+			? ImGuiColors.DalamudWhite
+			: isCurrentTarget
+				? ImGuiColors.HealerGreen
+				: ImGuiColors.DalamudOrange;
+
+		float textWidth = ImGui.CalcTextSize(label).X;
+		float offsetX = (width - textWidth) / 2f;
+		ImGui.SetCursorPosX(ImGui.GetCursorPosX() + Math.Max(0, offsetX));
+
+		ImGui.PushStyleColor(ImGuiCol.Text, color);
+		ImGui.Selectable(label, false, ImGuiSelectableFlags.None, new Vector2(textWidth, 0));
+		ImGui.PopStyleColor();
+
+		if (ImGui.IsItemClicked() && !isSelf)
+		{
+			Svc.Targets.Target = suggestedTarget;
+		}
+
+		if (ImGui.IsItemHovered() && !isSelf)
+		{
+			ImGui.SetTooltip("Click to target");
+		}
+	}
+
+	public static void DrawGcdCooldown(float width, bool drawTitle)
 	{
 		float remain = DataCenter.DefaultGCDRemain;
 		float total = DataCenter.DefaultGCDTotal;

--- a/RotationSolver/Updaters/MajorUpdater.cs
+++ b/RotationSolver/Updaters/MajorUpdater.cs
@@ -181,6 +181,13 @@ internal static class MajorUpdater
 				RSCommands.UpdateTargetFromNextAction();
 			}
 
+			// In Teaching Mode with auto-target enabled, also update the player's target so it matches
+			// the rotation's suggestion (important for tanks/healers where the optimal target varies).
+			if (!DataCenter.IsTargetOnly && Service.Config.TeachingMode && Service.Config.TeachingModeAutoTarget && DataCenter.InCombat)
+			{
+				RSCommands.UpdateTargetFromNextAction();
+			}
+
 			Wrath_IPCSubscriber.DisableAutoRotation();
 		}
 		catch (Exception ex)


### PR DESCRIPTION
Introduce config options for teaching mode: auto-targeting to match rotation suggestions during combat, and a target hint in the Next Action window. The hint displays the suggested target's name, color-coded by selection status, and allows clicking to switch targets. Auto-targeting logic is integrated into the main update loop.