### PR TITLE
Add config strategies for GNB heals, NIN mudra prio fix, mob distance calc fix

### DIFF
--- a/RotationSolver.Basic/Actions/ActionTargetInfo.cs
+++ b/RotationSolver.Basic/Actions/ActionTargetInfo.cs
@@ -4059,7 +4059,7 @@ public struct ActionTargetInfo(IBaseAction action)
 				return null;
 			}
 
-			// Prefer self first
+			// Prefer self first if player is the target of the boss
 			foreach (var t in DataCenter.TankbusterTargets)
 			{
 				if (ObjectHelper.IsAlive(t) && !t.IsConditionCannotTarget() && t.GameObjectId == Player.Object.GameObjectId)

--- a/RotationSolver.Basic/Helpers/ObjectHelper.cs
+++ b/RotationSolver.Basic/Helpers/ObjectHelper.cs
@@ -8,6 +8,7 @@ using ECommons.GameFunctions;
 using ECommons.GameHelpers;
 using ECommons.Logging;
 using FFXIVClientStructs.FFXIV.Client.Game;
+using FFXIVClientStructs.FFXIV.Client.Game.Character;
 using FFXIVClientStructs.FFXIV.Client.Game.Event;
 using FFXIVClientStructs.FFXIV.Client.System.Framework;
 using FFXIVClientStructs.FFXIV.Common.Component.BGCollision;
@@ -3209,7 +3210,7 @@ public static class ObjectHelper
 			return 0;
 		}
 
-		var effectiveHp = character.CurrentHp + ObjectHelper.GetObjectShield(battleChara);
+		var effectiveHp = character.CurrentHp + GetObjectShield(battleChara);
 		return (int)Math.Floor((float)effectiveHp / character.MaxHp * 100f);
 	}
 
@@ -3713,10 +3714,18 @@ public static class ObjectHelper
 			return float.MaxValue;
 		}
 
-		// Use XZ-plane (horizontal) distance only — the game engine measures action range
-		// purely on the horizontal plane, ignoring Y-axis differences.
 		var playerPos = Player.Object.Position;
 		var targetPos = battleChara.Position;
+
+		// Check vertical distance first - if too far vertically, the target is unreachable
+		var dy = MathF.Abs(targetPos.Y - playerPos.Y);
+		if (dy > 30f)
+		{
+			return dy;
+		}
+
+		// Use XZ-plane (horizontal) distance only — the game engine measures action range
+		// purely on the horizontal plane, ignoring Y-axis differences (when within vertical threshold).
 		var dx = targetPos.X - playerPos.X;
 		var dz = targetPos.Z - playerPos.Z;
 		var distance = MathF.Sqrt(dx * dx + dz * dz) - (Player.Object.HitboxRadius + battleChara.HitboxRadius);

--- a/RotationSolver.Basic/Helpers/StatusHelper.cs
+++ b/RotationSolver.Basic/Helpers/StatusHelper.cs
@@ -103,9 +103,11 @@ public static class StatusHelper
 	[
 		StatusID.Holmgang_409,
 		StatusID.LivingDead,
-        //StatusID.WalkingDead,
-        StatusID.Superbolide,
+		//StatusID.WalkingDead,
+		StatusID.Superbolide,
 		StatusID.Invulnerability,
+		StatusID.HpRecoveryDown,
+		StatusID.Mounted,
 	];
 
 	/// <summary>

--- a/RotationSolver/RebornRotations/Melee/NIN_Reborn.cs
+++ b/RotationSolver/RebornRotations/Melee/NIN_Reborn.cs
@@ -358,19 +358,6 @@ public sealed class NIN_Reborn : NinjaRotation
 		}
 		else if (TenPvE.CanUse(out _, usedUp: ShadowWalkerNeeded || InTrickAttack || TenPvE.Cooldown.WillHaveXChargesGCD(2, 2, 0) || BurnMudraStacks) && _ninActionAim == null)
 		{
-			//Vulnerable
-			if (ShadowWalkerNeeded && (!MeisuiPvE.Cooldown.IsCoolingDown || !TrickAttackPvE.Cooldown.IsCoolingDown || KunaisBanePvE.Cooldown.IsCoolingDown) && !IsShadowWalking && !HasTenChiJin && SuitonPvE.EnoughLevel)
-			{
-				if (DeathBlossomPvE.CanUse(out _) && JinPvE.CanUse(out _) && JinPvE.Info.IsQuestUnlocked() && HutonPvE.IsEnabled)
-				{
-					SetNinjutsu(HutonPvE);
-				}
-				else if (JinPvE.CanUse(out _) && JinPvE.Info.IsQuestUnlocked() && SuitonPvE.IsEnabled && ((TrickAttackPvE.IsEnabled && !KunaisBanePvE.EnoughLevel) || (KunaisBanePvE.IsEnabled && KunaisBanePvE.EnoughLevel)))
-				{
-					SetNinjutsu(SuitonPvE);
-				}
-			}
-
 			//Aoe
 			if (DeathBlossomPvE.CanUse(out _) || HakkeMujinsatsuPvE.CanUse(out _))
 			{
@@ -385,6 +372,19 @@ public sealed class NIN_Reborn : NinjaRotation
 				else if (KatonPvE.EnoughLevel && KatonPvE.IsEnabled && ChiPvE.Info.IsQuestUnlocked())
 				{
 					SetNinjutsu(KatonPvE);
+				}
+			}
+
+			//Vulnerable
+			if (ShadowWalkerNeeded && (!MeisuiPvE.Cooldown.IsCoolingDown || !TrickAttackPvE.Cooldown.IsCoolingDown || KunaisBanePvE.Cooldown.IsCoolingDown) && !IsShadowWalking && !HasTenChiJin && SuitonPvE.EnoughLevel)
+			{
+				if (DeathBlossomPvE.CanUse(out _) && JinPvE.CanUse(out _) && JinPvE.Info.IsQuestUnlocked() && HutonPvE.IsEnabled)
+				{
+					SetNinjutsu(HutonPvE);
+				}
+				else if (JinPvE.CanUse(out _) && JinPvE.Info.IsQuestUnlocked() && SuitonPvE.IsEnabled && ((TrickAttackPvE.IsEnabled && !KunaisBanePvE.EnoughLevel) || (KunaisBanePvE.IsEnabled && KunaisBanePvE.EnoughLevel)))
+				{
+					SetNinjutsu(SuitonPvE);
 				}
 			}
 

--- a/RotationSolver/RebornRotations/Tank/GNB_Reborn.cs
+++ b/RotationSolver/RebornRotations/Tank/GNB_Reborn.cs
@@ -1,3 +1,5 @@
+using System.ComponentModel;
+
 namespace RotationSolver.RebornRotations.Tank;
 
 [Rotation("Reborn", CombatType.PvE, GameVersion = "7.5")]
@@ -6,10 +8,35 @@ namespace RotationSolver.RebornRotations.Tank;
 public sealed class GNB_Reborn : GunbreakerRotation
 {
 	#region Config Options
-	[RotationConfig(CombatType.PvE, Name = "Restrict automatic use of Aurora to only being used on self")]
-	public bool AuroraSelf { get; set; } = false;
-	[RotationConfig(CombatType.PvE, Name = "Restrict automatic use of Heart of Stone/Heart of Corundum to only being used on self")]
-	public bool HeartOfStoneSelf { get; set; } = false;
+	[RotationConfig(CombatType.PvE, Name = "How to use Aurora")]
+	public AuroraUsageStrategy AuroraUsage { get; set; } = AuroraUsageStrategy.TankbusterTarget;
+
+	[RotationConfig(CombatType.PvE, Name = "How to use Heart Of Stone/Heart Of Corundum")]
+	public HeartOfStoneStrategy HeartOfStoneUsage { get; set; } = HeartOfStoneStrategy.TankbusterTarget;
+
+	public enum HeartOfStoneStrategy : byte
+	{
+		[Description("Full target usage")]
+		Fullusage,
+
+		[Description("Only use on tankbuster targets prioritizing self")]
+		TankbusterTarget,
+
+		[Description("Only use on self")]
+		SelfOnly,
+	}
+
+	public enum AuroraUsageStrategy : byte
+	{
+		[Description("Full target usage")]
+		Fullusage,
+
+		[Description("Only use on tankbuster targets prioritizing self")]
+		TankbusterTarget,
+
+		[Description("Only use on self")]
+		SelfOnly,
+	}
 
 	#endregion
 
@@ -99,24 +126,41 @@ public sealed class GNB_Reborn : GunbreakerRotation
 
 		if (HeartOfStonePvE.EnoughLevel)
 		{
-			if (!HeartOfStoneSelf && HeartOfCorundumPvE.EnoughLevel && HeartOfCorundumPvE.CanUse(out act, targetOverride: TargetType.Tankbuster))
+			switch (HeartOfStoneUsage)
 			{
-				return true;
-			}
+				case HeartOfStoneStrategy.SelfOnly:
+					if (HeartOfCorundumPvE.EnoughLevel && HeartOfCorundumPvE.CanUse(out act))
+					{
+						return true;
+					}
+					if (!HeartOfCorundumPvE.EnoughLevel && HeartOfStonePvE.CanUse(out act))
+					{
+						return true;
+					}
+					break;
 
-			if (HeartOfStoneSelf && HeartOfCorundumPvE.EnoughLevel && HeartOfCorundumPvE.CanUse(out act))
-			{
-				return true;
-			}
+				case HeartOfStoneStrategy.TankbusterTarget:
+					if (HeartOfCorundumPvE.EnoughLevel && HeartOfCorundumPvE.CanUse(out act, targetOverride: TargetType.Tankbuster))
+					{
+						return true;
+					}
+					if (!HeartOfCorundumPvE.EnoughLevel && HeartOfStonePvE.CanUse(out act, targetOverride: TargetType.Tankbuster))
+					{
+						return true;
+					}
+					break;
 
-			if (!HeartOfStoneSelf && !HeartOfCorundumPvE.EnoughLevel && HeartOfStonePvE.CanUse(out act, targetOverride: TargetType.Tankbuster))
-			{
-				return true;
-			}
-
-			if (HeartOfStoneSelf && !HeartOfCorundumPvE.EnoughLevel && HeartOfStonePvE.CanUse(out act))
-			{
-				return true;
+				case HeartOfStoneStrategy.Fullusage:
+				default:
+					if (HeartOfCorundumPvE.EnoughLevel && HeartOfCorundumPvE.CanUse(out act, targetOverride: TargetType.LowHP))
+					{
+						return true;
+					}
+					if (!HeartOfCorundumPvE.EnoughLevel && HeartOfStonePvE.CanUse(out act, targetOverride: TargetType.LowHP))
+					{
+						return true;
+					}
+					break;
 			}
 		}
 
@@ -174,14 +218,29 @@ public sealed class GNB_Reborn : GunbreakerRotation
 
 		if (!IsLastAbility(ActionID.AuroraPvE))
 		{
-			if (!AuroraSelf && AuroraPvE.CanUse(out act, targetOverride: TargetType.LowHP))
+			switch (AuroraUsage)
 			{
-				return true;
-			}
+				case AuroraUsageStrategy.SelfOnly:
+					if (AuroraPvE.CanUse(out act))
+					{
+						return true;
+					}
+					break;
 
-			if (AuroraSelf && AuroraPvE.CanUse(out act))
-			{
-				return true;
+				case AuroraUsageStrategy.TankbusterTarget:
+					if (AuroraPvE.CanUse(out act, targetOverride: TargetType.Tankbuster))
+					{
+						return true;
+					}
+					break;
+
+				case AuroraUsageStrategy.Fullusage:
+				default:
+					if (AuroraPvE.CanUse(out act, targetOverride: TargetType.LowHP))
+					{
+						return true;
+					}
+					break;
 			}
 		}
 

--- a/RotationSolver/UI/RotationConfigWindow.cs
+++ b/RotationSolver/UI/RotationConfigWindow.cs
@@ -4605,6 +4605,8 @@ public partial class RotationConfigWindow : Window
 			ImGui.Text($"Fate ID: {DataCenter.PlayerFateId}");
 		}
 		ImGui.Spacing();
+		ImGui.Text($"IsInWindurst: {DataCenter.IsInWindurst}");
+		ImGui.Spacing();
 		ImGui.Text($"In Field Operations: {DataCenter.IsInFieldOperations}");
 		ImGui.Text($"In Field Raid: {DataCenter.IsInFieldRaid}");
 		ImGui.Spacing();
@@ -4637,17 +4639,15 @@ public partial class RotationConfigWindow : Window
 		ImGui.Text($"MountRokkon: {DataCenter.MountRokkon}");
 		ImGui.Text($"SildihnSubterrane: {DataCenter.SildihnSubterrane}");
 		ImGui.Spacing();
-		ImGui.Text($"IsCastingMultiHit: {DataCenter.IsCastingMultiHit()}");
-		ImGui.Text($"IsCastingTankVfx: {DataCenter.IsCastingTankVfx()}");
-		ImGui.Text($"IsCastingAreaVfx: {DataCenter.IsCastingAreaVfx()}");
 		ImGui.Text($"AreHostilesCastingKnockback: {DataCenter.AreHostilesCastingKnockback}");
 		ImGui.Text($"IsHostileCastingAOE: {DataCenter.IsHostileCastingAOE}");
 		ImGui.Text($"IsHostileCastingToTank: {DataCenter.IsHostileCastingToTank}");
 		ImGui.Text($"IsHostileCastingStop: {DataCenter.IsHostileCastingStop}");
 		ImGui.Spacing();
-		var HellInACell = (StatusID)4734;
-		var HasHellInACell = StatusHelper.PlayerHasStatus(false, HellInACell);
-		ImGui.Text($"HasHellInACell: {HasHellInACell}");
+		ImGui.Text($"IsCastingMultiHit: {DataCenter.IsCastingMultiHit()}");
+		ImGui.Text($"IsCastingAreaVfx: {DataCenter.IsCastingAreaVfx()}");
+		ImGui.Text($"IsCastingTankVfx: {DataCenter.IsCastingTankVfx()}");
+		ImGui.Text($"TankbusterTargets: {DataCenter.TankbusterTargets.Count}");
 		ImGui.Spacing();
 		ImGui.Text($"IsInM11S: {DataCenter.IsInM11S}");
 		ImGui.Text($"IsTyrantCastingSpecialIndicator2: {DataCenter.IsTyrantCastingSpecialIndicator2()}");


### PR DESCRIPTION
Introduce enum-based config for Gunbreaker's Aurora and Heart of Stone/Corundum usage, supporting "Full usage", "Tankbuster target", and "Self only" strategies. Update ability targeting logic accordingly. Improve ObjectHelper distance calculation with vertical check. Expand NoNeedHealingStatus. Adjust NIN_Reborn Ninjutsu logic order. Update RotationConfigWindow with new debug info and TankbusterTargets count.