### PR TITLE
ECommons/Lumina fixes

### DIFF
--- a/RotationSolver.Basic/RotationSolver.Basic.csproj
+++ b/RotationSolver.Basic/RotationSolver.Basic.csproj
@@ -79,7 +79,7 @@
         <Using Include="Dalamud.Bindings.ImGui" />
         <Using Include="Newtonsoft.Json" />
 
-        <PackageReference Include="ECommons" Version="3.2.0.6" />
+        <PackageReference Include="ECommons" Version="3.2.0.9" />
 
         <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.3.0" />
 

--- a/RotationSolver.Basic/Rotations/Basic/BeastmasterRotation.cs
+++ b/RotationSolver.Basic/Rotations/Basic/BeastmasterRotation.cs
@@ -1,0 +1,33 @@
+﻿namespace RotationSolver.Basic.Rotations.Basic;
+
+public partial class BeastmasterRotation
+{
+	/// <summary>
+	/// 
+	/// </summary>
+	public override MedicineType MedicineType => MedicineType.Strength;
+
+	//private protected sealed override IBaseAction Raise => ;
+	//private protected sealed override IBaseAction TankStance => ;
+
+	#region Job Gauge
+
+	#endregion
+
+	#region Status Tracking
+
+	#endregion
+
+	#region Draw Debug
+
+	/// <inheritdoc/>
+	public override void DisplayBaseStatus()
+	{
+		ImGui.TextWrapped($"Beastmaster Data");
+	}
+	#endregion
+
+	#region Actions
+
+	#endregion
+}

--- a/RotationSolver.Basic/packages.lock.json
+++ b/RotationSolver.Basic/packages.lock.json
@@ -4,9 +4,9 @@
     "net10.0-windows10.0.26100": {
       "ECommons": {
         "type": "Direct",
-        "requested": "[3.2.0.6, )",
-        "resolved": "3.2.0.6",
-        "contentHash": "ZONTpNsOLTlX0OPhBU/mHK9EWqmxgc2ZPwZtmV0rucsNyARXjeNsaGC9bcumGPBVpICTQBqeg4V1iew3OdmGYQ=="
+        "requested": "[3.2.0.9, )",
+        "resolved": "3.2.0.9",
+        "contentHash": "JWD/HU+CUBFRCRTJzdyL+Ld6BedndYXk10bZHNbaGleO6WZQWxUUwAAKtJNZgvyrzQ53fqEvnuHml3mNYORl5w=="
       },
       "Microsoft.CodeAnalysis.CSharp": {
         "type": "Direct",

--- a/RotationSolver.GameData/Getters/RotationGetter.cs
+++ b/RotationSolver.GameData/Getters/RotationGetter.cs
@@ -165,8 +165,8 @@ internal class RotationGetter(Lumina.GameData gameData, ClassJob job)
 	/// Gets the job gauge code.
 	/// </summary>
 	/// <returns>The job gauge code.</returns>
-	private string GetJobGauge() => (job.Abbreviation == "BLU" || job.Abbreviation == "BLU") ? string.Empty : $"static {job.Abbreviation}Gauge JobGauge => Svc.Gauges.Get<{job.Abbreviation}Gauge>();";
-	//TODO: Remove BST exception when the class releases to allow BST rotation data to be generated
+	private string GetJobGauge() => (job.Abbreviation == "BLU" || job.Abbreviation == "BST") ? string.Empty : $"static {job.Abbreviation}Gauge JobGauge => Svc.Gauges.Get<{job.Abbreviation}Gauge>();";
+	//TODO: Remove BST exception when the class releases to allow BST gauge data to be generated
 
 	/// <summary>
 	/// Gets the limit break code for a specific action.

--- a/RotationSolver.GameData/Program.cs
+++ b/RotationSolver.GameData/Program.cs
@@ -108,8 +108,7 @@ public class Program
 			var rotationList = new List<string>();
 			foreach (var job in rotationsSheet)
 			{
-				//TODO: Remove BST exception when the class releases to allow BST rotation data to be generated
-				if (job.JobIndex > 0 && job.Abbreviation.ToString() != "BST")
+				if (job.JobIndex > 0)
 				{
 					rotationList.Add(new RotationGetter(gameData, job).GetCode());
 				}

--- a/RotationSolver.GameData/RotationSolver.GameData.csproj
+++ b/RotationSolver.GameData/RotationSolver.GameData.csproj
@@ -12,7 +12,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Lumina" Version="7.3.0" />
+		<PackageReference Include="Lumina" Version="7.4.0" />
 		<PackageReference Include="Lumina.Excel" Version="7.4.3" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
 		<PackageReference Include="ResXResourceReader.NetStandard" Version="1.3.0" />

--- a/RotationSolver.GameData/Util.cs
+++ b/RotationSolver.GameData/Util.cs
@@ -124,12 +124,14 @@ internal static partial class Util
 	/// <returns>The generated property code.</returns>
 	public static string ArrayNames(string propertyName, string propertyType, string modifier, params string[] items)
 	{
+		var itemsPart = items.Length > 0 ? string.Join(", ", items) + "," : string.Empty;
+		var basePart = modifier.Contains("override") ? $"..base.{propertyName}," : string.Empty;
 		var thisItems = $"""
-            [
-                {string.Join(", ", items)},
-                {(modifier.Contains("override") ? $"..base.{propertyName}," : string.Empty)}
-            ]
-            """;
+			[
+				{itemsPart}
+				{basePart}
+			]
+			""";
 		return $$"""
         private {{propertyType}}[] _{{propertyName}} = null;
 

--- a/RotationSolver/RotationSolver.csproj
+++ b/RotationSolver/RotationSolver.csproj
@@ -22,7 +22,7 @@
 
 	<ItemGroup>
 		<!-- Keep ECommons runtime so its DLL is included -->
-		<PackageReference Include="ECommons" Version="3.2.0.6" />
+		<PackageReference Include="ECommons" Version="3.2.0.9" />
 		<!-- Do not copy Roslyn runtime to output -->
 		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.3.0" PrivateAssets="all" ExcludeAssets="runtime">
 		  <IncludeAssets>compile; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/RotationSolver/packages.lock.json
+++ b/RotationSolver/packages.lock.json
@@ -16,9 +16,9 @@
       },
       "ECommons": {
         "type": "Direct",
-        "requested": "[3.2.0.6, )",
-        "resolved": "3.2.0.6",
-        "contentHash": "ZONTpNsOLTlX0OPhBU/mHK9EWqmxgc2ZPwZtmV0rucsNyARXjeNsaGC9bcumGPBVpICTQBqeg4V1iew3OdmGYQ=="
+        "requested": "[3.2.0.9, )",
+        "resolved": "3.2.0.9",
+        "contentHash": "JWD/HU+CUBFRCRTJzdyL+Ld6BedndYXk10bZHNbaGleO6WZQWxUUwAAKtJNZgvyrzQ53fqEvnuHml3mNYORl5w=="
       },
       "Microsoft.CodeAnalysis.CSharp": {
         "type": "Direct",
@@ -79,7 +79,7 @@
       "RotationSolverReborn.Basic": {
         "type": "Project",
         "dependencies": {
-          "ECommons": "[3.2.0.6, )",
+          "ECommons": "[3.2.0.9, )",
           "Microsoft.CodeAnalysis.CSharp": "[5.3.0, )",
           "RotationSolver.SourceGenerators": "[1.0.0, )",
           "Svg": "[3.4.7, )",


### PR DESCRIPTION
- Bump ECommons to 3.2.0.9 and Lumina to 7.4.0
- Add BeastmasterRotation class with empty actions/traits
- Update codegen to handle BST like BLU for gauges
- Refactor Util.ArrayNames for better formatting
- Always append ..base.AllBaseActions/AllTraits in resources
- Remove BST skip in rotation generation loop