### PR TITLE
fix sidebar scaling on scales > 100%

### DIFF
--- a/RotationSolver.SourceGenerators/RotationSolver.SourceGenerators.csproj
+++ b/RotationSolver.SourceGenerators/RotationSolver.SourceGenerators.csproj
@@ -4,6 +4,7 @@
 		<TargetFramework>netstandard2.0</TargetFramework>
 		<EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
 		<Platforms>x64</Platforms>
+		<PlatformTarget>AnyCPU</PlatformTarget>
 		<LangVersion>default</LangVersion>
 		<CopyLocalLockFileAssemblies>False</CopyLocalLockFileAssemblies>
 	</PropertyGroup>

--- a/RotationSolver/UI/RotationConfigWindow.cs
+++ b/RotationSolver/UI/RotationConfigWindow.cs
@@ -673,7 +673,7 @@ public partial class RotationConfigWindow : Window
 				}
 				else
 				{
-					if (ImGui.Selectable(displayName, _activeTab == item, ImGuiSelectableFlags.None, new Vector2(0, 20)))
+					if (ImGui.Selectable(displayName, _activeTab == item, ImGuiSelectableFlags.None, new Vector2(0, 20) * Scale))
 					{
 						_activeTab = item;
 						_searchResults = [];


### PR DESCRIPTION
This PR scales the sidebar tab height by the `GlobalScale` to fix issues where the sidebar text was clipped on scales larger than 100%.

| Before (200%) | After (200%) |
| - | - |
| <img width="575" height="498" alt="CleanShot 2026-05-05 at 13 04 09@2x" src="https://github.com/user-attachments/assets/eaabfb6e-f0e8-4970-b8bf-b4503c423b2f" /> | <img width="575" height="582" alt="image" src="https://github.com/user-attachments/assets/233fef13-e699-4382-a231-0226aef68453" />


It also updates the build configuration of the `SourceGenerators` package to support building the plugin on ARM CPUs.