### PR TITLE
Refactor ChurinBRD and ChurinDNC for clarity and efficiency

### DIFF
--- a/RotationSolver/ExtraRotations/Ranged/ChurinBRD.cs
+++ b/RotationSolver/ExtraRotations/Ranged/ChurinBRD.cs
@@ -328,6 +328,7 @@ public sealed class ChurinBRD : BardRotation
 
 	protected override bool EmergencyAbility(IAction nextGCD, out IAction? act)
 	{
+		act = null;
 		if (ChurinPotions.ShouldUsePotion(this, out act)) return true;
 
 		if (IsFirstCycle && InArmys && !RadiantFinalePvE.Cooldown.IsCoolingDown) IsFirstCycle = false;
@@ -591,17 +592,21 @@ public sealed class ChurinBRD : BardRotation
 	{
 		get
 		{
+			if (WeaponRemain <= DataCenter.CalculatedActionAhead + Math.Max(AnimationLock, 0.6f)) return false;
+
 			if (!EmpyrealArrowPvE.Cooldown.IsCoolingDown
 			    || EmpyrealArrowPvE.Cooldown.HasOneCharge)
 			{
-				return CanWeave && WeaponRemain > DataCenter.CalculatedActionAhead + AnimationLock;
+				return CanWeave;
 			}
 
 			var recast = EmpyrealArrowPvE.Cooldown.RecastTimeRemain;
-			var wTLessR = Math.Abs(recast - WeaponTotal);
 
-			return recast < WeaponTotal
-			       || wTLessR < WeaponRemain;
+			if (recast >= WeaponTotal) return false;
+
+			if (recast >= WeaponRemain) return false;
+
+			return CanWeave && EmpyrealArrowPvE.Cooldown.HasOneCharge;
 		}
 	}
 
@@ -639,9 +644,9 @@ public sealed class ChurinBRD : BardRotation
 
 		if (NoSong) return false;
 
-		if (EmpyrealArrowPvE.CanUse(out act))
+		if (EmpyrealArrowTimingCheck && CanUseEmpyrealArrow)
 		{
-			return EmpyrealArrowTimingCheck && CanUseEmpyrealArrow;
+			return EmpyrealArrowPvE.CanUse(out act);
 		}
 
 		return false;
@@ -888,7 +893,7 @@ public sealed class ChurinBRD : BardRotation
 			&& BloodletterPvE.Cooldown.CurrentCharges < 3
 			&& !willHaveMaxCharges;
 		var holdForBurstTiming = InBurst
-			&& (!willHaveOneCharge || IsLastAbility(ActionID.BloodletterPvE, ActionID.RainOfDeathPvE, ActionID.HeartbreakShotPvE));
+			&& (!willHaveOneCharge || !CanWeave);
 		var isInWanderersHold  = InWanderers && (holdForRagingOrCap || holdForBurstTiming);
 
 		var isInArmysHold = InArmys
@@ -899,14 +904,14 @@ public sealed class ChurinBRD : BardRotation
 		var isInMagesHold = InMages && SongEndAfter(MageRemainTime + WeaponTotal * 0.9f);
 
 		var isEmpyrealBlocking = !NoSong && !InBurst
-			&& (EmpyrealArrowPvE.Cooldown.WillHaveOneCharge(WeaponTotal)
+			&& (EmpyrealArrowPvE.Cooldown.WillHaveOneCharge(WeaponTotal) && CanUseEmpyrealArrow
 			    || wontHaveCharge);
 
 		if (isInWanderersHold || isInArmysHold || isInMagesHold || isEmpyrealBlocking) return false;
 
 		if (SongTimings == SongTiming.Cycle369 && NoSong && HeartbreakShotPvE.CanUse(out act, usedUp: false)) return true;
 
-		if (!EnoughWeaveTime) return false;
+		if (!CanWeave) return false;
 
 		var shouldUseUsedUp = InBurst || IsMedicated
 			|| (willHaveOneCharge && (InMages || (InArmys && SongTime > 30f)));
@@ -945,7 +950,7 @@ public sealed class ChurinBRD : BardRotation
 		if (Repertoire == 3) return true;
 		if (Repertoire == 2 && EmpyrealArrowPvE.Cooldown.WillHaveOneChargeGCD(1)) return true;
 
-		return SongEndAfter(WandRemainTime - WeaponTotal * 0.25f) && CanEarlyWeave;
+		return SongEndAfter(WandRemainTime - DataCenter.CalculatedActionAhead + AnimationLock) && WeaponRemain > LateWeaveWindow;
 	}
 
 	#endregion

--- a/RotationSolver/ExtraRotations/Ranged/ChurinDNC.cs
+++ b/RotationSolver/ExtraRotations/Ranged/ChurinDNC.cs
@@ -195,7 +195,7 @@ public sealed class ChurinDNC : DancerRotation
 				return ActiveStandardRecastRemain > WeaponTotal ? MidEspritThreshold : MaxEsprit;
 			}
 
-			if (HasDanceOfTheDawn && (!HasLastDance || CanSaberDance || IsLastGCD(ActionID.TillanaPvE)))
+			if ((HasDanceOfTheDawn|| !DanceOfTheDawnPvE.EnoughLevel) && (!HasLastDance || CanSaberDance || IsLastGCD(ActionID.TillanaPvE)))
 			{
 				return SaberDanceEspritCost;
 			}
@@ -681,7 +681,7 @@ public sealed class ChurinDNC : DancerRotation
 	private bool ActiveStandardWillHaveCharge =>
 		ActiveStandard.Cooldown.WillHaveOneCharge(SecondsToCompleteStandard + WeaponTotal);
 	private bool CanUseStandardBasedOnEsprit => !HasLastDance && !CanSpendEspritNow;
-	private bool CanUseStandardStepInBurst => !DisableStandardInBurst || HasFinishingMove;
+	private bool CanUseStandardStepInBurst => !DisableStandardInBurst || HasFinishingMove || !FinishingMovePvE.EnoughLevel;
 	private bool DevilmentReady
 	{
 		get
@@ -1382,6 +1382,12 @@ public sealed class ChurinDNC : DancerRotation
 			{
 				ImGui.Text($"Error evaluating potion conditions: {ex.Message}");
 			}
+		}
+
+		if (ImGui.CollapsingHeader("Dance Partner"))
+		{
+			ColoredTextRow("Should Swap Dance Partner?", ShouldSwapDancePartner);
+			ColoredTextRow("Has Available Dance Partner?", HasAvailableDancePartner(RestrictDPTarget));
 		}
 
 		if (ImGui.CollapsingHeader("Method Checks"))


### PR DESCRIPTION
This pull request refines the logic for Bard (`ChurinBRD.cs`) and Dancer (`ChurinDNC.cs`) rotation solvers, focusing on ability timing, weaving checks, and UI improvements for debugging. The most significant changes include stricter and clearer checks for ability usage, improved handling of ability charges and timings, and enhanced debug output for Dancer's partner logic.

**Bard (BRD) Ability Logic Improvements:**

* Refined the logic for when `Empyreal Arrow` can be used, adding stricter checks for weapon remain time and simplifying the charge/timing logic. This helps prevent premature or suboptimal usage.
* Updated `TryUseEmpyrealArrow` to check both `EmpyrealArrowTimingCheck` and `CanUseEmpyrealArrow` before attempting to use the ability, ensuring both timing and usability conditions are met.
* Improved `TryUseHeartBreakShot` logic to use `CanWeave` instead of `EnoughWeaveTime`, and made the Empyreal Arrow blocking logic stricter by requiring both a pending charge and usability. [[1]](diffhunk://#diff-dc3c2c8c98b8d9674bafcd7d6b9ad0a7a85647049d94c3636b011728d5269b1aL891-R896) [[2]](diffhunk://#diff-dc3c2c8c98b8d9674bafcd7d6b9ad0a7a85647049d94c3636b011728d5269b1aL902-R914)
* Adjusted `TryUsePitchPerfect` to use more precise timing calculations for early weaving, improving the decision for when to use the ability.
* Ensured `act` is always set to `null` at the start of `UpdateCustomTimings` for clearer intent and safety.

**Dancer (DNC) Logic and UI Enhancements:**

* Modified `EspritThreshold` to handle cases where `Dance of the Dawn` is unavailable due to level, preventing logic errors at lower levels.
* Updated `CanUseStandardStepInBurst` to allow Standard Step usage in burst phases if the player is not high enough level for Finishing Move, improving low-level behavior.
* Added a new debug UI section in `DisplayRotationStatus` to show Dance Partner status, including whether a swap is needed and if an available partner exists.