### PR TITLE
BLU rotation fixes and various misc

### DIFF
--- a/RotationSolver.Basic/Actions/ActionTargetInfo.cs
+++ b/RotationSolver.Basic/Actions/ActionTargetInfo.cs
@@ -363,7 +363,7 @@ public struct ActionTargetInfo(IBaseAction action)
 			return false;
 		}
 
-		if (DataCenter.IsInMaskedCarnivale)
+		if (DataCenter.Job == Job.BLU && DataCenter.IsInMaskedCarnivale)
 		{
 			if (Service.Config.BlockflatdamagedeathimmuneBlu && action.Setting.IsFlatDamageDeath
 			&& !MaskedCarnivaleHelper.IsVulnerableToFlatOrDeath(battleChara))

--- a/RotationSolver.Basic/DataCenter.cs
+++ b/RotationSolver.Basic/DataCenter.cs
@@ -1122,7 +1122,6 @@ internal static class DataCenter
 
 	internal static void ResetAllRecords()
 	{
-		PluginLog.Information("Resetting all action and damage records.");
 		LastAction = 0;
 		LastGCD = 0;
 		LastAbility = 0;

--- a/RotationSolver.Basic/Rotations/Basic/BardRotation.cs
+++ b/RotationSolver.Basic/Rotations/Basic/BardRotation.cs
@@ -379,7 +379,15 @@ public partial class BardRotation
 
 	static partial void ModifyRadiantFinalePvE(ref ActionSetting setting)
 	{
-		setting.ActionCheck = () => JobGauge.Coda.Any(s => s != Song.None);
+		setting.ActionCheck = () =>
+		{
+			var coda = JobGauge.Coda;
+			for (int i = 0; i < coda.Length; i++)
+			{
+				if (coda[i] != Song.None) return true;
+			}
+			return false;
+		};
 		setting.StatusProvide = [StatusID.RadiantFinale_2964, StatusID.RadiantEncoreReady];
 		setting.StatusFromSelf = false;
 		setting.TargetType = TargetType.Self;

--- a/RotationSolver.Basic/Rotations/Basic/BlueMageRotation.cs
+++ b/RotationSolver.Basic/Rotations/Basic/BlueMageRotation.cs
@@ -1139,6 +1139,19 @@ public partial class BlueMageRotation
 		};
 	}
 
+	static partial void ModifyPhantomFlurryPvE_23289(ref ActionSetting setting)
+	{
+		setting.AttackTypeOverride = AttackType.Physical;
+		setting.AspectOverride = Aspect.Blunt;
+		setting.IsFriendly = false;
+		setting.ActionCheck = () => !IsMoving;
+		setting.StatusNeed = [StatusID.PhantomFlurry];
+		setting.CreateConfig = () => new ActionConfig()
+		{
+			AoeCount = 1,
+		};
+	}
+
 	static partial void ModifyNightbloomPvE(ref ActionSetting setting)
 	{
 		setting.AttackTypeOverride = AttackType.Magic;

--- a/RotationSolver/RebornRotations/Limited Jobs/BLU_Reborn.cs
+++ b/RotationSolver/RebornRotations/Limited Jobs/BLU_Reborn.cs
@@ -114,6 +114,21 @@ public sealed class BLU_Reborn : BlueMageRotation
 			}
 		}
 
+		if (SeaShantyPvE.CanUse(out act))
+		{
+			return true;
+		}
+
+		if (PhantomFlurryPvE_23289.CanUse(out act) && StatusHelper.PlayerWillStatusEnd(1, true, StatusID.PhantomFlurry))
+		{
+			return true;
+		}
+
+		if (PhantomFlurryPvE.CanUse(out act))
+		{
+			return true;
+		}
+
 		if (FeatherRainPvE.CanUse(out act))
 		{
 			return true;

--- a/RotationSolver/RebornRotations/Melee/DRG_Reborn.cs
+++ b/RotationSolver/RebornRotations/Melee/DRG_Reborn.cs
@@ -13,6 +13,12 @@ public sealed class DRG_Reborn : DragoonRotation
 	[RotationConfig(CombatType.PvE, Name = "Max distance you need to be from the target for Stardiver useage")]
 	public float StardiverDistance { get; set; } = 20;
 
+	[RotationConfig(CombatType.PvE, Name = "Use Stardiver while moving")]
+	public bool StardiverMoving { get; set; } = true;
+
+	[RotationConfig(CombatType.PvE, Name = "Use Dragonfire Dive while moving")]
+	public bool DragonfireDiveMoving { get; set; } = true;
+
 	[Range(1, 20, ConfigUnitType.Yalms)]
 	[RotationConfig(CombatType.PvE, Name = "Max distance you need to be from the target for Dragonfire Dive useage")]
 	public float DragonfireDiveDistance { get; set; } = 20;
@@ -69,7 +75,7 @@ public sealed class DRG_Reborn : DragoonRotation
 	#region oGCD Logic
 	protected override bool EmergencyAbility(IAction nextGCD, out IAction? act)
 	{
-		if (IsLastAction() == IsLastGCD())
+		if (IsLastAction() == IsLastGCD() && (StardiverMoving || (!StardiverMoving && !IsMoving)))
 		{
 			if (StardiverPvE.CanUse(out act))
 			{
@@ -150,7 +156,7 @@ public sealed class DRG_Reborn : DragoonRotation
 
 		if ((BattleLitanyPvE.EnoughLevel && HasBattleLitany) || (!BattleLitanyPvE.EnoughLevel))
 		{
-			if (DragonfireDivePvE.CanUse(out act))
+			if ((DragonfireDiveMoving || (!DragonfireDiveMoving && !IsMoving)) && DragonfireDivePvE.CanUse(out act))
 			{
 				if (DragonfireDivePvE.Target.Target.DistanceToPlayer() <= DragonfireDiveDistance)
 				{

--- a/RotationSolver/RebornRotations/PVPRotations/Ranged/MCH_Default.PvP.cs
+++ b/RotationSolver/RebornRotations/PVPRotations/Ranged/MCH_Default.PvP.cs
@@ -26,9 +26,9 @@ public sealed class MCH_DefaultPvP : MachinistRotation
 
 	protected override bool AttackAbility(IAction nextGCD, out IAction? action)
 	{
-		if (AnalysisPvP.CanUse(out action, usedUp: true))
+		if (nextGCD.IsTheSameTo(false, ActionID.DrillPvP, ActionID.BioblasterPvP, ActionID.AirAnchorPvP, ActionID.ChainSawPvP))
 		{
-			if (nextGCD.IsTheSameTo(false, ActionID.DrillPvP, ActionID.BioblasterPvP, ActionID.AirAnchorPvP, ActionID.ChainSawPvP))
+			if (AnalysisPvP.CanUse(out action, usedUp: true))
 			{
 				return true;
 			}

--- a/RotationSolver/RebornRotations/Tank/WAR_Reborn.cs
+++ b/RotationSolver/RebornRotations/Tank/WAR_Reborn.cs
@@ -144,7 +144,9 @@ public sealed class WAR_Reborn : WarriorRotation
 
 	protected override bool GeneralAbility(IAction nextGCD, out IAction? act)
 	{
-		if ((InCombat && Player?.GetHealthRatio() < HealIntuition && NumberOfHostilesInRange > 0) || (InCombat && PartyMembers.Count() is 1 && NumberOfHostilesInRange > 0))
+		int _partyCount = 0;
+		foreach (var _ in PartyMembers) _partyCount++;
+		if ((InCombat && Player?.GetHealthRatio() < HealIntuition && NumberOfHostilesInRange > 0) || (InCombat && _partyCount == 1 && NumberOfHostilesInRange > 0))
 		{
 			if (BloodwhettingPvE.CanUse(out act))
 			{

--- a/RotationSolver/UI/EasterEggWindow.cs
+++ b/RotationSolver/UI/EasterEggWindow.cs
@@ -272,7 +272,14 @@ internal class EasterEggWindow : Window
 		return (false, 0);
 	}
 
-	private static bool IsDraw(Cell[] board) => !board.Any(c => c == Cell.Empty);
+	private static bool IsDraw(Cell[] board)
+	{
+		for (int i = 0; i < board.Length; i++)
+		{
+			if (board[i] == Cell.Empty) return false;
+		}
+		return true;
+	}
 
 	private static bool CheckWin(Cell[] board, Cell who)
 	{

--- a/RotationSolver/UI/RotationConfigWindow.cs
+++ b/RotationSolver/UI/RotationConfigWindow.cs
@@ -1959,8 +1959,14 @@ public partial class RotationConfigWindow : Window
 		];
 
 		// Check if "Boss Mod" and "BossMod Reborn" are enabled
-		bool isBossModEnabled = pluginsToCheck.Any(plugin => plugin.Name == "Boss Mod" && plugin.IsEnabled);
-		bool isBossModRebornEnabled = pluginsToCheck.Any(plugin => plugin.Name == "BossModReborn" && plugin.IsEnabled);
+		bool isBossModEnabled = false;
+		bool isBossModRebornEnabled = false;
+		foreach (var plugin in pluginsToCheck)
+		{
+			if (plugin.Name == "Boss Mod" && plugin.IsEnabled) isBossModEnabled = true;
+			if (plugin.Name == "BossModReborn" && plugin.IsEnabled) isBossModRebornEnabled = true;
+			if (isBossModEnabled && isBossModRebornEnabled) break;
+		}
 
 		// Iterate through the list and check if each plugin is installed and enabled
 		foreach (AutoDutyPlugin plugin in pluginsToCheck)

--- a/RotationSolver/Updaters/MajorUpdater.cs
+++ b/RotationSolver/Updaters/MajorUpdater.cs
@@ -21,6 +21,12 @@ internal static class MajorUpdater
 	private static bool _isActivatedThisCycle;
 	private static bool _rotationsLoaded;
 
+	// Cached GeneralAction sheet lookup (RowId -> GeneralAction RowId) for teaching mode highlighting
+	private static Dictionary<uint, uint>? _generalActionLookup;
+
+	// Reusable list for VFX cleanup to avoid per-frame allocations
+	private static readonly List<VfxNewData> _vfxRemaining = [];
+
 	public static bool IsValid
 	{
 		get
@@ -146,14 +152,13 @@ internal static class MajorUpdater
 
 		try
 		{
-			if (autoOnEnabled)
+			// Only call UpdateTargets once — cover both the auto-on check and the activated path
+			if (autoOnEnabled || _isActivatedThisCycle)
 			{
 				TargetUpdater.UpdateTargets();
 			}
 			if (!_isActivatedThisCycle)
 				return;
-
-			TargetUpdater.UpdateTargets();
 
 			// Target updater always needs to be first to update
 			MacroUpdater.UpdateMacro();
@@ -299,7 +304,7 @@ internal static class MajorUpdater
 				// That could leave finished entries behind if an unfinished entry was at the front.
 				// To reliably remove finished VFX entries, drain the queue and re-enqueue only
 				// the unfinished items.
-				var remaining = new List<VfxNewData>();
+				_vfxRemaining.Clear();
 				while (DataCenter.VfxDataQueue.TryDequeue(out var vfx))
 				{
 					try
@@ -311,24 +316,24 @@ internal static class MajorUpdater
 						if (vfx.Duration >= 0.5f)
 						{
 							if (vfx.TimeDuration.TotalSeconds <= vfx.Duration)
-								remaining.Add(vfx);
+								_vfxRemaining.Add(vfx);
 						}
 						else
 						{
 							// Unknown / very short duration: keep for up to 5 seconds by default
 							if (vfx.TimeDuration.TotalSeconds <= 5.0)
-								remaining.Add(vfx);
+								_vfxRemaining.Add(vfx);
 						}
 					}
 					catch
 					{
 						// On any unexpected error, keep the item to avoid data loss
-						remaining.Add(vfx);
+						_vfxRemaining.Add(vfx);
 					}
 				}
 
 				// Re-enqueue items that are still active
-				foreach (var item in remaining)
+				foreach (var item in _vfxRemaining)
 				{
 					DataCenter.VfxDataQueue.Enqueue(item);
 				}
@@ -410,12 +415,11 @@ internal static class MajorUpdater
 							{
 								Svc.Targets.Target = closestEnemy;
 							}
-							// Respect TargetDelay before auto-targeting the closest enemy
-							if (Service.Config.TargetDelayEnable)
+							else
 							{
+								// Respect TargetDelay before auto-targeting the closest enemy
 								RSCommands.SetTargetWithDelay(closestEnemy);
 							}
-							PluginLog.Information($"Targeting {closestEnemy}");
 						}
 					}
 				}
@@ -437,21 +441,25 @@ internal static class MajorUpdater
 
 	private static HotbarID? GetGeneralActionHotbarID(IBaseAction baseAction)
 	{
-		Lumina.Excel.ExcelSheet<GeneralAction> generalActions = Svc.Data.GetExcelSheet<GeneralAction>();
-		if (generalActions == null)
+		// Build the lookup once and cache it to avoid a full sheet scan every frame
+		if (_generalActionLookup == null)
 		{
-			return null;
-		}
+			var sheet = Svc.Data.GetExcelSheet<GeneralAction>();
+			if (sheet == null)
+				return null;
 
-		foreach (GeneralAction gAct in generalActions)
-		{
-			if (gAct.Action.RowId == baseAction.ID)
+			_generalActionLookup = [];
+			foreach (GeneralAction gAct in sheet)
 			{
-				return new HotbarID(HotbarSlotType.GeneralAction, gAct.RowId);
+				var actionRowId = gAct.Action.RowId;
+				if (actionRowId != 0)
+					_generalActionLookup.TryAdd(actionRowId, gAct.RowId);
 			}
 		}
 
-		return null;
+		return _generalActionLookup.TryGetValue(baseAction.ID, out uint generalActionRowId)
+			? new HotbarID(HotbarSlotType.GeneralAction, generalActionRowId)
+			: null;
 	}
 
 	private static void LogOnce(string context, Exception ex)


### PR DESCRIPTION
- Replaced LINQ Any() with explicit loops for efficiency in several places.
- Added DRG_Reborn config for Stardiver/Dragonfire Dive while moving and updated logic.
- Added Phantom Flurry (23289) support to BlueMageRotation and BLU_Reborn.
- Scoped ActionTargetInfo checks to BLU in Masked Carnivale.
- Cached GeneralAction hotbar lookup in MajorUpdater.
- Reused static list for VFX cleanup to reduce allocations.
- Refined target selection and party count logic.
- Minor code cleanup and improved debug logging.