### PR TITLE
fix(targeting): fall through for hostile fixed-distance moves

### DIFF
--- a/RotationSolver.Basic/Actions/ActionTargetInfo.cs
+++ b/RotationSolver.Basic/Actions/ActionTargetInfo.cs
@@ -1922,14 +1922,25 @@ public struct ActionTargetInfo(IBaseAction action)
 				}
 				break;
 
-			// Fixed-distance self-move: no target needed; always use self so the action fires.
+			// Fixed-distance self-move: self-targeting only fires the action when it is genuinely
+			// self-cast (IsFriendly). Hostile-targeted variants must fall through to the standard
+			// targeting path so a real enemy is selected.
 			case SpecialActionType.FixedDistanceMoveForward:
-				return Player.Object;
+				if (isFriendly)
+				{
+					return Player.Object;
+				}
+				break;
 
-			// Backward movement: character moves away from its current position/target.
-			// Self-targeting is sufficient to fire the action; destination safety is validated separately.
+			// Backward movement: self-targeting fires friendly variants (e.g. DRG Elusive Jump,
+			// RPR Hells Egress). Hostile-targeted variants (e.g. BRD Repelling Shot) deliver damage
+			// to an enemy and knock the user back; they need a hostile target, so fall through.
 			case SpecialActionType.FixedDistanceMoveBackward:
-				return Player.Object;
+				if (isFriendly)
+				{
+					return Player.Object;
+				}
+				break;
 		}
 
 		if (targetOverride == default)


### PR DESCRIPTION
## Summary

`33e6acb` added an explicit `FixedDistanceMoveForward`/`Backward` case in `ActionTargetInfo.FindTargetByType` that unconditionally returns `Player.Object`. Any action with that `SpecialType` that requires a hostile target gets queued against self, the game silently rejects the call, and `CanUse` traces as `Accept` while the action never fires.

BRD Repelling Shot (PvP `29415`, PvE `7542`) is the only basic-rotations action affected. It damages an enemy and knocks the user back, so `ModifyRepellingShotPvP/PvE` correctly leave `IsFriendly` defaulted to `false`. Every other `FixedDistance*` modifier (DRG Elusive Jump, RPR Hells Egress, RPR Hells Ingress, AST Epicycle, RPR Harpe) sets `IsFriendly = true` because those are genuinely self-cast.

The patch gates both early returns on `isFriendly`. Self-cast variants keep the short-circuit, hostile variants fall through to the standard target-finding path.

Verified in Crystalline Conflict on Bard with `ActionTracer` enabled. `RepellingShotPvP` picks up a real hostile target and fires on cooldown.