### PR TITLE
Add territory checks for potion use and content detection

### DIFF
--- a/RotationSolver.Basic/DataCenter.cs
+++ b/RotationSolver.Basic/DataCenter.cs
@@ -586,6 +586,47 @@ internal static class DataCenter
 	#endregion
 
 	#region Misc Duty Info
+
+	/// <summary>
+	///
+	/// </summary>
+	public static bool IsInEurekaFieldOp => Territory?.ContentType == TerritoryContentType.Eureka;
+
+	/// <summary>
+	///
+	/// </summary>
+	public static bool IsInDeepDungeons => Territory?.ContentType == TerritoryContentType.DeepDungeons;
+
+	/// <summary>
+	/// 
+	/// </summary>
+	public static bool IsInPilgrimsTraverse => IsInTerritory(1281) 
+	|| IsInTerritory(1282) || IsInTerritory(1283) 
+	|| IsInTerritory(1284) || IsInTerritory(1285) 
+	|| IsInTerritory(1286) || IsInTerritory(1287) 
+	|| IsInTerritory(1288) || IsInTerritory(1289) 
+	|| IsInTerritory(1290);
+
+	/// <summary>
+	/// 
+	/// </summary>
+	public static bool IsInPalaceOfTheDead => IsInTerritory(561)
+	|| IsInTerritory(562) || IsInTerritory(563)
+	|| IsInTerritory(564) || IsInTerritory(565)
+	|| IsInTerritory(593) || IsInTerritory(594)
+	|| IsInTerritory(595) || IsInTerritory(596)
+	|| IsInTerritory(597) || IsInTerritory(598)
+	|| IsInTerritory(599) || IsInTerritory(600)
+	|| IsInTerritory(601) || IsInTerritory(602)
+	|| IsInTerritory(603) || IsInTerritory(604)
+	|| IsInTerritory(605) || IsInTerritory(606)
+	|| IsInTerritory(607);
+
+	/// <summary>
+	/// 
+	/// </summary>
+	public static bool IsInTheFinalVerse => IsInTerritory(1311) || IsInTerritory(1333);
+
 	/// <summary>
 	/// Determines if the current content is a Monster Hunter duty
 	/// </summary>

--- a/RotationSolver.Basic/Rotations/CustomRotation_Items.cs
+++ b/RotationSolver.Basic/Rotations/CustomRotation_Items.cs
@@ -235,8 +235,31 @@ public partial class CustomRotation
 		HpPotionItem? best = null;
 		foreach (var a in HpPotions)
 		{
-			bool isDeepDungeons = DataCenter.Territory?.ContentType == TerritoryContentType.DeepDungeons;
-			if (a.CanUse(out _, true) && (a.ID != 47102 || (a.ID == 47102 && isDeepDungeons) || (a.ID == 20309 && isDeepDungeons && !StatusHelper.PlayerHasStatus(false, StatusID.Rehabilitation_648))))
+			if (a.ID != 47102 && a.ID != 22306 && a.ID != 20309 && a.CanUse(out _, true))
+			{
+				if (best == null || a.MaxHp >= best.MaxHp)
+				{
+					best = a;
+				}
+			}
+
+			if ((DataCenter.IsInPilgrimsTraverse || DataCenter.IsInTheFinalVerse) && a.ID == 47102 && a.CanUse(out _, true) && !StatusHelper.PlayerHasStatus(false, StatusID.Rehabilitation_4191))
+			{
+				if (best == null || a.MaxHp >= best.MaxHp)
+				{
+					best = a;
+				}
+			}
+
+			if (DataCenter.IsInEurekaFieldOp && a.ID == 22306 && !StatusHelper.PlayerHasStatus(false, StatusID.Rehabilitation_648) && a.CanUse(out _, true))
+			{
+				if (best == null || a.MaxHp >= best.MaxHp)
+				{
+					best = a;
+				}
+			}
+
+			if (DataCenter.IsInPalaceOfTheDead && a.ID == 20309 && !StatusHelper.PlayerHasStatus(false, StatusID.Rehabilitation_648) && a.CanUse(out _, true))
 			{
 				if (best == null || a.MaxHp >= best.MaxHp)
 				{


### PR DESCRIPTION
Added new DataCenter properties for content/territory detection (Eureka, Deep Dungeons, Pilgrim's Traverse, Palace of the Dead, The Final Verse). Refactored UseHpPotion logic to select potions based on these properties for improved context-aware item usage.