### PR TITLE
add pre-pull checking for canuse

### DIFF
--- a/RotationSolver.Basic/Rotations/CustomRotation_Actions.cs
+++ b/RotationSolver.Basic/Rotations/CustomRotation_Actions.cs
@@ -16,7 +16,7 @@ public partial class CustomRotation
 	static partial void ModifyTrueNorthPvE(ref ActionSetting setting)
 	{
 		setting.StatusProvide = [StatusID.TrueNorth];
-		setting.ActionCheck = () => !IsLastAbility(ActionID.TrueNorthPvE) && DataCenter.DefaultGCDRemain > 0.630f;
+		setting.ActionCheck = () => !IsLastAbility(ActionID.TrueNorthPvE) && (DataCenter.DefaultGCDRemain > 0.630f || Service.CountDownTime > 0);
 	}
 
 	static partial void ModifyShirkPvE(ref ActionSetting setting)


### PR DESCRIPTION
currently, truenorth cannot be pressed by rsr due to the checking requires to be incombat
add pre-pull to the checking, so that truenorth can pass it during countdown