### PR TITLE
Update PvP action logic and adjusted movement checks

### DIFF
--- a/RotationSolver.Basic/Rotations/Basic/BardRotation.cs
+++ b/RotationSolver.Basic/Rotations/Basic/BardRotation.cs
@@ -483,7 +483,7 @@ public partial class BardRotation
 
 	static partial void ModifyRepellingShotPvP(ref ActionSetting setting)
 	{
-		setting.SpecialType = SpecialActionType.FixedDistanceMoveBackward;
+		setting.SpecialType = SpecialActionType.HostileMovingAttack;
 	}
 
 	static partial void ModifyEncoreOfLightPvP(ref ActionSetting setting)

--- a/RotationSolver.Basic/Service.cs
+++ b/RotationSolver.Basic/Service.cs
@@ -43,7 +43,7 @@ internal class Service : IDisposable
 	/// <summary>
 	/// Gets or sets a value indicating whether the player can move.
 	/// </summary>
-	internal static unsafe bool CanMove
+	internal static bool CanMove
 	{
 		get => ForceDisableMovement == 0;
 		set

--- a/RotationSolver/RebornRotations/PVPRotations/Magical/SMN_Default.PVP.cs
+++ b/RotationSolver/RebornRotations/PVPRotations/Magical/SMN_Default.PVP.cs
@@ -48,13 +48,18 @@ public class SMN_DefaultPvP : SummonerRotation
 			return true;
 		}
 
+		if (CrimsonCyclonePvP.CanUse(out action) && Target.DistanceToPlayer() <= 5f)
+		{
+			return true;
+		}
+
 		return base.AttackAbility(nextGCD, out action);
 	}
 
 	[RotationDesc(ActionID.CrimsonCyclonePvP)]
 	protected override bool MoveForwardAbility(IAction nextGCD, out IAction? action)
 	{
-		if (CrimsonCyclonePvP.CanUse(out action) && Target.DistanceToPlayer() < 5)
+		if (CrimsonCyclonePvP.CanUse(out action))
 		{
 			return true;
 		}


### PR DESCRIPTION
- Changed Repelling Shot PvP to use HostileMovingAttack type in BardRotation.
- Adjusted SMN_DefaultPvP to allow CrimsonCyclonePvP as an attack ability within 5 units and removed distance check from MoveForwardAbility.