### PR TITLE
:bug: Fixed a bug in ChurinDNC step hold logic.

### DIFF
--- a/RotationSolver/ExtraRotations/Ranged/ChurinDNC.cs
+++ b/RotationSolver/ExtraRotations/Ranged/ChurinDNC.cs
@@ -133,6 +133,7 @@ public sealed class ChurinDNC : DancerRotation
     /// Checks if the player is in a low-level burst scenario,
     /// </summary>
     private bool IsLowLevelBurst => !HasEnoughLevelForBurst && HasStandardFinish;
+    private static bool HasTechFromOtherDancer => StatusHelper.PlayerHasStatus(false, StatusID.TechnicalFinish);
     private static bool HasTillana => HasActiveStatus(StatusID.FlourishingFinish);
     private static bool IsMedicated => HasActiveStatus(StatusID.Medicated);
 
@@ -729,37 +730,44 @@ public sealed class ChurinDNC : DancerRotation
     /// <param name="strategy">
     /// The HoldStrategy to evaluate, which defines the conditions under which to hold Step and/or Finish actions when no targets are in range.
     /// </param>
-    /// <param name="isTechnical">
-    /// A boolean value indicating whether the dance step being evaluated is a Technical Step (true) or a Standard Step (false), which may affect the conditions for holding actions based on the strategy.
-    /// </param>
     /// <returns>
     /// True if the conditions for holding Step and/or Finish actions are met based on the specified strategy and the presence of targets in range; otherwise, false.
     /// </returns>
-    private bool CanUseStepHoldCheck(HoldStrategy strategy, bool isTechnical) => strategy switch
+    private bool CanUseStepHoldCheck(HoldStrategy strategy) => strategy switch
     {
         HoldStrategy.DontHoldStepAndFinish => true,
         HoldStrategy.HoldStepAndFinish => AreDanceTargetsInRange,
-        HoldStrategy.HoldStepOnly => CanHoldStepOnly(isTechnical),
-        HoldStrategy.HoldFinishOnly => CanHoldFinishOnly(isTechnical),
+        HoldStrategy.HoldStepOnly => CanHoldStepOnly(strategy),
+        HoldStrategy.HoldFinishOnly => CanHoldFinishOnly(strategy),
         _ => true
     };
-    private bool CanHoldStepOnly(bool isTechnical)
+    private bool CanHoldStepOnly(HoldStrategy strategy)
     {
-        var shouldHoldTechStep = isTechnical && ShouldUseTechStep && !HasTechnicalStep && !HasTillana;
-        var shouldHoldStandardStep = !isTechnical && ActiveStandard.IsEnabled
-                                                  && (!CanFinishingMove || !HasFinishingMove) && !HasStandardStep;
+        var shouldHoldTechStep = strategy == TechHoldStrategy
+                                 && ShouldUseTechStep
+                                 && !HasTechnicalStep
+                                 && !HasTillana;
 
-        if (!shouldHoldTechStep && !shouldHoldStandardStep) return false;
-        return (shouldHoldTechStep || shouldHoldStandardStep) && AreDanceTargetsInRange;
+        var shouldHoldStandardStep =  strategy == StandardHoldStrategy
+                                      && ActiveStandard.IsEnabled
+                                      && (!CanFinishingMove || !HasFinishingMove)
+                                      && !HasStandardStep;
+
+        if (!shouldHoldTechStep && !shouldHoldStandardStep) return true;
+        return AreDanceTargetsInRange;
     }
-    private bool CanHoldFinishOnly(bool isTechnical)
+    private bool CanHoldFinishOnly(HoldStrategy strategy)
     {
-        var shouldHoldTechFinish = isTechnical && (HasTillana || HasTechnicalStep);
-        var shouldHoldStandardFinish = !isTechnical && ActiveStandard.IsEnabled && (CanFinishingMove || HasStandardStep);
+        var shouldHoldTechFinish = strategy == TechHoldStrategy
+            && (HasTillana || HasTechnicalStep);
 
-        if (!shouldHoldTechFinish && !shouldHoldStandardFinish) return false;
+        var shouldHoldStandardFinish =  strategy == StandardHoldStrategy
+                                        && ActiveStandard.IsEnabled
+                                        && (CanFinishingMove || HasStandardStep);
 
-        return (shouldHoldTechFinish|| shouldHoldStandardFinish) && AreDanceTargetsInRange;
+        if (!shouldHoldTechFinish && !shouldHoldStandardFinish) return true;
+
+        return AreDanceTargetsInRange;
     }
     private bool CanUseTechStep
     {
@@ -775,7 +783,7 @@ public sealed class ChurinDNC : DancerRotation
             }
 
             return IsTimingOk(TechnicalRecastRemain, TechnicalStepPvE)
-                   && CanUseStepHoldCheck(TechHoldStrategy, true);
+                   && CanUseStepHoldCheck(TechHoldStrategy);
         }
     }
 
@@ -791,7 +799,7 @@ public sealed class ChurinDNC : DancerRotation
             if (ShouldUseTechStep && TechnicalStepPvE.CanUse(out _) && !HasTillana) return false;
 
             return IsTimingOk(ActiveStandardRecastRemain, ActiveStandard)
-                   && CanUseStepHoldCheck(StandardHoldStrategy, false);
+                   && CanUseStepHoldCheck(StandardHoldStrategy);
         }
     }
 
@@ -894,7 +902,7 @@ public sealed class ChurinDNC : DancerRotation
                 return true;
             }
 
-            if (CanTechnicalFinish && CanUseStepHoldCheck(TechHoldStrategy, true))
+            if (CanTechnicalFinish && CanUseStepHoldCheck(TechHoldStrategy))
             {
                 return QuadrupleTechnicalFinishPvE.CanUse(out act);
             }
@@ -915,7 +923,7 @@ public sealed class ChurinDNC : DancerRotation
             return true;
         }
 
-        if (CanStandardFinish && CanUseStepHoldCheck(StandardHoldStrategy, false))
+        if (CanStandardFinish && CanUseStepHoldCheck(StandardHoldStrategy))
         {
             return DoubleStandardFinishPvE.CanUse(out act);
         }
@@ -979,7 +987,7 @@ public sealed class ChurinDNC : DancerRotation
             blockTillana = true;
         }
 
-        return !blockTillana && TillanaPvE.CanUse(out act) && CanUseStepHoldCheck(TechHoldStrategy, true);
+        return !blockTillana && TillanaPvE.CanUse(out act) && CanUseStepHoldCheck(TechHoldStrategy);
     }
 
     private bool TryUseLastDance(out IAction? act)
@@ -1291,7 +1299,7 @@ public sealed class ChurinDNC : DancerRotation
         if (ImGui.CollapsingHeader("Step Logic"))
         {
             ValueRow("Tech Hold Strategy", TechHoldStrategy);
-            BoolRow("Tech Hold Check", CanUseStepHoldCheck(TechHoldStrategy, true));
+            BoolRow("Tech Hold Check", CanUseStepHoldCheck(TechHoldStrategy));
 
             if (ImGui.TreeNode("Technical Step Blocking Reasons"))
             {
@@ -1309,7 +1317,7 @@ public sealed class ChurinDNC : DancerRotation
             ImGui.Separator();
 
             ValueRow("Standard Hold Strategy", StandardHoldStrategy);
-            BoolRow("Standard Hold Check", CanUseStepHoldCheck(StandardHoldStrategy, false));
+            BoolRow("Standard Hold Check", CanUseStepHoldCheck(StandardHoldStrategy));
             ValueRow("Esprit Threshold", EspritThreshold);
             ValueRow("Current Esprit", Esprit);
             if (ImGui.TreeNode("Standard Step Blocking Reasons"))


### PR DESCRIPTION
This pull request refactors the handling of step and finish hold logic in the Dancer rotation solver, simplifying method signatures and improving code clarity. The main change is to replace the use of a boolean `isTechnical` parameter with the more descriptive `HoldStrategy` enum throughout the logic, which reduces ambiguity and potential errors. Additionally, the logic for determining whether to hold steps or finishes has been slightly adjusted to better reflect intent.

**Refactoring and simplification of hold logic:**

* The `CanUseStepHoldCheck`, `CanHoldStepOnly`, and `CanHoldFinishOnly` methods now use only the `HoldStrategy` parameter instead of both `HoldStrategy` and a boolean `isTechnical`, making the code easier to read and less error-prone.
* All calls to `CanUseStepHoldCheck` throughout the class have been updated to remove the `isTechnical` argument, reflecting the new method signature. [[1]](diffhunk://#diff-47a4eb6c618e99b36d8294fb8cab1da42f6e3561e705aa2075ffe4f2a2549957L778-R786) [[2]](diffhunk://#diff-47a4eb6c618e99b36d8294fb8cab1da42f6e3561e705aa2075ffe4f2a2549957L794-R802) [[3]](diffhunk://#diff-47a4eb6c618e99b36d8294fb8cab1da42f6e3561e705aa2075ffe4f2a2549957L897-R905) [[4]](diffhunk://#diff-47a4eb6c618e99b36d8294fb8cab1da42f6e3561e705aa2075ffe4f2a2549957L918-R926) [[5]](diffhunk://#diff-47a4eb6c618e99b36d8294fb8cab1da42f6e3561e705aa2075ffe4f2a2549957L982-R990) [[6]](diffhunk://#diff-47a4eb6c618e99b36d8294fb8cab1da42f6e3561e705aa2075ffe4f2a2549957L1294-R1302) [[7]](diffhunk://#diff-47a4eb6c618e99b36d8294fb8cab1da42f6e3561e705aa2075ffe4f2a2549957L1312-R1320)

**Logic improvements:**

* The logic in `CanHoldStepOnly` and `CanHoldFinishOnly` has been modified so that if no hold condition is met, the methods now return `true` instead of `false`, which better matches the intended behavior for when steps/finishes should not be held.

**Minor additions:**

* Added a new helper property `HasTechFromOtherDancer` to check for the presence of the `TechnicalFinish` status from another dancer. Will expand on this later.