### PR TITLE
Various fixes to BLU

### DIFF
--- a/RotationSolver.Basic/Actions/ActionSetting.cs
+++ b/RotationSolver.Basic/Actions/ActionSetting.cs
@@ -180,6 +180,11 @@ public class ActionSetting
 	public bool IsParalysisSpell { get; set; } = false;
 
 	/// <summary>
+	/// Does this action care about the Interrupt check on masked carnivale mobs.
+	/// </summary>
+	public bool IsInterruptSpell { get; set; } = false;
+
+	/// <summary>
 	/// Does this action primarily apply <b>Blind</b>? When true, it is skipped against mobs not vulnerable to Blind in the Masked Carnivale.
 	/// </summary>
 	public bool IsBlindSpell { get; set; } = false;

--- a/RotationSolver.Basic/Actions/ActionTargetInfo.cs
+++ b/RotationSolver.Basic/Actions/ActionTargetInfo.cs
@@ -393,6 +393,13 @@ public struct ActionTargetInfo(IBaseAction action)
 				return false;
 			}
 
+			if (Service.Config.BlockinterruptimmuneBlu && action.Setting.IsInterruptSpell
+			&& !MaskedCarnivaleHelper.IsVulnerableToInterruption(battleChara))
+			{
+				if (Service.Config.InDebug) PluginLog.Debug($"[CheckResistance] {battleChara.Name} is not vulnerable to interruption — skipping {action.Info.Name}.");
+				return false;
+			}
+
 			if (Service.Config.BlockblindimmuneBlu && action.Setting.IsBlindSpell
 				&& !MaskedCarnivaleHelper.IsVulnerableToBlind(battleChara))
 			{
@@ -428,13 +435,14 @@ public struct ActionTargetInfo(IBaseAction action)
 				return false;
 			}
 
+			if (Service.Config.BlockimmuneBlu && !MaskedCarnivaleHelper.IsActionAspectAllowed(battleChara, action))
+			{
+				if (Service.Config.InDebug) PluginLog.Debug($"[CheckResistance] {battleChara.Name} is immune to action {action.Info.Name} aspect (BlockimmuneBLU).");
+				return false;
+			}
+
 			if (Service.Config.BlocknonweakBlu && !MaskedCarnivaleHelper.HasNoResistancesOrImmunities(battleChara))
 			{
-				if (Service.Config.BlockimmuneBlu && !MaskedCarnivaleHelper.IsActionAspectAllowed(battleChara, action))
-				{
-					if (Service.Config.InDebug) PluginLog.Debug($"[CheckResistance] {battleChara.Name} is immune to action {action.Info.Name} aspect (BlockimmuneBLU).");
-					return false;
-				}
 
 				// shouldCheckWeakness is true if the action has at least one non-unaspected aspect
 				// (or any aspect when AllowunaspectedBlu is off).

--- a/RotationSolver.Basic/Configuration/Configs.cs
+++ b/RotationSolver.Basic/Configuration/Configs.cs
@@ -68,6 +68,9 @@ internal partial class Configs : IPluginConfiguration
 	[ConditionBool, UI("Prevent specific Paralysis actions from being used against mobs that are immune to those effects.", Filter = DutySpecifcTheMaskedCarnivale)]
 	private static readonly bool _blockparalysisimmuneBLU = false;
 
+	[ConditionBool, UI("Prevent specific Interrupt actions from being used against mobs that are immune to those effects.", Filter = DutySpecifcTheMaskedCarnivale)]
+	private static readonly bool _blockinterruptimmuneBLU = false;
+
 	[ConditionBool, UI("Prevent specific Blind actions from being used against mobs that are immune to those effects.", Filter = DutySpecifcTheMaskedCarnivale)]
 	private static readonly bool _blockblindimmuneBLU = false;
 
@@ -87,7 +90,7 @@ internal partial class Configs : IPluginConfiguration
 	private static readonly bool _blockimmuneBLU = true;
 
 	[ConditionBool, UI("If a mob is weak to a specific aspect, only use actions of that aspect.", Filter = DutySpecifcTheMaskedCarnivale)]
-	private static readonly bool _blocknonweakBLU = true;
+	private static readonly bool _blocknonweakBLU = false;
 
 	[ConditionBool, UI("Still allow unaspected actions.", Filter = DutySpecifcTheMaskedCarnivale, Parent = nameof(BlocknonweakBlu))]
 	private static readonly bool _allowunaspectedBLU = true;

--- a/RotationSolver.Basic/Rotations/Basic/BlueMageRotation.cs
+++ b/RotationSolver.Basic/Rotations/Basic/BlueMageRotation.cs
@@ -310,6 +310,7 @@ public partial class BlueMageRotation
 		//setting.TargetType = TargetType.Interrupt;
 		setting.AttackTypeOverride = AttackType.Physical;
 		setting.AspectOverride = Aspect.Piercing;
+		setting.IsInterruptSpell = true;
 	}
 
 	static partial void ModifySnortPvE(ref ActionSetting setting)
@@ -317,9 +318,27 @@ public partial class BlueMageRotation
 		setting.AttackTypeOverride = AttackType.Magic;
 		setting.AspectOverride = Aspect.Wind;
 		setting.IsFriendly = false;
+		setting.IsInterruptSpell = true;
 		setting.CreateConfig = () => new ActionConfig()
 		{
 			AoeCount = 1,
+		};
+		setting.ActionCheck = () =>
+		{
+			if (Player == null) return false;
+			var playerFace = Player.GetFaceVector();
+			var playerPos = Player.Position;
+			const float snortRange = 6f;
+			const double coneHalfAngle = Math.PI / 4; // 45 degrees each side = 90 degree cone
+			foreach (var target in DataCenter.AllHostileTargets)
+			{
+				if (!target.CanInterrupt()) continue;
+				if (target.DistanceToPlayer() > snortRange) continue;
+				var dir = Vector3.Normalize(target.Position - playerPos);
+				var angle = playerFace.AngleTo(dir);
+				if (angle <= coneHalfAngle) return true;
+			}
+			return false;
 		};
 	}
 

--- a/RotationSolver.Basic/Rotations/CustomRotation_GCD.cs
+++ b/RotationSolver.Basic/Rotations/CustomRotation_GCD.cs
@@ -71,7 +71,7 @@ public partial class CustomRotation
 				return act;
 			}
 
-			if (DataCenter.CommandStatus.HasFlag(AutoStatus.Interrupt))
+			if (DataCenter.MergedStatus.HasFlag(AutoStatus.Interrupt))
 			{
 				if (DataCenter.CurrentDutyRotation?.MyInterruptGCD(out act) == true)
 				{

--- a/RotationSolver/RebornRotations/Limited Jobs/BLU_Reborn.cs
+++ b/RotationSolver/RebornRotations/Limited Jobs/BLU_Reborn.cs
@@ -280,7 +280,7 @@ public sealed class BLU_Reborn : BlueMageRotation
 
 		if (UseSnort)
 		{
-			if (SnortPvE.CanUse(out act, targetOverride: TargetType.Interrupt))
+			if (SnortPvE.CanUse(out act))
 			{
 				return true;
 			}

--- a/RotationSolver/UI/SearchableConfigs/Searchable.cs
+++ b/RotationSolver/UI/SearchableConfigs/Searchable.cs
@@ -52,6 +52,10 @@ internal readonly struct JobFilter
 					JobRole.Melee,
 					JobRole.RangedPhysical,
 				];
+				Jobs =
+				[
+					Job.BLU,
+				];
 				break;
 
 			case JobFilterType.Dispel:


### PR DESCRIPTION
Introduce IsInterruptSpell to ActionSetting and BlockinterruptimmuneBlu config to skip interrupt actions on immune mobs in Masked Carnivale. Update ActionTargetInfo and BlueMageRotation for new logic, including custom Snort targeting. Refactor BlockimmuneBlu/BlocknonweakBlu checks and use MergedStatus for interrupts. Add BLU to relevant JobFilterType.