### PR TITLE
Improve object tracking, job logic, and spell selection

### DIFF
--- a/RotationSolver.Basic/Data/ObjectListDelay.cs
+++ b/RotationSolver.Basic/Data/ObjectListDelay.cs
@@ -10,8 +10,16 @@ public class ObjectListDelay<T> : IEnumerable<T> where T : IGameObject
 {
 	private IEnumerable<T> _list = [];
 	private readonly Func<(float min, float max)> _getRange;
-	private Dictionary<ulong, DateTime> _revealTime = [];
+	private readonly Dictionary<ulong, DateTime> _revealTime = [];
+	private readonly Dictionary<ulong, DateTime> _lastSeen = [];
 	private readonly Random _ran = new();
+
+	/// <summary>
+	/// How long an object's reveal timer is retained after it briefly disappears from
+	/// <see cref="Delay(IEnumerable{T})"/>'s input (e.g. a single-frame filter flicker),
+	/// so it is not mistakenly treated as a brand-new object and re-delayed.
+	/// </summary>
+	private static readonly TimeSpan StaleGracePeriod = TimeSpan.FromSeconds(2);
 
 	/// <summary>
 	/// Initializes a new instance of the <see cref="ObjectListDelay{T}"/> class.
@@ -42,18 +50,20 @@ public class ObjectListDelay<T> : IEnumerable<T> where T : IGameObject
 	public void Delay(IEnumerable<T> originData)
 	{
 		List<T> outList = [];
-		Dictionary<ulong, DateTime> revealTime = [];
 		var now = DateTime.Now;
 
 		foreach (var item in originData)
 		{
-			if (!_revealTime.TryGetValue(item.GameObjectId, out var time))
+			var id = item.GameObjectId;
+			_lastSeen[id] = now;
+
+			if (!_revealTime.TryGetValue(id, out var time))
 			{
 				(var min, var max) = _getRange();
 				var delaySecond = min + ((float)_ran.NextDouble() * (max - min));
 				time = now + TimeSpan.FromMilliseconds(delaySecond * 1000);
+				_revealTime[id] = time;
 			}
-			revealTime[item.GameObjectId] = time;
 
 			if (now > time)
 			{
@@ -61,8 +71,31 @@ public class ObjectListDelay<T> : IEnumerable<T> where T : IGameObject
 			}
 		}
 
+		// Prune objects that have genuinely been absent for a while so this doesn't grow
+		// unbounded. Anything within the grace period is kept even if it wasn't present in
+		// this particular call, so a single-frame absence doesn't reset its delay timer.
+		if (_lastSeen.Count > 0)
+		{
+			List<ulong>? stale = null;
+			foreach (var kvp in _lastSeen)
+			{
+				if (now - kvp.Value > StaleGracePeriod)
+				{
+					(stale ??= []).Add(kvp.Key);
+				}
+			}
+
+			if (stale != null)
+			{
+				foreach (var id in stale)
+				{
+					_lastSeen.Remove(id);
+					_revealTime.Remove(id);
+				}
+			}
+		}
+
 		_list = outList;
-		_revealTime = revealTime;
 	}
 
 	/// <summary>

--- a/RotationSolver.Basic/DataCenter.cs
+++ b/RotationSolver.Basic/DataCenter.cs
@@ -858,6 +858,11 @@ internal static class DataCenter
 			return true;
 		}
 
+		if (DutyRotation.WhiteMageLevel >= 4)
+		{
+			return true;
+		}
+
 		if (StatusHelper.PlayerHasStatus(false, StatusID.VariantRaiseSet))
 		{
 			return true;

--- a/RotationSolver.Basic/Helpers/ObjectHelper.cs
+++ b/RotationSolver.Basic/Helpers/ObjectHelper.cs
@@ -3787,9 +3787,17 @@ public static class ObjectHelper
 			return 0; // This may need to be changed to 100
 		}
 
-		if (battleChara.DoomNeedHealing())
+		if (!battleChara.IsValid())
 		{
-			return 0.01f;
+			return 0; // This may need to be changed to 100
+		}
+
+		if (battleChara.IsParty())
+		{
+			if (battleChara.DoomNeedHealing())
+			{
+				return 0.01f;
+			}
 		}
 
 		if (DataCenter.RefinedHP.TryGetValue(battleChara.GameObjectId, out var hp))
@@ -3797,12 +3805,19 @@ public static class ObjectHelper
 			return hp;
 		}
 
-		if (battleChara.MaxHp == 0)
+		try
 		{
-			return 0; // Avoid division by zero
-		}
+			if (battleChara.MaxHp == 0)
+			{
+				return 0; // Avoid division by zero
+			}
 
-		return (float)battleChara.CurrentHp / battleChara.MaxHp;
+			return (float)battleChara.CurrentHp / battleChara.MaxHp;
+		}
+		catch (Exception)
+		{
+			return 0;
+		}
 	}
 
 	/// <summary>

--- a/RotationSolver.Basic/Helpers/StatusHelper.cs
+++ b/RotationSolver.Basic/Helpers/StatusHelper.cs
@@ -144,29 +144,79 @@ public static class StatusHelper
 	/// </summary>
 	public static readonly Dictionary<uint, StatusID[]> SouthHornWeaknessByNameId = new()
 	{
+		{ 13638, [StatusID.FireWeakness] },
+		{ 13646, [StatusID.FireWeakness] },
+		{ 13656, [StatusID.IceWeakness] },
+		{ 13666, [StatusID.IceWeakness] },
+		{ 13668, [StatusID.IceWeakness] },
 		{ 13703, [StatusID.FireWeakness] },
+		{ 13717, [StatusID.LightningWeakness] },
+		{ 13718, [StatusID.LightningWeakness] },
+		{ 13726, [StatusID.LightningWeakness] },
+		{ 13728, [StatusID.LightningWeakness] },
+		{ 13729, [StatusID.LightningWeakness] },
+		{ 13740, [StatusID.FireWeakness] },
+		{ 13747, [StatusID.LightningWeakness] },
+		{ 13748, [StatusID.LightningWeakness] },
+		{ 13853, [StatusID.WindWeakness] },
 		{ 13855, [StatusID.WindWeakness] },
+		{ 13871, [StatusID.FireWeakness] },
+		{ 13872, [StatusID.WindWeakness] },
+		{ 13873, [StatusID.IceWeakness] },
+		{ 13874, [StatusID.FireWeakness] },
+		{ 13875, [StatusID.FireWeakness] },
 		{ 13877, [StatusID.FireWeakness] },
 		{ 13878, [StatusID.FireWeakness] },
+		{ 13879, [StatusID.LightningWeakness] },
 		{ 13880, [StatusID.IceWeakness] },
+		{ 13881, [StatusID.LightningWeakness] },
+		{ 13882, [StatusID.IceWeakness] },
 		{ 13883, [StatusID.LightningWeakness] },
 		{ 13884, [StatusID.FireWeakness] },
+		{ 13885, [StatusID.IceWeakness] },
 		{ 13886, [StatusID.FireWeakness] },
 		{ 13887, [StatusID.FireWeakness] },
+		{ 13888, [StatusID.IceWeakness] },
+		{ 13890, [StatusID.FireWeakness] },
+		{ 13891, [StatusID.LightningWeakness] },
+		{ 13892, [StatusID.WindWeakness] },
+		{ 13893, [StatusID.FireWeakness] },
+		{ 13894, [StatusID.FireWeakness] },
 		{ 13895, [StatusID.FireWeakness] },
+		{ 13896, [StatusID.IceWeakness] },
+		{ 13897, [StatusID.IceWeakness] },
+		{ 13898, [StatusID.WindWeakness] },
 		{ 13900, [StatusID.FireWeakness] },
+		{ 13901, [StatusID.WindWeakness] },
 		{ 13902, [StatusID.IceWeakness] },
+		{ 13903, [StatusID.LightningWeakness] },
+		{ 13904, [StatusID.IceWeakness] },
+		{ 13906, [StatusID.FireWeakness] },
+		{ 13907, [StatusID.IceWeakness] },
+		{ 13908, [StatusID.IceWeakness] },
 		{ 13909, [StatusID.IceWeakness] },
+		{ 13911, [StatusID.FireWeakness] },
+		{ 13912, [StatusID.LightningWeakness] },
 		{ 13913, [StatusID.LightningWeakness] },
+		{ 13915, [StatusID.LightningWeakness] },
+		{ 13916, [StatusID.IceWeakness] },
+		{ 13917, [StatusID.LightningWeakness] },
+		{ 13918, [StatusID.IceWeakness] },
 		{ 13919, [StatusID.FireWeakness] },
+		{ 13922, [StatusID.WindWeakness] },
+		{ 13924, [StatusID.LightningWeakness] },
+		{ 13925, [StatusID.FireWeakness] },
+		{ 13926, [StatusID.FireWeakness] },
 		{ 13928, [StatusID.LightningWeakness] },
 		{ 13930, [StatusID.IceWeakness] },
 		{ 13931, [StatusID.FireWeakness] },
 		{ 13932, [StatusID.FireWeakness] },
+		{ 13933, [StatusID.LightningWeakness] },
 		{ 13934, [StatusID.LightningWeakness] },
 		{ 13935, [StatusID.WindWeakness] },
 		{ 13936, [StatusID.LightningWeakness] },
 		{ 13937, [StatusID.LightningWeakness] },
+		{ 13938, [StatusID.IceWeakness] },
 	};
 
 	/// <summary>
@@ -543,7 +593,12 @@ public static class StatusHelper
 	/// <returns></returns>
 	public static bool DoomNeedHealing(this IBattleChara Doomp)
 	{
-		if (Doomp == null || !Doomp.IsValid())
+		if (Doomp == null)
+		{
+			return false;
+		}
+
+		if (!Doomp.IsValid())
 		{
 			return false;
 		}

--- a/RotationSolver/RebornRotations/Magical/RDM_Reborn.cs
+++ b/RotationSolver/RebornRotations/Magical/RDM_Reborn.cs
@@ -359,15 +359,15 @@ public sealed class RDM_Reborn : RedMageRotation
 
 		if (CanInstantCast || HasAccelerate)
 		{
-			if (!ImpactPvE.EnoughLevel)
+			if (EnhancedAccelerationIiTrait.EnoughLevel)
 			{
-				if (ScatterPvE.CanUse(out act))
+				if (GrandImpactPvE.CanUse(out act, skipStatusProvideCheck: CanGrandImpact, skipCastingCheck: true))
 				{
 					return true;
 				}
 			}
 
-			if (!GrandImpactPvE.EnoughLevel && ImpactPvE.EnoughLevel)
+			if (!ImpactPvE.EnoughLevel && ImpactPvE.EnoughLevel)
 			{
 				if (ImpactPvE.CanUse(out act))
 				{
@@ -375,9 +375,9 @@ public sealed class RDM_Reborn : RedMageRotation
 				}
 			}
 
-			if (EnhancedAccelerationIiTrait.EnoughLevel)
+			if (!ImpactPvE.EnoughLevel)
 			{
-				if (GrandImpactPvE.CanUse(out act, skipStatusProvideCheck: CanGrandImpact, skipCastingCheck: true))
+				if (ScatterPvE.CanUse(out act))
 				{
 					return true;
 				}
@@ -522,6 +522,21 @@ public sealed class RDM_Reborn : RedMageRotation
 			 EnchantedReprisePvE.CanUse(out act))
 		{
 			return true;
+		}
+
+		if (WhiteMana < BlackMana)
+		{
+			if (VeraeroIiPvE.CanUse(out act))
+			{
+				return true;
+			}
+		}
+		if (WhiteMana >= BlackMana)
+		{
+			if (VerthunderIiPvE.CanUse(out act))
+			{
+				return true;
+			}
 		}
 
 		// Single Target


### PR DESCRIPTION
- ObjectListDelay<T>: Add grace period for brief disappearances, track last seen times, and prune stale objects.
- DataCenter.cs: Allow WhiteMageLevel >= 4 for condition previously only for ChemistLevel >= 3.
- ObjectHelper.cs: Refactor HP ratio logic for better null/validity checks and Doom handling.
- StatusHelper.cs: Expand SouthHornWeaknessByNameId mappings; refactor DoomNeedHealing for clarity.
- RDM_Reborn.cs: Reorder spell selection logic and add mana-based preference for Veraero II/Verthunder II.