### PR TITLE
make ph.m.knight skip blazing spellblade if it's debuff already present on target

### DIFF
--- a/RotationSolver.Basic/Rotations/Duties/PhantomRotation.cs
+++ b/RotationSolver.Basic/Rotations/Duties/PhantomRotation.cs
@@ -910,6 +910,7 @@ public partial class DutyRotation
 	static partial void ModifyBlazingSpellbladePvE(ref ActionSetting setting)
 	{
 		setting.ActionCheck = () => MysticKnightLevel >= 4;
+		setting.TargetStatusProvide = [StatusID.BlazingBane];
 		setting.IsFriendly = false;
 	}
 

--- a/RotationSolver/RebornRotations/Duty/PhantomDefault.cs
+++ b/RotationSolver/RebornRotations/Duty/PhantomDefault.cs
@@ -1090,9 +1090,15 @@ public sealed class PhantomDefault : PhantomRotation
 			return true;
 		}
 
-		if (BlazingSpellbladePvE.CanUse(out act))
+		if (BlazingSpellbladePvE.CanUse(out act, skipStatusProvideCheck: true))
 		{
-			return true;
+			if (BlazingSpellbladePvE.Target.Target?.WillStatusEnd(30, true, BlazingSpellbladePvE.Setting.TargetStatusProvide ?? []) ?? false)
+			{
+				if (BlazingSpellbladePvE.Target.Target?.WillStatusEnd(30, false, BlazingSpellbladePvE.Setting.TargetStatusProvide ?? []) ?? false)
+				{
+					return true;
+				}
+			}
 		}
 
 		if (HolySpellbladePvE.CanUse(out act))


### PR DESCRIPTION
recasts for `Blazing Spellblade` and `Holy Spellblade` are both 30 sec and shared
debuff length on `Blazing Spellblade` is 70 sec
`Holy Spellblade` has 100 potency more and even more for undead targets so alternating Blazing and Holy is a potency gain
this also allows us to skip Blazing if someone else happened to debuff the target in case of multiple Ph.M.Knights around
doesn't break anything cos if we skip Blazing we still have Holy around cos Holy is unlocked at an earier level and is checked against as a possible next GCD action later in the code
